### PR TITLE
feat(ollama): add logprobs/top_logprobs support, capture and display token log probabilities

### DIFF
--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -42,11 +42,14 @@ def default_config() -> dict:
             "frequency_penalty": None,
             "stop": None,
             "num_ctx": None,
-            "num_batch" : None
+            "num_batch" : None,
+            "logprobs": None,
+            "top_logprobs": None
         },
         "displaySettings": {
             "showToolExecution": True,
-            "showMetrics": False
+            "showMetrics": False,
+            "showLogprobs": False
         },
         "hilSettings": {
             "enabled": True

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -254,6 +254,10 @@ class ConfigManager:
                 validated["modelConfig"]["num_ctx"] = model_config["num_ctx"] if model_config["num_ctx"] is not None else None
             if "num_batch" in model_config:
                 validated["modelConfig"]["num_batch"] = model_config["num_batch"] if model_config["num_batch"] is not None else None
+            if "logprobs" in model_config:
+                validated["modelConfig"]["logprobs"] = model_config["logprobs"] if model_config["logprobs"] is not None else None
+            if "top_logprobs" in model_config:
+                validated["modelConfig"]["top_logprobs"] = model_config["top_logprobs"] if model_config["top_logprobs"] is not None else None
 
 
         if "displaySettings" in config_data and isinstance(config_data["displaySettings"], dict):
@@ -261,6 +265,8 @@ class ConfigManager:
                 validated["displaySettings"]["showToolExecution"] = bool(config_data["displaySettings"]["showToolExecution"])
             if "showMetrics" in config_data["displaySettings"]:
                 validated["displaySettings"]["showMetrics"] = bool(config_data["displaySettings"]["showMetrics"])
+            if "showLogprobs" in config_data["displaySettings"]:
+                validated["displaySettings"]["showLogprobs"] = bool(config_data["displaySettings"]["showLogprobs"])
 
         if "hilSettings" in config_data and isinstance(config_data["hilSettings"], dict):
             if "enabled" in config_data["hilSettings"]:

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -43,6 +43,7 @@ INTERACTIVE_COMMANDS = {
     'reload-servers': 'Reload MCP servers',
     'reset-config': 'Reset to default config',
     'save-config': 'Save current configuration',
+    'show-logprobs': 'Toggle log probabilities display',
     'show-metrics': 'Toggle performance metrics display',
     'show-thinking': 'Toggle thinking visibility',
     'show-tool-execution': 'Toggle tool execution display',

--- a/mcp_client_for_ollama/utils/logprobs_display.py
+++ b/mcp_client_for_ollama/utils/logprobs_display.py
@@ -1,0 +1,100 @@
+"""Display utilities for logprobs data from Ollama responses."""
+from rich.console import Console
+from rich.table import Table
+import rich.box
+
+
+def display_logprobs(console: Console, logprobs_data: list, max_alternatives: int = 3) -> None:
+    """Display logprobs data in a formatted Rich table.
+
+    Args:
+        console: Rich console for output
+        logprobs_data: List of logprob entries from Ollama response
+        max_alternatives: Maximum number of alternative tokens to show per position
+    """
+    if not logprobs_data:
+        console.print("[yellow]No logprobs data available. Make sure logprobs is enabled in model-config.[/yellow]")
+        return
+
+    # Create a table for logprobs display
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        box=rich.box.ROUNDED,
+        expand=False,
+        title="📊 Token Log Probabilities",
+        title_style="bold white"
+    )
+
+    table.add_column("#", style="dim", width=4, justify="right")
+    table.add_column("Token", style="green bold", width=15)
+    table.add_column("Logprob", style="cyan", width=10, justify="right")
+    table.add_column("Probability", style="yellow", width=12, justify="right")
+    table.add_column("Alternatives", style="magenta dim", width=50)
+
+    import math
+
+    for idx, entry in enumerate(logprobs_data, start=1):
+        # Handle both dict and object access patterns
+        try:
+            if hasattr(entry, 'token'):
+                # Object access
+                token = entry.token
+                logprob = entry.logprob
+                top_logprobs_list = getattr(entry, 'top_logprobs', []) or []
+            else:
+                # Dict access
+                token = entry.get('token', '')
+                logprob = entry.get('logprob', 0)
+                top_logprobs_list = entry.get('top_logprobs', []) or []
+        except Exception:
+            # Skip entries we can't parse
+            continue
+
+        # Convert logprob to probability percentage
+        probability = math.exp(logprob) * 100
+
+        # Format token display - escape only control chars, show everything else as-is
+        token_display = token.replace('\n', '\\n').replace('\t', '\\t').replace('\r', '\\r')
+
+        # Format alternatives
+        alternatives_text = ""
+        if top_logprobs_list:
+            alt_parts = []
+            for alt in top_logprobs_list[:max_alternatives]:
+                try:
+                    if hasattr(alt, 'token'):
+                        alt_token = alt.token
+                        alt_logprob = alt.logprob
+                    else:
+                        alt_token = alt.get('token', '')
+                        alt_logprob = alt.get('logprob', 0)
+
+                    alt_prob = math.exp(alt_logprob) * 100
+
+                    # Skip if it's the same as the chosen token
+                    if alt_token == token:
+                        continue
+
+                    # Format alternative token display
+                    alt_token_display = alt_token.replace('\n', '\\n').replace('\t', '\\t').replace('\r', '\\r')
+
+                    alt_parts.append(f"{alt_token_display} ({alt_prob:.1f}%)")
+                except Exception:
+                    continue
+
+            alternatives_text = ", ".join(alt_parts) if alt_parts else "-"
+        else:
+            alternatives_text = "-"
+
+        table.add_row(
+            str(idx),
+            token_display,
+            f"{logprob:.3f}",
+            f"{probability:.2f}%",
+            alternatives_text
+        )
+
+    console.print()
+    console.print(table)
+    console.print()

--- a/uv.lock
+++ b/uv.lock
@@ -390,15 +390,15 @@ wheels = [
 
 [[package]]
 name = "ollama"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/47/f9ee32467fe92744474a8c72e138113f3b529fc266eea76abfdec9a33f3b/ollama-0.6.0.tar.gz", hash = "sha256:da2b2d846b5944cfbcee1ca1e6ee0585f6c9d45a2fe9467cbcd096a37383da2f", size = 50811, upload-time = "2025-09-24T22:46:02.417Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/c1/edc9f41b425ca40b26b7c104c5f6841a4537bb2552bfa6ca66e81405bb95/ollama-0.6.0-py3-none-any.whl", hash = "sha256:534511b3ccea2dff419ae06c3b58d7f217c55be7897c8ce5868dfb6b219cf7a0", size = 14130, upload-time = "2025-09-24T22:46:01.19Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add model configuration fields `logprobs` and `top_logprobs`
- Capture top-level `logprobs` from streaming response chunks and expose them alongside content, tool calls and metrics
- Add `show-logprobs` toggle to control visibility and persist `showLogprobs` in saved config
- Show logprobs immediately after each completed response (initial and follow-up responses)
- Configuration can be saved