### PR TITLE
chore(release): bump version to 0.18.3

### DIFF
--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.18.2"
+version = "0.18.3"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.18.2"
+    "mcp-client-for-ollama==0.18.3"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.18.2"
+__version__ = "0.18.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.18.2"
+version = "0.18.3"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
This pull request updates the version of both the `ollmcp` CLI package and its dependency `mcp-client-for-ollama` from `0.18.2` to `0.18.3`. The change ensures consistency across the project and prepares it for the latest release.

Version bump and dependency updates:

* Updated the `version` field in `cli-package/pyproject.toml` and `pyproject.toml` from `0.18.2` to `0.18.3` to reflect the new release. [[1]](diffhunk://#diff-b2111e5fdefd6c9a134306441e6555204eb94b0dfd5e068ccb65b787b86f0fedL3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)
* Changed the dependency in `cli-package/pyproject.toml` to require `mcp-client-for-ollama==0.18.3` instead of `0.18.2`.
* Updated the `__version__` variable in `mcp_client_for_ollama/__init__.py` to `0.18.3`.