### PR TITLE
Adding SSE and Streamable HTTP transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 ## Features
 
 - 🌐 **Multi-Server Support**: Connect to multiple MCP servers simultaneously
+- 🚀 **Multiple Transport Types**: Supports STDIO, SSE, and Streamable HTTP server connections
 - 🎨 **Rich Terminal Interface**: Interactive console UI
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧠 **Context Management**: Control conversation memory with configurable retention settings
 - 🔄 **Cross-Language Support**: Seamlessly work with both Python and JavaScript MCP servers
 - 🔍 **Auto-Discovery**: Automatically find and use Claude's existing MCP server configurations
-- 🚀 **Dynamic Model Switching**: Switch between any installed Ollama model without restarting
+- 🎛️ **Dynamic Model Switching**: Switch between any installed Ollama model without restarting
 - 💾 **Configuration Persistence**: Save and load tool preferences between sessions
 - 📊 **Usage Analytics**: Track token consumption and conversation history metrics
 - 🔌 **Plug-and-Play**: Works immediately with standard MCP-compliant tool servers
@@ -74,6 +75,9 @@ If you don't provide any options, the client will use auto-discovery mode to fin
 - `--mcp-server`: Path to one or more MCP server scripts (.py or .js). Can be specified multiple times.
 - `--servers-json`: Path to a JSON file with server configurations.
 - `--auto-discovery`: Auto-discover servers from Claude's default config file (default behavior if no other options provided).
+
+> Note: Claude's configuration file is typically located at:
+`~/Library/Application Support/Claude/claude_desktop_config.json`
 
 #### Model Options:
 - `--model`: Ollama model to use (default: "qwen2.5:7b")
@@ -157,12 +161,13 @@ The configuration saves:
 
 ## Server Configuration Format
 
-The JSON configuration file should follow this format:
+The JSON configuration file supports STDIO, SSE, and Streamable HTTP server types:
+
 
 ```json
 {
   "mcpServers": {
-    "server-name": {
+    "stdio-server": {
       "command": "command-to-run",
       "args": ["arg1", "arg2", "..."],
       "env": {
@@ -170,22 +175,37 @@ The JSON configuration file should follow this format:
         "ENV_VAR2": "value2"
       },
       "disabled": false
+    },
+    "sse-server": {
+      "type": "sse",
+      "url": "http://localhost:8000/sse",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      },
+      "disabled": false
+    },
+    "http-server": {
+      "type": "streamable_http",
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "X-API-Key": "your-api-key-here"
+      },
+      "disabled": false
     }
   }
 }
 ```
 
-Claude's configuration file is typically located at:
-`~/Library/Application Support/Claude/claude_desktop_config.json`
+> Note: If you specify a URL without a type, the client will default to using Streamable HTTP transport.
 
 ## Compatible Models
 
 The following Ollama models work well with tool use:
 
 - qwen2.5
-- llama3.3
-- llama3.2
+- qwen3
 - llama3.1
+- llama3.2
 - mistral
 
 For a complete list of Ollama models with tool use capabilities, visit the [official Ollama models page](https://ollama.com/search?c=tools).

--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.3.2"
+version = "0.4.0"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.3.2"
+    "mcp-client-for-ollama==0.4.0"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/mcp_client_for_ollama/server/discovery.py
+++ b/mcp_client_for_ollama/server/discovery.py
@@ -66,12 +66,32 @@ def parse_server_configs(config_path: str) -> List[Dict[str, Any]]:
             # Skip disabled servers
             if config.get('disabled', False):
                 continue
-                
-            all_servers.append({
-                "type": "config",
+            
+            # Determine server type
+            server_type = "config"  # Default type for STDIO servers
+            
+            # Check for URL-based server types (sse or streamable_http)
+            if "type" in config:
+                # Type is explicitly specified in config
+                server_type = config["type"]
+            elif "url" in config:
+                # URL exists but no type, default to streamable_http
+                server_type = "streamable_http"
+            
+            # Create server config object
+            server = {
+                "type": server_type,
                 "name": name,
                 "config": config
-            })
+            }
+            
+            # For URL-based servers, add direct access to URL and headers
+            if server_type in ["sse", "streamable_http"]:
+                server["url"] = config.get("url")
+                if "headers" in config:
+                    server["headers"] = config.get("headers")
+                
+            all_servers.append(server)
             
         return all_servers
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.3.2"
+version = "0.4.0"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -368,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# v0.4.0 - Adding SSE and Streamable HTTP transports

## 🚀 Highlights
This PR adds support for Server-Sent Events (SSE) and Streamable HTTP transports in the MCP Client for Ollama, along with upgrading compatibility to MCP 1.9.0.
## 🔧 Changes

- Upgraded compatibility with MCP 1.9.0
- Added full support for SSE transport
- Added support for Streamable HTTP transport (using SSE client as fallback)
- Updated import paths to match the new module structure in MCP 1.9.0