### PR TITLE
v0.13.0 – Typer CLI Migration, Enhanced Interactive UX, and CI Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@
 [![CI](https://github.com/jonigl/mcp-client-for-ollama/actions/workflows/ci.yml/badge.svg)](https://github.com/jonigl/mcp-client-for-ollama/actions/workflows/ci.yml)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/jonigl/mcp-client-for-ollama/v0.2.5/misc/ollmcp-demo.gif" alt="MCP Client for Ollama Demo">
+  <img src="https://raw.githubusercontent.com/jonigl/mcp-client-for-ollama/v0.13.0/misc/ollmcp-demo.gif" alt="MCP Client for Ollama Demo">
+</p>
+<p align="center">
+  <a href="https://asciinema.org/a/jxc6N8oKZAWrzH8aK867zhXdO" target="_blank">🎥 View this demo as an asciinema recording</a>
 </p>
 
 ## Table of Contents
@@ -45,9 +48,7 @@
 
 ## Overview
 
-This project provides a robust Python-based client that connects to one or more Model Context Protocol (MCP) servers and uses Ollama to process queries with tool use capabilities. The client establishes connections to MCP servers, sends queries to Ollama models, and handles the tool calls the model makes.
-
-This implementation was adapted from the [Model Context Protocol quickstart guide](https://modelcontextprotocol.io/quickstart/client) and customized to work with Ollama, providing a user-friendly interface for interacting with LLMs that support function calling.
+MCP Client for Ollama (`ollmcp`) is a modern, interactive terminal application (TUI) for connecting local Ollama LLMs to one or more Model Context Protocol (MCP) servers, enabling advanced tool use and workflow automation. With a rich, user-friendly interface, it lets you manage tools, models, and server connections in real time—no coding required. Whether you're building, testing, or just exploring LLM tool use, this client streamlines your workflow with features like fuzzy autocomplete, advanced model configuration, MCP servers hot-reloading for development, and Human-in-the-Loop safety controls.
 
 ## Features
 
@@ -85,7 +86,7 @@ This implementation was adapted from the [Model Context Protocol quickstart guid
 **Option 1:** Install with pip and run
 
 ```bash
-pip install ollmcp
+pip install --upgrade ollmcp
 ollmcp
 ```
 

--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.12.0"
+version = "0.13.0"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.12.0"
+    "mcp-client-for-ollama==0.13.0"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.12.0"
+version = "0.13.0"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
# **v0.13.0 – Typer CLI Migration, Enhanced Interactive UX, and CI Improvements**

## 🚀 **Highlights**
This release delivers a modernized CLI powered by Typer, refined interactive model configuration, fuzzy autocomplete for better user input, and streamlined CI. It also updates the principal demo GIF in the README for improved clarity and presentation.

## 🔧 **Changes**

* **CLI Overhaul with Typer**

  * Migrated from `argparse` to **Typer** for a more user-friendly and modern CLI experience.
  * Grouped CLI options for clearer help output:

    * **MCP Server**: `--mcp-server`, `--servers-json`, `--auto-discovery`
    * **Ollama Model**: `--model`, `--host`
  * Left general flags (e.g. `--version`) ungrouped for simplicity.

* **Interactive Configuration Improvements**

  * Improved prompts and validation for each parameter.
  * Prompts now dynamically display current model, thinking mode status, and tool count.
  * Enhanced user feedback and guidance during setup.

* **Fuzzy Autocompletion & UX Enhancements**

  * Added `FZFStyleCompleter` using `WordCompleter` + `FuzzyCompleter` for intuitive fuzzy matching.
  * Arrow indicator (`▶`) highlights best autocomplete match.
  * Centralized prompt logic and completer styles in `constants.py`.
  * Enabled `ignore_case` matching for better experience.

* **Documentation & Visuals**

  * Updated `README.md` to reflect CLI and UX changes.
  * Replaced main demo GIF with an updated version showcasing the new interface.

* **CI/CD Enhancements**

  * Updated GitHub Actions:

    * `action-gh-release` from v1 to v2 with `generate_release_notes` enabled.
    * `setup-python` from v4 to v5 for better compatibility and performance.

📦 **Version bump** to `v0.13.0` to capture CLI, UX, and CI evolution.

## 👨‍💻 Demo

[![asciicast](https://github.com/user-attachments/assets/4a4370e1-72d1-426e-b0ce-6af0ba85588b)](https://asciinema.org/a/jxc6N8oKZAWrzH8aK867zhXdO)
