### PR TITLE
refactor: add constant for mcp protocol version

### DIFF
--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -16,6 +16,7 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from .discovery import process_server_paths, process_server_urls, parse_server_configs, auto_discover_servers
+from ..utils.constants import MCP_PROTOCOL_VERSION
 
 class ServerConnector:
     """Manages connections to one or more MCP servers.
@@ -398,7 +399,7 @@ class ServerConnector:
         # Always add MCP Protocol Version header for HTTP connections
         server_type = server.get("type", "script")
         if server_type in ["sse", "streamable_http"]:
-            headers["MCP-Protocol-Version"] = "2025-06-18"
+            headers["MCP-Protocol-Version"] = MCP_PROTOCOL_VERSION
 
         return headers
 

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -18,8 +18,12 @@ DEFAULT_MODEL = "qwen2.5:7b"
 # Default ollama lcoal url for API requests
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
+
 # URL for checking package updates on PyPI
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mcp-client-for-ollama/json"
+
+# MCP Protocol Version
+MCP_PROTOCOL_VERSION = "2025-06-18"
 
 # Interactive commands and their descriptions for autocomplete
 INTERACTIVE_COMMANDS = {


### PR DESCRIPTION
This pull request centralizes the definition of the MCP protocol version by moving it to a constant in `utils/constants.py` and updates its usage in the server connector logic. This change improves maintainability by ensuring the protocol version is defined in a single location and referenced consistently.

**Constants centralization:**

* Added `MCP_PROTOCOL_VERSION` to `mcp_client_for_ollama/utils/constants.py` to define the MCP protocol version in one place.

**Codebase consistency:**

* Updated `mcp_client_for_ollama/server/connector.py` to import and use `MCP_PROTOCOL_VERSION` instead of a hardcoded string when setting the `MCP-Protocol-Version` HTTP header. [[1]](diffhunk://#diff-18edad15e35e8ea7693a7e915319bc3042f5dd0602e1a440607b2af158525fbaR19) [[2]](diffhunk://#diff-18edad15e35e8ea7693a7e915319bc3042f5dd0602e1a440607b2af158525fbaL401-R402)