### PR TITLE
fix: ensure CLI model flag overrides saved config

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -1014,6 +1014,11 @@ async def async_main(mcp_server, mcp_server_url, servers_json, auto_discovery, m
     try:
         await client.connect_to_servers(mcp_server, mcp_server_url, config_path, auto_discovery_final)
         client.auto_load_default_config()
+
+        # If model was explicitly provided via CLI flag (not default), override any loaded config
+        if model != DEFAULT_MODEL:
+            client.model_manager.set_model(model)
+
         await client.chat_loop()
     finally:
         await client.cleanup()


### PR DESCRIPTION
This pull request introduces an improvement to the model selection logic in the `async_main` function of `mcp_client_for_ollama/client.py`. Now, if a model is explicitly provided via the CLI flag (and it's not the default), the client will override any loaded configuration and use the specified model for the session.

Model selection logic:

* In `async_main`, added a check to override the loaded config with the CLI-specified model if it differs from the default, ensuring user intent is respected.