### PR TITLE
Adding streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 - 🌐 **Multi-Server Support**: Connect to multiple MCP servers simultaneously
 - 🚀 **Multiple Transport Types**: Supports STDIO, SSE, and Streamable HTTP server connections
 - 🎨 **Rich Terminal Interface**: Interactive console UI
+- 🖥️ **Streaming Responses**: View model outputs in real-time as they're generated
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧠 **Context Management**: Control conversation memory with configurable retention settings
 - 🔄 **Cross-Language Support**: Seamlessly work with both Python and JavaScript MCP servers
@@ -57,7 +58,7 @@ git clone https://github.com/jonigl/mcp-client-for-ollama.git
 cd mcp-client-for-ollama
 uv venv && source .venv/bin/activate
 uv pip install .
-uv run -m mcp_client_for_ollama.client
+uv run -m mcp_client_for_ollama
 ```
 
 ## Usage

--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.4.0"
+    "mcp-client-for-ollama==0.5.0"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/mcp_client_for_ollama/__main__.py
+++ b/mcp_client_for_ollama/__main__.py
@@ -1,0 +1,14 @@
+"""
+Main entry point for the MCP Client for Ollama when run as a module.
+
+This allows you to run the client using:
+    python -m mcp_client_for_ollama
+
+It simply imports and runs the main function from cli.py.
+"""
+
+import asyncio
+from .cli import main
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -1,0 +1,91 @@
+"""
+This file implements streaming functionality for the MCP client for Ollama.
+
+Classes:
+    StreamingManager: Handles streaming responses from Ollama.
+"""
+from rich.markdown import Markdown
+from rich.live import Live
+from rich.spinner import Spinner
+from rich.table import Table
+from rich.text import Text
+
+class StreamingManager:
+    """Manages streaming responses for Ollama API calls"""
+    
+    def __init__(self, console):
+        """Initialize the streaming manager
+        
+        Args:
+            console: Rich console for output
+        """
+        self.console = console
+
+    def get_table(self, header=True):
+        """Create a table for displaying streaming responses
+        
+        Returns:
+            Table: Rich table object
+        """
+         # Create a table with spinner in first row and content in second
+        table = Table.grid(expand=True)
+        spinner = Spinner("dots")
+        spinner.style = "cyan"  # Make the spinner cyan
+        thinking_text = Text("Thinking...", style="cyan")
+        if not header:
+            spinner = ""
+            thinking_text = ""
+        # Create inner grid for spinner and text with minimal padding
+        header = Table.grid(padding=(0, 1))
+        header.add_row(spinner, thinking_text)
+        # Add header and content to main table                        
+        table.add_row(header)
+        return table
+
+
+    async def process_streaming_response(self, stream, print_response=True):
+        """Process a streaming response from Ollama with status spinner and content updates
+        
+        Args:
+            stream: Async iterator of response chunks
+            print_response: Flag to control live updating of response text
+                
+        Returns:
+            str: Accumulated response text
+            list: Tool calls if any
+        """
+            
+        accumulated_text = ""
+        tool_calls = []
+        
+        # Process the streaming response chunks with live updating markdown
+        if print_response:            
+            with Live(console=self.console, refresh_per_second=10) as live:
+                    table = self.get_table()
+                    live.update(table)
+                    async for chunk in stream:
+                        if hasattr(chunk, 'message') and hasattr(chunk.message, 'content'):
+                            content = chunk.message.content
+                            accumulated_text += content
+                            table = self.get_table(header=not chunk.done)
+                            if len(accumulated_text) > 0:
+                                table.add_row(Markdown(accumulated_text))
+                            live.update(table)
+                        if hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and chunk.message.tool_calls:
+                            # return messages with tool calls
+                            for tool in chunk.message.tool_calls:
+                                tool_calls.append(tool)
+            if len(accumulated_text) > 0:
+                self.console.print()
+        else:
+            async for chunk in stream:
+                if hasattr(chunk, 'message') and hasattr(chunk.message, 'content') and chunk.message.content:
+                    content = chunk.message.content
+                    if content:
+                        accumulated_text += content
+                    elif hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and chunk.message.tool_calls:                        
+                        for tool in chunk.message.tool_calls:
+                            tool_calls.append(tool)
+                                        
+        # Return the accumulated text and tool calls
+        return accumulated_text, tool_calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -368,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# v0.5.0 – Add Support for Ollama Streaming Responses

## 🚀 Highlights
This PR introduces response streaming capabilities in the MCP Client for Ollama. When stream=True is set, the client now returns streaming responses from the server, enabling more responsive and efficient interactions.

## 🔧 Changes
* Implemented response streaming support via the ollama chat `stream=True` flag
* Using rich live for Markdown stream response

## ⚠️ Note
* **Known issue**: Streaming does not function correctly in Ollama when tools are enabled. See [ollama/ollama-python#463](https://github.com/ollama/ollama-python/issues/463) for details.