### PR TITLE
feat: add --mcp-server-url option to support direct URL connections to SSE/HTTP MCP servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,31 +44,31 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-        
+
     - name: Install and test main package
       run: |
         # Install in development mode
         pip install -e .
-        
+
         # Run tests only in the main package's tests directory
         cd tests
         python -m pytest -xvs
         cd ..
-        
+
     - name: Install and test CLI package
       run: |
         # Install CLI package in development mode
         cd cli-package
         pip install -e .
-        
+
         # Run tests only in the CLI package's tests directory
         cd tests
-        python -m pytest -xvs 
+        python -m pytest -xvs
 
   build-check:
     name: Check build packages
@@ -79,23 +79,23 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-        
+
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-        
+
     - name: Build main package
       run: python -m build .
-      
+
     - name: Check main package
       run: twine check dist/*
-      
+
     - name: Build CLI package
       run: |
         cd cli-package
         python -m build .
-        
+
     - name: Check CLI package
       run: |
         cd cli-package
@@ -112,26 +112,26 @@ jobs:
         CLI_VERSION=$(grep -E '^version\s*=\s*"[^"]+"' cli-package/pyproject.toml | sed -E 's/^version\s*=\s*"([^"]+)".*/\1/')
         CLI_DEP_VERSION=$(grep -E '"mcp-client-for-ollama==' cli-package/pyproject.toml | sed -E 's/.*"mcp-client-for-ollama==([^"]+)".*/\1/')
         INIT_VERSION=$(grep -E '__version__\s*=\s*"[^"]+"' mcp_client_for_ollama/__init__.py | sed -E 's/.*__version__\s*=\s*"([^"]+)".*/\1/')
-        
+
         echo "Main package version: $MAIN_VERSION"
         echo "CLI package version: $CLI_VERSION"
         echo "CLI dependency version: $CLI_DEP_VERSION"
         echo "Init version: $INIT_VERSION"
-        
+
         # Check that all versions match
         if [ "$MAIN_VERSION" != "$CLI_VERSION" ]; then
           echo "::error::Version mismatch: Main package ($MAIN_VERSION) != CLI package ($CLI_VERSION)"
           exit 1
         fi
-        
+
         if [ "$MAIN_VERSION" != "$CLI_DEP_VERSION" ]; then
           echo "::error::Version mismatch: Main package ($MAIN_VERSION) != CLI dependency ($CLI_DEP_VERSION)"
           exit 1
         fi
-        
+
         if [ "$MAIN_VERSION" != "$INIT_VERSION" ]; then
           echo "::error::Version mismatch: Main package ($MAIN_VERSION) != __init__.py ($INIT_VERSION)"
           exit 1
         fi
-        
+
         echo "All versions are consistent: $MAIN_VERSION"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ ollmcp
 #### MCP Server Configuration:
 
 - `--mcp-server`: Path to one or more MCP server scripts (.py or .js). Can be specified multiple times.
+- `--mcp-server-url`: URL to one or more SSE or Streamable HTTP MCP servers. Can be specified multiple times.
 - `--servers-json`: Path to a JSON file with server configurations.
 - `--auto-discovery`: Auto-discover servers from Claude's default config file (default behavior if no other options provided).
 
@@ -152,6 +153,14 @@ ollmcp
 
 ### Usage Examples
 
+Simplest way to run the client:
+
+```bash
+ollmcp
+```
+> [!TIP]
+> This will automatically discover and connect to any MCP servers configured in Claude's settings and use the default model `qwen2.5:7b` or the model specified in your configuration file.
+
 Connect to a single server:
 
 ```bash
@@ -161,9 +170,11 @@ ollmcp --mcp-server /path/to/weather.py --model llama3.2:3b
 Connect to multiple servers:
 
 ```bash
-ollmcp --mcp-server /path/to/weather.py --mcp-server /path/to/filesystem.js --model qwen2.5:latest
-
+ollmcp --mcp-server /path/to/weather.py --mcp-server /path/to/filesystem.js
 ```
+
+>[!TIP]
+> If model is not specified, the default model `qwen2.5:7b` will be used or the model specified in your configuration file.
 
 Use a JSON configuration file:
 
@@ -171,10 +182,37 @@ Use a JSON configuration file:
 ollmcp --servers-json /path/to/servers.json --model llama3.2:1b
 ```
 
+>[!TIP]
+> See the [Server Configuration Format](#server-configuration-format) section for details on how to structure the JSON file.
+
 Use a custom Ollama host:
 
 ```bash
 ollmcp --host http://localhost:22545 --servers-json /path/to/servers.json --model qwen3:latest
+```
+
+Connect to SSE or Streamable HTTP servers by URL:
+
+```bash
+ollmcp --mcp-server-url http://localhost:8000/sse --model qwen2.5:latest
+```
+
+Connect to multiple URL servers:
+
+```bash
+ollmcp --mcp-server-url http://localhost:8000/sse --mcp-server-url http://localhost:9000/mcp
+```
+
+Mix local scripts and URL servers:
+
+```bash
+ollmcp --mcp-server /path/to/weather.py --mcp-server-url http://localhost:8000/mcp --model qwen3:1.7b
+```
+
+Use auto-discovery with mixed server types:
+
+```bash
+ollmcp --mcp-server /path/to/weather.py --mcp-server-url http://localhost:8000/mcp --auto-discovery
 ```
 
 ## Interactive Commands

--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -15,7 +15,7 @@ from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
-from .discovery import process_server_paths, parse_server_configs, auto_discover_servers
+from .discovery import process_server_paths, process_server_urls, parse_server_configs, auto_discover_servers
 
 class ServerConnector:
     """Manages connections to one or more MCP servers.
@@ -39,11 +39,12 @@ class ServerConnector:
         self.enabled_tools = {}  # Dict to store tool enabled status
         self.session_ids = {}  # Dict to store session IDs for HTTP connections
 
-    async def connect_to_servers(self, server_paths=None, config_path=None, auto_discovery=False) -> Tuple[dict, list, dict]:
+    async def connect_to_servers(self, server_paths=None, server_urls=None, config_path=None, auto_discovery=False) -> Tuple[dict, list, dict]:
         """Connect to one or more MCP servers
 
         Args:
             server_paths: List of paths to server scripts (.py or .js)
+            server_urls: List of URLs for SSE or Streamable HTTP servers
             config_path: Path to JSON config file with server configurations
             auto_discovery: Whether to automatically discover servers
 
@@ -58,6 +59,13 @@ class ServerConnector:
             for server in script_servers:
                 self.console.print(f"[cyan]Found server script: {server['path']}[/cyan]")
             all_servers.extend(script_servers)
+
+        # Process server URLs
+        if server_urls:
+            url_servers = process_server_urls(server_urls)
+            for server in url_servers:
+                self.console.print(f"[cyan]Found server URL: {server['url']} (type: {server['type']})[/cyan]")
+            all_servers.extend(url_servers)
 
         # Process config file
         if config_path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ Issues = "https://github.com/jonigl/mcp-client-for-ollama/issues"
 
 [tool.setuptools]
 packages = ["mcp_client_for_ollama", "mcp_client_for_ollama.config", "mcp_client_for_ollama.models", "mcp_client_for_ollama.server", "mcp_client_for_ollama.tools", "mcp_client_for_ollama.utils"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -1,0 +1,130 @@
+"""Test server discovery functionality."""
+
+from mcp_client_for_ollama.server.discovery import process_server_urls
+
+
+def test_process_server_urls():
+    """Test that server URL processing works correctly."""
+    # Test single URL string
+    result = process_server_urls("http://localhost:8000/sse")
+    assert len(result) == 1
+    assert result[0]["type"] == "sse"
+    assert result[0]["url"] == "http://localhost:8000/sse"
+    assert result[0]["name"] == "localhost_8000"
+
+    # Test list of URLs
+    urls = [
+        "http://localhost:8000/sse",
+        "https://api.example.com/mcp",
+        "http://server1.com:9000/streamable"
+    ]
+    result = process_server_urls(urls)
+    assert len(result) == 3
+
+    # Check SSE detection
+    sse_server = next(s for s in result if s["url"] == "http://localhost:8000/sse")
+    assert sse_server["type"] == "sse"
+
+    # Check default streamable_http type
+    http_server = next(s for s in result if s["url"] == "https://api.example.com/mcp")
+    assert http_server["type"] == "streamable_http"
+
+    # Test invalid URLs are filtered out
+    invalid_urls = ["not-a-url", "ftp://invalid.com", ""]
+    result = process_server_urls(invalid_urls)
+    assert len(result) == 0
+
+    # Test empty input
+    assert process_server_urls([]) == []
+    assert process_server_urls(None) == []
+
+
+def test_server_url_name_generation():
+    """Test that server names are generated correctly from URLs."""
+    # Test with path - path doesn't affect name, only hostname matters
+    result = process_server_urls("http://localhost:8000/api/mcp")
+    assert result[0]["name"] == "localhost_8000"
+
+    # Test with SSE path
+    result = process_server_urls("http://localhost:8000/sse")
+    assert result[0]["name"] == "localhost_8000"
+
+    # Test without path
+    result = process_server_urls("http://localhost:9000")
+    assert result[0]["name"] == "localhost_9000"
+
+    # Test with complex host including dots (IP address)
+    result = process_server_urls("https://127.0.0.1:8443/mcp/v1")
+    assert result[0]["name"] == "127_0_0_1_8443"
+
+    # Test with domain containing dots
+    result = process_server_urls("https://api.example.com:8080/mcp")
+    assert result[0]["name"] == "api_example_com_8080"
+
+
+def test_server_name_uniqueness():
+    """Test that different hosts get unique names."""
+    # Test multiple servers with different hosts
+    urls = [
+        "http://server1.com/sse",
+        "http://server2.com/sse",
+        "https://api.example.com:8000/sse"
+    ]
+    result = process_server_urls(urls)
+    assert len(result) == 3
+
+    names = [server["name"] for server in result]
+    assert len(set(names)) == 3  # All names should be unique
+    assert "server1_com" in names
+    assert "server2_com" in names
+    assert "api_example_com_8000" in names
+
+
+def test_same_host_different_types():
+    """Test that same host with different server types can coexist."""
+    # Note: This creates a name collision but is rare in practice
+    urls = [
+        "http://localhost:8000/sse",
+        "http://localhost:8000/mcp"
+    ]
+    result = process_server_urls(urls)
+    assert len(result) == 2
+
+    # Both have same name but different types
+    assert all(server["name"] == "localhost_8000" for server in result)
+    types = [server["type"] for server in result]
+    assert "sse" in types
+    assert "streamable_http" in types
+
+
+def test_ip_address_name_generation():
+    """Test that IP addresses in URLs generate proper names without dots."""
+    # This is the specific case that was causing the parsing issue
+    result = process_server_urls("http://127.0.0.1:8000/mcp")
+    assert result[0]["name"] == "127_0_0_1_8000"
+
+    # Test tool name parsing with the generated name
+    tool_name = f"{result[0]['name']}.hello_world"
+    server_name, actual_tool_name = tool_name.split('.', 1) if '.' in tool_name else (None, tool_name)
+
+    assert server_name == "127_0_0_1_8000"
+    assert actual_tool_name == "hello_world"
+
+
+def test_server_type_detection():
+    """Test that server types are detected correctly."""
+    # SSE detection by path
+    result = process_server_urls("http://localhost:8000/sse")
+    assert result[0]["type"] == "sse"
+
+    # SSE detection by URL content
+    result = process_server_urls("http://localhost:8000/api/sse/endpoint")
+    assert result[0]["type"] == "sse"
+
+    # Default to streamable_http
+    result = process_server_urls("http://localhost:8000/mcp")
+    assert result[0]["type"] == "streamable_http"
+
+    # Default to streamable_http for generic URLs
+    result = process_server_urls("https://api.example.com")
+    assert result[0]["type"] == "streamable_http"

--- a/uv.lock
+++ b/uv.lock
@@ -133,6 +133,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload_time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload_time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -205,6 +214,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=1.12.0" },
@@ -213,6 +227,9 @@ requires-dist = [
     { name = "rich", specifier = ">=14.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.1" }]
 
 [[package]]
 name = "mdurl"
@@ -234,6 +251,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/96/c7fe0d2d1b3053be614822a7b722c7465161b3672ce90df71515137580a0/ollama-0.5.1.tar.gz", hash = "sha256:5a799e4dc4e7af638b11e3ae588ab17623ee019e496caaf4323efbaa8feeff93", size = 41112, upload_time = "2025-05-30T21:32:48.679Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/76/3f96c8cdbf3955d7a73ee94ce3e0db0755d6de1e0098a70275940d1aff2f/ollama-0.5.1-py3-none-any.whl", hash = "sha256:4c8839f35bc173c7057b1eb2cbe7f498c1a7e134eafc9192824c8aecb3617506", size = 13369, upload_time = "2025-05-30T21:32:47.429Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload_time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload_time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload_time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload_time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -371,6 +406,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload_time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload_time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload_time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload_time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -608,6 +661,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload_time = "2025-06-21T04:03:17.337Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload_time = "2025-06-21T04:03:15.705Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload_time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload_time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload_time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload_time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload_time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload_time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload_time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload_time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload_time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload_time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload_time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload_time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload_time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload_time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload_time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload_time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload_time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload_time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload_time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload_time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload_time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload_time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload_time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload_time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload_time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload_time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload_time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload_time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload_time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload_time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload_time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload_time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes Made:

### 1. **Command-line Arguments Section**
- Added `--mcp-server-url`: URL to one or more SSE or Streamable HTTP MCP servers. Can be specified multiple times.

### 2. **Usage Examples Section**
- Added example for connecting to SSE/HTTP servers by URL
- Added example for connecting to multiple URL servers
- Added example for mixing local scripts and URL servers
- Reorganized examples to show the progression from simple to complex usage

## Key Features Documented:

✅ **URL Support**: Users can now connect directly to HTTP-based MCP servers  
✅ **Multiple URLs**: Can specify multiple `--mcp-server-url` options  
✅ **Mixed Usage**: Can combine local scripts (`--mcp-server`) with URLs (`--mcp-server-url`)  
✅ **Auto-detection**: The client automatically detects SSE vs Streamable HTTP based on URL paths  

The documentation now clearly shows users how to use the new URL functionality alongside existing features, making it easy to understand the different ways to connect to MCP servers

## Mixing servers
Running like this:
```
ollmcp --mcp-server weather.py --mcp-server-url http://127.0.0.1:8000/mcp
```
Looks like this:
<img width="1057" height="913" alt="image" src="https://github.com/user-attachments/assets/acfd257f-0134-4dfb-b586-cf3593ccf7d2" />
