### PR TITLE
feat: checking SSE and Streamable HTTP mcp servers connectivity before e starting sessions

### DIFF
--- a/mcp_client_for_ollama/utils/connection.py
+++ b/mcp_client_for_ollama/utils/connection.py
@@ -1,0 +1,25 @@
+"""Utility to test connectivity"""
+import urllib.request
+import urllib.error
+
+def check_url_connectivity(url):
+    """
+    Check the connectivity of a URL by performing GET and POST requests.
+    """
+    try:
+        # Test GET
+        urllib.request.urlopen(url, timeout=2)
+
+        # Test POST (empty data)
+        req = urllib.request.Request(url, data=b'', method='POST')
+        urllib.request.urlopen(req, timeout=2)
+
+        return True
+
+    except urllib.error.HTTPError:
+        # Server responded with an HTTP error code (like 406, 404, 500, etc.)
+        # This means the server is reachable, so return True
+        return True
+    except (urllib.error.URLError, OSError):
+        # Skip URLs that are unreachable or timeout
+        return False

--- a/uv.lock
+++ b/uv.lock
@@ -221,8 +221,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = "~=1.12.0" },
-    { name = "ollama", specifier = "~=0.5.1" },
+    { name = "mcp", specifier = "~=1.12.4" },
+    { name = "ollama", specifier = "~=0.5.3" },
     { name = "prompt-toolkit", specifier = "~=3.0.51" },
     { name = "rich", specifier = "~=14.1.0" },
     { name = "typer", specifier = "~=0.16.0" },


### PR DESCRIPTION
> The server MUST provide a single HTTP endpoint path (hereafter referred to as the MCP endpoint) that supports both POST and GET methods.

source: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http

Tests

<img width="777" height="721" alt="Screenshot 2025-08-14 at 13 19 04" src="https://github.com/user-attachments/assets/3e783582-90cd-4bfd-a9e8-594a886c08b3" />
<img width="609" height="317" alt="image" src="https://github.com/user-attachments/assets/4a110259-959f-4bbc-ae49-51ba5bef750a" />


