### PR TITLE
fix: allowing multiple tool requests before ollama chat response

### DIFF
--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.6.0"
+version = "0.6.1"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.6.0"
+    "mcp-client-for-ollama==0.6.1"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -218,14 +218,14 @@ class MCPClient:
                     "name": tool_name
                 })            
 
-                # Get stream response from Ollama with the tool results                                
-                stream = await self.ollama.chat(
-                    model=model,
-                    messages=messages,
-                    stream=True,
-                )
-                # Process the streaming response
-                response_text, _ = await self.streaming_manager.process_streaming_response(stream)
+        # Get stream response from Ollama with the tool results                                
+        stream = await self.ollama.chat(
+            model=model,
+            messages=messages,
+            stream=True,
+        )
+        # Process the streaming response
+        response_text, _ = await self.streaming_manager.process_streaming_response(stream)
 
         if not response_text:
             self.console.print("[red]No response received.[/red]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.6.0"
+version = "0.6.1"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
# v0.6.1 – Support Multiple Tool Requests Before Ollama Chat Response

## 🛠️ Fix
* Enabled handling of multiple tool requests before receiving a response from the Ollama chat, improving request concurrency and workflow flexibility.