### PR TITLE
Workflow does not contain explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jonigl/mcp-client-for-ollama/security/code-scanning/1](https://github.com/jonigl/mcp-client-for-ollama/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to apply to all jobs. Since the workflow primarily involves testing and building Python packages, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents without granting unnecessary write access.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
