### PR TITLE
feat(cli): migrate from argparse to Typer, group CLI options and add autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 - 🌐 **Multi-Server Support**: Connect to multiple MCP servers simultaneously
 - 🚀 **Multiple Transport Types**: Supports STDIO, SSE, and Streamable HTTP server connections
 - 🎨 **Rich Terminal Interface**: Interactive console UI
-- 🖥️ **Streaming Responses**: View model outputs in real-time as they're generated
+- 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧑‍💻 **Human-in-the-Loop (HIL)**: Review and approve tool executions before they run for enhanced control and safety
 - 🎮 **Advanced Model Configuration**: Fine-tune 10+ model parameters including temperature, sampling, repetition control, and more
@@ -72,6 +72,7 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 - 📊 **Usage Analytics**: Track token consumption and conversation history metrics
 - 🔌 **Plug-and-Play**: Works immediately with standard MCP-compliant tool servers
 - 🔔 **Update Notifications**: Automatically detects when a new version is available
+- 🖥️ **Modern CLI with Typer**: Grouped options, shell autocompletion, and improved help output
 
 ## Requirements
 
@@ -116,7 +117,16 @@ ollmcp
 
 ### Command-line Arguments
 
-#### Server Options:
+> [!TIP]
+> The CLI now uses `Typer` for a modern experience: grouped options, rich help, and built-in shell autocompletion. To enable autocompletion, run:
+>
+> ```bash
+> ollmcp --install-completion
+> ```
+>
+> Then restart your shell or follow the printed instructions.
+
+#### MCP Server Configuration:
 
 - `--mcp-server`: Path to one or more MCP server scripts (.py or .js). Can be specified multiple times.
 - `--servers-json`: Path to a JSON file with server configurations.
@@ -126,10 +136,18 @@ ollmcp
 > Claude's configuration file is typically located at:
 > `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-#### Model Options:
+
+#### Ollama Configuration:
 
 - `--model MODEL`: Ollama model to use. Default: `qwen2.5:7b`
 - `--host HOST`: Ollama host URL. Default: `http://localhost:11434`
+
+#### General Options:
+
+- `--version`: Show version and exit
+- `--install-completion`: Install shell autocompletion scripts for the client
+- `--show-completion`: Show available shell completion options
+- `--help`: Show help message and exit
 
 ### Usage Examples
 
@@ -322,6 +340,12 @@ What would you like to do? (y):
 
 ## Autocomplete and Prompt Features
 
+### Typer Shell Autocompletion
+
+- The CLI supports shell autocompletion for all options and arguments via Typer
+- To enable, run `ollmcp --install-completion` and follow the instructions for your shell
+- Enjoy tab-completion for all grouped and general options
+
 ### FZF-style Autocomplete
 
 - Fuzzy matching for commands as you type
@@ -448,6 +472,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Model Context Protocol](https://modelcontextprotocol.io/) for the specification and examples
 - [Ollama](https://ollama.com/) for the local LLM runtime
 - [Rich](https://rich.readthedocs.io/) for the terminal user interface
+- [Typer](https://typer.tiangolo.com/) for the modern CLI experience
+- [UV](https://www.uvicorn.org/) for the lightning-fast Python package manager and virtual environment management
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 - 🖥️ **Streaming Responses**: View model outputs in real-time as they're generated
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧑‍💻 **Human-in-the-Loop (HIL)**: Review and approve tool executions before they run for enhanced control and safety
-- 🎛️ **Advanced Model Configuration**: Fine-tune 10+ model parameters including temperature, sampling, repetition control, and more
+- 🎮 **Advanced Model Configuration**: Fine-tune 10+ model parameters including temperature, sampling, repetition control, and more
 - 💬 **System Prompt Customization**: Define and edit the system prompt to control model behavior and persona
 - 🎨 **Enhanced Tool Display**: Beautiful, structured visualization of tool executions with JSON syntax highlighting
 - 🧠 **Context Management**: Control conversation memory with configurable retention settings

--- a/mcp_client_for_ollama/__main__.py
+++ b/mcp_client_for_ollama/__main__.py
@@ -7,8 +7,7 @@ This allows you to run the client using:
 It simply imports and runs the main function from cli.py.
 """
 
-import asyncio
-from .cli import main
+from .cli import run_cli
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_cli()

--- a/mcp_client_for_ollama/cli.py
+++ b/mcp_client_for_ollama/cli.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 """Command-line interface for the MCP Client for Ollama."""
 
-import asyncio
-from .client import main
+from .client import app
 
 def run_cli():
     """Run the MCP Client for Ollama command-line interface."""
-    asyncio.run(main())
+    app()
 
 if __name__ == "__main__":
     run_cli()

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -84,12 +84,6 @@ class ConfigManager:
 
             # Validate loaded configuration and provide defaults for missing fields
             validated_config = self._validate_config(config_data)
-
-            self.console.print(Panel(
-                f"[green]Configuration loaded successfully from:[/green]\n"
-                f"[blue]{config_path}[/blue]",
-                title="Config Loaded", border_style="green", expand=False
-            ))
             return validated_config
 
         except Exception as e:

--- a/mcp_client_for_ollama/models/config_manager.py
+++ b/mcp_client_for_ollama/models/config_manager.py
@@ -261,7 +261,7 @@ class ModelConfigManager:
             f"[bold][orange3]11.[/orange3] presence_penalty:[/bold] {format_value(self.presence_penalty)}\n"
             f"[bold][orange3]12.[/orange3] frequency_penalty:[/bold] {format_value(self.frequency_penalty)}\n"
             f"[bold][orange3]13.[/orange3] stop:[/bold] {format_value(self.stop)}",
-            title="[bold blue]🎛️ Model Parameters[/bold blue]",
+            title="[bold blue]🎮 Model Parameters[/bold blue]",
             border_style="blue", expand=False))
         self.console.print("\n[bold yellow]Note:[/bold yellow] Unset values will use Ollama's defaults.")
         self.console.print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "ollama==0.5.1",
     "prompt-toolkit>=3.0.51",
     "rich>=14.0.0",
+    "typer>=0.12.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,7 @@ dependencies = [
     { name = "ollama" },
     { name = "prompt-toolkit" },
     { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.metadata]
@@ -172,6 +173,7 @@ requires-dist = [
     { name = "ollama", specifier = "==0.5.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "typer", specifier = ">=0.12.0" },
 ]
 
 [[package]]
@@ -366,6 +368,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +407,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856, upload-time = "2025-05-29T15:45:27.628Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/81/c60b35fe9674f63b38a8feafc414fca0da378a9dbd5fa1e0b8d23fcc7a9b/starlette-0.47.0-py3-none-any.whl", hash = "sha256:9d052d4933683af40ffd47c7465433570b4949dc937e20ad1d73b34e72f10c37", size = 72796, upload-time = "2025-05-29T15:45:26.305Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Migrated CLI from argparse to Typer for improved usability, modern Python CLI practices, and shell autocompletion
- Grouped Typer CLI options for MCP server (--mcp-server, --servers-json, --auto-discovery) and Ollama model (--model, --host) for clearer help output
- Left general options (e.g. --version) ungrouped for simplicity
- Improved interactive model configuration: better prompts, validation, and user feedback for each parameter
- Update README.md