### PR TITLE
feat(history): add full conversation history management with export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
   - [Human-in-the-Loop (HIL) Tool Execution](#human-in-the-loop-hil-tool-execution)
   - ✨**NEW** [MCP Prompts](#mcp-prompts)
   - [Performance Metrics](#performance-metrics)
+  - ✨**NEW** [History Management](#history-management)
 - [Autocomplete and Prompt Features](#autocomplete-and-prompt-features)
 - [Configuration Management](#configuration-management)
 - [Server Configuration Format](#server-configuration-format)
@@ -60,9 +61,9 @@ MCP Client for Ollama (`ollmcp`) is a modern, interactive terminal application (
 ## Features
 
 - 🤖 **Agent Mode**: Iterative tool execution when models request multiple tool calls, with a configurable loop limit to prevent infinite loops
-- 📋 **MCP Prompts Support**: Browse, invoke, and manage prompts from MCP servers with argument collection, preview, and safe rollback
 - 🌐 **Multi-Server Support**: Connect to multiple MCP servers simultaneously
 - 🚀 **Multiple Transport Types**: Supports STDIO, SSE, and Streamable HTTP server connections
+- 📋 **MCP Prompts Support**: Browse, invoke, and manage prompts from MCP servers with argument collection, preview, and safe rollback
 - ☁️ **Ollama Cloud Support**: Works seamlessly with Ollama Cloud models for tool calling, enabling access to powerful cloud-hosted models while using local MCP tools
 - 🎨 **Rich Terminal Interface**: Interactive console UI with modern styling
 - 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
@@ -74,7 +75,8 @@ MCP Client for Ollama (`ollmcp`) is a modern, interactive terminal application (
 - 🎨 **Enhanced Tool Display**: Beautiful, structured visualization of tool executions with JSON syntax highlighting
 - 🧠 **Context Management**: Control conversation memory with configurable retention settings
 - 🤔 **Thinking Mode**: Advanced reasoning capabilities with visible thought processes for supported models (e.g., gpt-oss, deepseek-r1, qwen3, etc.)
-- 🗣️ **Cross-Language Support**: Seamlessly work with both Python and JavaScript MCP servers
+ - 🗣️ **Cross-Language Support**: Seamlessly work with both Python and JavaScript MCP servers
+ - 📜 **History Management**: View full conversation history, export to JSON for backup/analysis, and import previous sessions for continuity
 - 🔍 **Auto-Discovery**: Automatically find and use Claude's existing MCP server configurations
 - 🔁 **Dynamic Model Switching**: Switch between any installed Ollama model without restarting
 - 💾 **Configuration Persistence**: Save and load tool preferences and model settings between sessions
@@ -255,7 +257,10 @@ During chat, use these commands:
 | `cls`            | `clear-screen`   | Clear the terminal screen                           |
 | `context`        | `c`              | Toggle context retention                            |
 | `context-info`   | `ci`             | Display context statistics                          |
+| `export-history` | `eh`             | Export chat history to a JSON file                  |
+| `full-history`   | `fh`             | Display all conversation history                    |
 | `help`           | `h`              | Display help and available commands                 |
+| `import-history` | `ih`             | Import chat history from a JSON file                |
 | `human-in-loop`  | `hil`            | Toggle Human-in-the-Loop confirmations for tool execution |
 | `load-config`    | `lc`             | Load tool and model configuration from a file       |
 | `loop-limit`     | `ll`             | Set maximum iterative tool-loop iterations (Agent Mode). Default: 3 |
@@ -517,6 +522,50 @@ The Performance Metrics feature displays detailed model performance data after e
 
 > [!NOTE]
 > **Data Source**: All metrics come directly from Ollama's response, ensuring accuracy and reliability.
+
+### History Management
+
+The History Management feature allows you to view, export, and import your conversation history. This is useful for:
+
+- 📜 **Full History View**: Review all conversations from your current session
+- 💾 **Export**: Save conversations to JSON files for backup or analysis
+- 📥 **Import**: Load previous conversation history to continue where you left off
+- 🔄 **Portability**: Share or transfer conversations between sessions
+
+#### History Commands
+
+**View Full History:**
+```
+full-history  # or 'fh'
+```
+Displays all conversation history from the current session in a formatted view, showing both queries and responses.
+
+**Export History:**
+```
+export-history  # or 'eh'
+```
+Exports your current chat history to a JSON file. You can specify a custom filename or use the default timestamp-based name (e.g., `ollmcp_chat_history_2026-01-05_143022.json`). Files are saved to `~/.config/ollmcp/history/` directory. The command includes file overwrite protection.
+
+**Import History:**
+```
+import-history  # or 'ih'
+```
+Imports a previously exported chat history from a JSON file. The command validates the JSON structure to ensure compatibility. Imported history is added to your current conversation context.
+
+**History Storage:**
+- Export location: `~/.config/ollmcp/history/`
+- Default filename format: `ollmcp_chat_history_YYYY-MM-DD_HHMMSS.json`
+- JSON format includes both queries and responses with proper structure validation
+
+**Benefits:**
+- **Session Continuity**: Resume conversations across different sessions
+- **Backup**: Keep records of important conversations
+- **Analysis**: Export history for external analysis or review
+- **Sharing**: Share conversation context with team members
+- **Testing**: Import test conversations for development and debugging
+
+> [!TIP]
+> When exporting, if you don't provide a filename, the system automatically generates a timestamped filename to prevent accidental overwrites.
 
 ## Autocomplete and Prompt Features
 

--- a/mcp_client_for_ollama/prompts/handler.py
+++ b/mcp_client_for_ollama/prompts/handler.py
@@ -8,6 +8,7 @@ from .display import display_prompt_list, display_prompt_preview
 from .content import filter_prompt_messages
 from .injection import convert_prompt_messages_to_history
 from ..utils.hil_manager import AbortQueryException
+from ..utils.input import get_input_no_autocomplete
 
 
 class PromptHandler:
@@ -151,8 +152,10 @@ class PromptHandler:
                     self.console.print(f"[white]{arg_desc}[/white]")
 
                 try:
-                    self.console.print(f"[bold yellow]{arg_name}❯[/bold yellow] ", end="")
-                    value = input()
+                    value = await get_input_no_autocomplete(f"{arg_name}")
+                    if value == "quit":
+                        self.console.print("[yellow]Prompt invocation cancelled.[/yellow]")
+                        return None
                 except (KeyboardInterrupt, EOFError):
                     self.console.print("\n[yellow]Prompt invocation cancelled.[/yellow]")
                     return None

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -18,6 +18,9 @@ DEFAULT_MODEL = "qwen2.5:7b"
 # Default ollama lcoal url for API requests
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
+# Default number of history entries to display when returning from menus
+DEFAULT_HISTORY_DISPLAY_LIMIT = 5
+
 
 # URL for checking package updates on PyPI
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mcp-client-for-ollama/json"
@@ -33,7 +36,10 @@ INTERACTIVE_COMMANDS = {
     'context-info': 'Show context information',
     'context': 'Toggle context retention',
     'exit': 'Exit the application',
+    'export-history': 'Export chat history to JSON',
+    'full-history': 'View full conversation history',
     'help': 'Show help information',
+    'import-history': 'Import chat history from JSON',
     'human-in-the-loop': 'Toggle HIL confirmations',
     'load-config': 'Load saved configuration',
     'loop-limit': 'Set agent max loop limit',

--- a/mcp_client_for_ollama/utils/history.py
+++ b/mcp_client_for_ollama/utils/history.py
@@ -1,0 +1,143 @@
+"""
+Chat history management utilities for the MCP client for Ollama.
+
+This module provides functions for displaying, exporting, and importing chat history.
+"""
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+from rich.console import Console
+from rich.panel import Panel
+from rich.markdown import Markdown
+from rich.text import Text
+
+
+def display_full_history(chat_history: List[Dict], console: Console) -> None:
+    """Display the full chat history to the console
+
+    Args:
+        chat_history: List of chat history entries with 'query' and 'response' keys
+        console: Rich console for output
+    """
+    if not chat_history:
+        console.print("[yellow]No chat history available.[/yellow]")
+        return
+
+    console.print(Panel(
+        f"[bold]Full Chat History[/bold] - {len(chat_history)} conversations",
+        border_style="blue",
+        expand=False
+    ))
+
+    for i, entry in enumerate(chat_history, start=1):
+        console.print(f"[bold green]Query {i}:[/bold green]")
+        console.print(Text(entry["query"].strip(), style="green"))
+        console.print("[bold blue]Answer:[/bold blue]")
+        console.print(Markdown(entry["response"].strip()))
+        console.print()
+
+
+def export_history(chat_history: List[Dict], console: Console, filename: Optional[str] = None) -> bool:
+    """Export chat history to a JSON file
+
+    Args:
+        chat_history: List of chat history entries with 'query' and 'response' keys
+        console: Rich console for output
+        filename: Optional custom filename. If None, uses timestamp-based default
+
+    Returns:
+        bool: True if export was successful, False otherwise
+    """
+    if not chat_history:
+        console.print("[yellow]No chat history to export.[/yellow]")
+        return False
+
+    # Use config directory for history exports (consistent with app config location)
+    history_dir = Path.home() / ".config" / "ollmcp" / "history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate filename if not provided
+    if not filename:
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        filename = f"ollmcp_chat_history_{timestamp}.json"
+
+    # Ensure .json extension
+    if not filename.endswith('.json'):
+        filename += '.json'
+
+    filepath = history_dir / filename
+
+    # Check if file already exists
+    if filepath.exists():
+        console.print(f"⚠️ File already exists: [cyan]{filepath}[/cyan]")
+        console.print("[yellow]Please use a different filename to avoid overwriting.[/yellow]")
+        return False
+
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            json.dump(chat_history, f, indent=2, ensure_ascii=False)
+
+        console.print(f"[green]✓[/green] Chat history exported successfully to:")
+        console.print(f"  [cyan]{filepath}[/cyan]")
+        console.print(f"  ({len(chat_history)} conversations)")
+        return True
+
+    except Exception as e:
+        console.print(f"[red]✗[/red] Failed to export chat history: {str(e)}")
+        return False
+
+
+def import_history(filepath: str, console: Console) -> Optional[List[Dict]]:
+    """Import chat history from a JSON file
+
+    Args:
+        filepath: Path to the JSON file to import
+        console: Rich console for output
+
+    Returns:
+        List[Dict]: Loaded and validated chat history, or None if import failed
+    """
+    # Expand user path
+    filepath = os.path.expanduser(filepath)
+
+    # Check if file exists
+    if not os.path.exists(filepath):
+        console.print(f"[red]✗[/red] File not found: [cyan]{filepath}[/cyan]")
+        return None
+
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        # Validate structure
+        if not isinstance(data, list):
+            console.print("[red]✗[/red] Invalid history file: Expected a list of conversations")
+            return None
+
+        # Validate each entry
+        for i, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                console.print(f"[red]✗[/red] Invalid entry at position {i+1}: Expected a dictionary")
+                return None
+
+            if 'query' not in entry or 'response' not in entry:
+                console.print(f"[red]✗[/red] Invalid entry at position {i+1}: Missing 'query' or 'response' key")
+                return None
+
+            if not isinstance(entry['query'], str) or not isinstance(entry['response'], str):
+                console.print(f"[red]✗[/red] Invalid entry at position {i+1}: 'query' and 'response' must be strings")
+                return None
+
+        console.print(f"[green]✓[/green] Chat history imported successfully:")
+        console.print(f"  [cyan]{filepath}[/cyan]")
+        console.print(f"  ({len(data)} conversations)")
+        return data
+
+    except json.JSONDecodeError as e:
+        console.print(f"[red]✗[/red] Invalid JSON file: {str(e)}")
+        return None
+    except Exception as e:
+        console.print(f"[red]✗[/red] Failed to import chat history: {str(e)}")
+        return None

--- a/mcp_client_for_ollama/utils/input.py
+++ b/mcp_client_for_ollama/utils/input.py
@@ -1,0 +1,35 @@
+"""
+Input utilities for the MCP client for Ollama.
+
+This module provides functions for getting user input without autocomplete.
+"""
+from prompt_toolkit import PromptSession
+from prompt_toolkit.styles import Style
+from .constants import DEFAULT_COMPLETION_STYLE
+
+
+async def get_input_no_autocomplete(prompt_text: str) -> str:
+    """Get user input without autocomplete (for file paths, config names, etc.)
+
+    This is useful for inputs where prompt/command autocomplete would be distracting
+    or inappropriate, such as file paths, config names, or prompt arguments.
+
+    Args:
+        prompt_text: The prompt text to display (without the ❯ symbol)
+
+    Returns:
+        str: User input or 'quit' if cancelled
+    """
+    try:
+        # Create a temporary session without completer
+        temp_session = PromptSession(
+            style=Style.from_dict(DEFAULT_COMPLETION_STYLE)
+        )
+        user_input = await temp_session.prompt_async(
+            f"{prompt_text}❯ "
+        )
+        return user_input
+    except KeyboardInterrupt:
+        return "quit"
+    except EOFError:
+        return "quit"


### PR DESCRIPTION
- Add full-history/fh command to view all session conversations
- Add export-history/eh command with timestamp-based naming and overwrite protection
- Add import-history/ih command with JSON validation
- Create utils/history.py module for reusable history functions
- Add get_input_no_autocomplete() utility for file/config inputs
- Update README with comprehensive history management documentation