### PR TITLE
fix: don't use chat if no tool selected

### DIFF
--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.6.2"
+version = "0.6.3"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.6.2"
+    "mcp-client-for-ollama==0.6.3"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -216,16 +216,16 @@ class MCPClient:
                     "role": "tool",
                     "content": result.content[0].text,
                     "name": tool_name
-                })            
+                })
 
-        # Get stream response from Ollama with the tool results                                
-        stream = await self.ollama.chat(
-            model=model,
-            messages=messages,
-            stream=True,
-        )
-        # Process the streaming response
-        response_text, _ = await self.streaming_manager.process_streaming_response(stream)
+            # Get stream response from Ollama with the tool results                                
+            stream = await self.ollama.chat(
+                model=model,
+                messages=messages,
+                stream=True,
+            )
+            # Process the streaming response
+            response_text, _ = await self.streaming_manager.process_streaming_response(stream)
 
         if not response_text:
             self.console.print("[red]No response received.[/red]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.6.2"
+version = "0.6.3"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
# v0.6.3 –  Prevent Chat Usage When No Tool Is Selected

## 🛠️ Fix
* Chat functionality is not used if no tool is selected, preventing unintended or empty chat interactions.