### PR TITLE
feat: add shorter flag options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ollmcp
 ### Command-line Arguments
 
 > [!TIP]
-> The CLI now uses `Typer` for a modern experience: grouped options, rich help, and built-in shell autocompletion. To enable autocompletion, run:
+> The CLI now uses `Typer` for a modern experience: grouped options, rich help, and built-in shell autocompletion. Advanced users can use short flags for faster commands. To enable autocompletion, run:
 >
 > ```bash
 > ollmcp --install-completion
@@ -129,27 +129,26 @@ ollmcp
 
 #### MCP Server Configuration:
 
-- `--mcp-server`: Path to one or more MCP server scripts (.py or .js). Can be specified multiple times.
-- `--mcp-server-url`: URL to one or more SSE or Streamable HTTP MCP servers. Can be specified multiple times.
-- `--servers-json`: Path to a JSON file with server configurations.
-- `--auto-discovery`: Auto-discover servers from Claude's default config file (default behavior if no other options provided).
+- `--mcp-server`, `-s`: Path to one or more MCP server scripts (.py or .js). Can be specified multiple times.
+- `--mcp-server-url`, `-u`: URL to one or more SSE or Streamable HTTP MCP servers. Can be specified multiple times.
+- `--servers-json`, `-j`: Path to a JSON file with server configurations.
+- `--auto-discovery`, `-a`: Auto-discover servers from Claude's default config file (default behavior if no other options provided).
 
 > [!TIP]
 > Claude's configuration file is typically located at:
 > `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-
 #### Ollama Configuration:
 
-- `--model MODEL`: Ollama model to use. Default: `qwen2.5:7b`
-- `--host HOST`: Ollama host URL. Default: `http://localhost:11434`
+- `--model`, `-m` MODEL: Ollama model to use. Default: `qwen2.5:7b`
+- `--host`, `-H` HOST: Ollama host URL. Default: `http://localhost:11434`
 
 #### General Options:
 
-- `--version`: Show version and exit
+- `--version`, `-v`: Show version and exit
+- `--help`, `-h`: Show help message and exit
 - `--install-completion`: Install shell autocompletion scripts for the client
 - `--show-completion`: Show available shell completion options
-- `--help`: Show help message and exit
 
 ### Usage Examples
 
@@ -165,12 +164,16 @@ Connect to a single server:
 
 ```bash
 ollmcp --mcp-server /path/to/weather.py --model llama3.2:3b
+# Or using short flags:
+ollmcp -s /path/to/weather.py -m llama3.2:3b
 ```
 
 Connect to multiple servers:
 
 ```bash
 ollmcp --mcp-server /path/to/weather.py --mcp-server /path/to/filesystem.js
+# Or using short flags:
+ollmcp -s /path/to/weather.py -s /path/to/filesystem.js
 ```
 
 >[!TIP]
@@ -180,6 +183,8 @@ Use a JSON configuration file:
 
 ```bash
 ollmcp --servers-json /path/to/servers.json --model llama3.2:1b
+# Or using short flags:
+ollmcp -j /path/to/servers.json -m llama3.2:1b
 ```
 
 >[!TIP]
@@ -188,31 +193,41 @@ ollmcp --servers-json /path/to/servers.json --model llama3.2:1b
 Use a custom Ollama host:
 
 ```bash
-ollmcp --host http://localhost:22545 --servers-json /path/to/servers.json --model qwen3:latest
+ollmcp --host http://localhost:22545 --servers-json /path/to/servers.json --auto-discovery
+# Or using short flags:
+ollmcp -H http://localhost:22545 -j /path/to/servers.json -a
 ```
 
 Connect to SSE or Streamable HTTP servers by URL:
 
 ```bash
 ollmcp --mcp-server-url http://localhost:8000/sse --model qwen2.5:latest
+# Or using short flags:
+ollmcp -u http://localhost:8000/sse -m qwen2.5:latest
 ```
 
 Connect to multiple URL servers:
 
 ```bash
 ollmcp --mcp-server-url http://localhost:8000/sse --mcp-server-url http://localhost:9000/mcp
+# Or using short flags:
+ollmcp -u http://localhost:8000/sse -u http://localhost:9000/mcp
 ```
 
 Mix local scripts and URL servers:
 
 ```bash
 ollmcp --mcp-server /path/to/weather.py --mcp-server-url http://localhost:8000/mcp --model qwen3:1.7b
+# Or using short flags:
+ollmcp -s /path/to/weather.py -u http://localhost:8000/mcp -m qwen3:1.7b
 ```
 
 Use auto-discovery with mixed server types:
 
 ```bash
 ollmcp --mcp-server /path/to/weather.py --mcp-server-url http://localhost:8000/mcp --auto-discovery
+# Or using short flags:
+ollmcp -s /path/to/weather.py -u http://localhost:8000/mcp -a
 ```
 
 ## Interactive Commands

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -861,47 +861,47 @@ class MCPClient:
                 title="Reload Failed", border_style="red", expand=False
             ))
 
-app = typer.Typer(help="MCP Client for Ollama")
+app = typer.Typer(help="MCP Client for Ollama", context_settings={"help_option_names": ["-h", "--help"]})
 
 @app.command()
 def main(
     # MCP Server Configuration
     mcp_server: Optional[List[str]] = typer.Option(
-        None, "--mcp-server",
+        None, "--mcp-server", "-s",
         help="Path to a server script (.py or .js)",
         rich_help_panel="MCP Server Configuration"
     ),
     mcp_server_url: Optional[List[str]] = typer.Option(
-        None, "--mcp-server-url",
+        None, "--mcp-server-url", "-u",
         help="URL for SSE or Streamable HTTP MCP server (e.g., http://localhost:8000/sse, https://domain-name.com/mcp, etc)",
         rich_help_panel="MCP Server Configuration"
     ),
     servers_json: Optional[str] = typer.Option(
-        None, "--servers-json",
+        None, "--servers-json", "-j",
         help="Path to a JSON file with server configurations",
         rich_help_panel="MCP Server Configuration"
     ),
     auto_discovery: bool = typer.Option(
-        False, "--auto-discovery",
+        False, "--auto-discovery", "-a",
         help=f"Auto-discover servers from Claude's config at {DEFAULT_CLAUDE_CONFIG} - If no other options are provided, this will be enabled by default",
         rich_help_panel="MCP Server Configuration"
     ),
 
     # Ollama Configuration
     model: str = typer.Option(
-        DEFAULT_MODEL, "--model",
+        DEFAULT_MODEL, "--model", "-m",
         help="Ollama model to use",
         rich_help_panel="Ollama Configuration"
     ),
     host: str = typer.Option(
-        DEFAULT_OLLAMA_HOST, "--host",
+        DEFAULT_OLLAMA_HOST, "--host", "-H",
         help="Ollama host URL",
         rich_help_panel="Ollama Configuration"
     ),
 
     # General Options
     version: Optional[bool] = typer.Option(
-        None, "--version",
+        None, "--version", "-v",
         help="Show version and exit",
     )
 ):


### PR DESCRIPTION
## Add short flag options for CLI commands

This PR adds convenient short flags for all CLI options to improve the user experience for advanced users.

### Changes:
- **Short flags added:**
  - `--mcp-server` → `-s`
  - `--mcp-server-url` → `-u`
  - `--servers-json` → `-j`
  - `--auto-discovery` → `-a`
  - `--model` → `-m`
  - `--host` → `-H`
  - `--version` → `-v`
  - `--help` → `-h` (automatically provided by Typer)

- **Updated README.md:**
  - Added short flags to command-line arguments documentation
  - Updated usage examples to show both long and short flag alternatives
  - Added tip highlighting short flags for advanced users

### Benefits:
- Faster command-line usage for power users
- Maintains backward compatibility with existing long flags
- Follows standard CLI conventions (e.g., `-h` for help, `-v` for version)
- Improves developer experience when testing with different configurations

**Example:**
```bash
# Before
ollmcp --mcp-server /path/to/server.py --model llama3.2:3b --auto-discovery

# After (short flags)
ollmcp -s /path/to/server.py -m llama3.2:3b -a
```