### PR TITLE
fix: thinking mode now it is properly set

### DIFF
--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.10.0"
+version = "0.10.1"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.10.0"
+    "mcp-client-for-ollama==0.10.1"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -220,8 +220,8 @@ class MCPClient:
         }
 
         # Add thinking parameter if thinking mode is enabled and model supports it
-        if self.thinking_mode and self.supports_thinking_mode():
-            chat_params["think"] = True
+        if self.supports_thinking_mode():
+            chat_params["think"] = self.thinking_mode
 
         # Initial Ollama API call with the query and available tools
         stream = await self.ollama.chat(**chat_params)
@@ -231,7 +231,7 @@ class MCPClient:
         tool_calls = []
         response_text, tool_calls = await self.streaming_manager.process_streaming_response(
             stream,
-            thinking_mode=self.thinking_mode and self.supports_thinking_mode(),
+            thinking_mode=self.thinking_mode,
             show_thinking=self.show_thinking
         )
         # Check if there are any tool calls in the response
@@ -274,15 +274,15 @@ class MCPClient:
             }
 
             # Add thinking parameter if thinking mode is enabled and model supports it
-            if self.thinking_mode and self.supports_thinking_mode():
-                chat_params_followup["think"] = True
+            if self.supports_thinking_mode():
+                chat_params_followup["think"] = self.thinking_mode
 
             stream = await self.ollama.chat(**chat_params_followup)
 
             # Process the streaming response with thinking mode support
             response_text, _ = await self.streaming_manager.process_streaming_response(
                 stream,
-                thinking_mode=self.thinking_mode and self.supports_thinking_mode(),
+                thinking_mode=self.thinking_mode,
                 show_thinking=self.show_thinking
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.10.0"
+version = "0.10.1"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
# v0.10.1 –  correct Thinking Mode Execution and Visibility

## 🛠️ Fix
Resolved an issue where thinking mode was improperly handled. Previously, when thinking mode was disabled, the system still executed the thinking phase but did not display it. Now, with thinking mode disabled, the phase is neither executed nor shown, ensuring correct and expected behavior.

## 🔗 Related
Fixes part of [#22](https://github.com/jonigl/mcp-client-for-ollama/issues/22)