### PR TITLE
feat(connector): enhance capability handling for tools and prompts during server connection

### DIFF
--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -198,8 +198,8 @@ class ServerConnector:
                 read_stream, write_stream = stdio_transport
                 session = await self.exit_stack.enter_async_context(ClientSession(read_stream, write_stream))
 
-            # Initialize the session
-            await session.initialize()
+            # Initialize the session and capture capabilities
+            init_result = await session.initialize()
 
             # Store the session
             self.sessions[server_name] = {
@@ -207,40 +207,54 @@ class ServerConnector:
                 "tools": []
             }
 
-            # Get tools from this server
-            response = await session.list_tools()
-
-            # Store and merge tools, prepending server name to avoid conflicts
+            # Get tools from this server if capability is present
             server_tools = []
-            for tool in response.tools:
-                # Create a qualified name for the tool that includes the server
-                qualified_name = f"{server_name}.{tool.name}"
-                # Clone the tool but update the name
-                tool_copy = Tool(
-                    name=qualified_name,
-                    description=f"[{server_name}] {tool.description}" if hasattr(tool, 'description') else f"Tool from {server_name}",
-                    inputSchema=tool.inputSchema,
-                    outputSchema=tool.outputSchema if hasattr(tool, 'outputSchema') else None
-                )
-                server_tools.append(tool_copy)
-                self.enabled_tools[qualified_name] = True
+            capabilities = getattr(init_result, 'capabilities', None)
+            if capabilities and getattr(capabilities, 'tools', None):
+                try:
+                    response = await session.list_tools()
+                    # Store and merge tools, prepending server name to avoid conflicts
+                    for tool in response.tools:
+                        # Create a qualified name for the tool that includes the server
+                        qualified_name = f"{server_name}.{tool.name}"
+                        # Clone the tool but update the name
+                        tool_copy = Tool(
+                            name=qualified_name,
+                            description=f"[{server_name}] {tool.description}" if hasattr(tool, 'description') else f"Tool from {server_name}",
+                            inputSchema=tool.inputSchema,
+                            outputSchema=tool.outputSchema if hasattr(tool, 'outputSchema') else None
+                        )
+                        server_tools.append(tool_copy)
+                        self.enabled_tools[qualified_name] = True
+                except Exception as e:
+                    self.console.print(f"[yellow]Warning: Failed to list tools from {server_name}: {str(e)}[/yellow]")
+            else:
+                self.console.print(f"[dim]Server {server_name} does not support tools capability[/dim]")
 
             self.sessions[server_name]["tools"] = server_tools
             self.available_tools.extend(server_tools)
 
-            # Try to get prompts from this server
+            # Get prompts from this server if capability is present
             server_prompts = []
-            try:
-                # Attempt to list prompts - will fail gracefully if not supported
-                prompts_response = await session.list_prompts()
-                server_prompts = prompts_response.prompts if hasattr(prompts_response, 'prompts') else []
-                if server_prompts:
-                    self.prompts_by_server[server_name] = server_prompts
-            except (AttributeError, NotImplementedError, Exception):
-                # Server doesn't support prompts or feature not available
-                pass
+            if capabilities and getattr(capabilities, 'prompts', None):
+                try:
+                    prompts_response = await session.list_prompts()
+                    server_prompts = prompts_response.prompts if hasattr(prompts_response, 'prompts') else []
+                    if server_prompts:
+                        self.prompts_by_server[server_name] = server_prompts
+                except Exception as e:
+                    self.console.print(f"[yellow]Warning: Failed to list prompts from {server_name}: {str(e)}[/yellow]")
+            else:
+                self.console.print(f"[dim]Server {server_name} does not support prompts capability[/dim]")
 
-            prompt_count_msg = f" and {len(server_prompts)} prompt(s)" if server_prompts else ""
+            # @TODO Resources capability check (not yet implemented)
+            # if capabilities and getattr(capabilities, 'resources', None):
+            #     # Future: Implement resources support
+            #     pass
+            # else:
+            #     self.console.print(f"[dim]Server {server_name} does not support resources capability[/dim]")
+
+            prompt_count_msg = f" and {len(server_prompts)} prompt(s)"
             self.console.print(f"[green]Successfully connected to {server_name} with {len(server_tools)} tool(s){prompt_count_msg}[/green]")
             return True
 

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -1,6 +1,7 @@
 """Constants used throughout the MCP Client for Ollama application."""
 
 import os
+from mcp.types import LATEST_PROTOCOL_VERSION
 
 # Default Claude config file location
 DEFAULT_CLAUDE_CONFIG = os.path.expanduser("~/Library/Application Support/Claude/claude_desktop_config.json")
@@ -28,8 +29,10 @@ MAX_COMPLETION_MENU_ROWS = 7
 # URL for checking package updates on PyPI
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mcp-client-for-ollama/json"
 
-# MCP Protocol Version
-MCP_PROTOCOL_VERSION = "2025-06-18"
+# MCP Protocol Version - Using SDK's latest supported version (currently "2025-11-25")
+# The SDK handles backward compatibility with servers on older protocol versions:
+# Supported versions: ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
+MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION
 
 # Interactive commands and their descriptions for autocomplete
 INTERACTIVE_COMMANDS = {

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,5 +1,7 @@
 """Test server connector functionality."""
 
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 from mcp_client_for_ollama.server.connector import ServerConnector
 from mcp_client_for_ollama.utils.constants import MCP_PROTOCOL_VERSION
 from contextlib import AsyncExitStack
@@ -208,3 +210,148 @@ def test_get_url_from_server():
         "name": "test-server"
     }
     assert connector._get_url_from_server(server) is None
+
+
+class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
+    """Test capability-based feature detection."""
+
+    async def test_server_without_tools_capability(self):
+        """Test that connection succeeds when server doesn't support tools."""
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack)
+
+            # Mock server configuration
+            server = {
+                "name": "test-server",
+                "type": "script",
+                "path": "/fake/path.py"
+            }
+
+            # Mock the session and initialization
+            mock_session = AsyncMock()
+            mock_init_result = MagicMock()
+            mock_init_result.capabilities = MagicMock()
+            mock_init_result.capabilities.tools = None  # No tools capability
+            mock_init_result.capabilities.prompts = None
+            mock_session.initialize.return_value = mock_init_result
+
+            # Mock the transport and session creation
+            with patch('mcp_client_for_ollama.server.connector.stdio_client') as mock_stdio, \
+                 patch('mcp_client_for_ollama.server.connector.ClientSession', return_value=mock_session), \
+                 patch.object(connector, '_create_script_params', return_value=MagicMock()):
+
+                mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+                mock_stdio.return_value.__aexit__ = AsyncMock()
+
+                # Connect to server
+                result = await connector._connect_to_server(server)
+
+                # Verify connection succeeded despite no tools
+                assert result is True
+                assert "test-server" in connector.sessions
+                assert connector.sessions["test-server"]["tools"] == []
+                assert mock_session.list_tools.call_count == 0  # Should not call list_tools
+
+    async def test_server_without_prompts_capability(self):
+        """Test that connection succeeds when server doesn't support prompts."""
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack)
+
+            # Mock server configuration
+            server = {
+                "name": "test-server",
+                "type": "script",
+                "path": "/fake/path.py"
+            }
+
+            # Mock the session and initialization
+            mock_session = AsyncMock()
+            mock_init_result = MagicMock()
+            mock_init_result.capabilities = MagicMock()
+            mock_init_result.capabilities.tools = MagicMock()  # Has tools
+            mock_init_result.capabilities.prompts = None  # No prompts capability
+
+            # Mock list_tools response
+            mock_tools_response = MagicMock()
+            mock_tools_response.tools = []
+            mock_session.initialize.return_value = mock_init_result
+            mock_session.list_tools.return_value = mock_tools_response
+
+            # Mock the transport and session creation
+            with patch('mcp_client_for_ollama.server.connector.stdio_client') as mock_stdio, \
+                 patch('mcp_client_for_ollama.server.connector.ClientSession', return_value=mock_session), \
+                 patch.object(connector, '_create_script_params', return_value=MagicMock()):
+
+                mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+                mock_stdio.return_value.__aexit__ = AsyncMock()
+
+                # Connect to server
+                result = await connector._connect_to_server(server)
+
+                # Verify connection succeeded and prompts were not queried
+                assert result is True
+                assert "test-server" in connector.sessions
+                assert "test-server" not in connector.prompts_by_server
+                assert mock_session.list_prompts.call_count == 0  # Should not call list_prompts
+
+    async def test_server_with_all_capabilities(self):
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack)
+
+            # Mock server configuration
+            server = {
+                "name": "test-server",
+                "type": "script",
+                "path": "/fake/path.py"
+            }
+
+            # Mock the session and initialization
+            mock_session = AsyncMock()
+            mock_init_result = MagicMock()
+            mock_init_result.capabilities = MagicMock()
+            mock_init_result.capabilities.tools = MagicMock()  # Has tools
+            mock_init_result.capabilities.prompts = MagicMock()  # Has prompts
+            mock_init_result.capabilities.resources = MagicMock()  # Has resources (not used yet)
+
+            # Mock list_tools response
+            mock_tool = MagicMock()
+            mock_tool.name = "test_tool"
+            mock_tool.description = "A test tool"
+            mock_tool.inputSchema = {}
+            mock_tools_response = MagicMock()
+            mock_tools_response.tools = [mock_tool]
+            mock_session.list_tools.return_value = mock_tools_response
+
+            # Mock list_prompts response
+            mock_prompt = MagicMock()
+            mock_prompt.name = "test_prompt"
+            mock_prompts_response = MagicMock()
+            mock_prompts_response.prompts = [mock_prompt]
+            mock_session.list_prompts.return_value = mock_prompts_response
+
+            mock_session.initialize.return_value = mock_init_result
+
+            # Mock the transport and session creation
+            with patch('mcp_client_for_ollama.server.connector.stdio_client') as mock_stdio, \
+                 patch('mcp_client_for_ollama.server.connector.ClientSession', return_value=mock_session), \
+                 patch.object(connector, '_create_script_params', return_value=MagicMock()), \
+                 patch('mcp_client_for_ollama.server.connector.Tool') as mock_tool_class:
+
+                # Make Tool constructor return the mock tool with proper attributes
+                mock_tool_class.return_value = mock_tool
+
+                mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+                mock_stdio.return_value.__aexit__ = AsyncMock()
+
+                # Connect to server
+                result = await connector._connect_to_server(server)
+
+                # Verify connection succeeded and both tools and prompts were listed
+                assert result is True
+                assert "test-server" in connector.sessions
+                assert len(connector.sessions["test-server"]["tools"]) == 1
+                assert "test-server" in connector.prompts_by_server
+                assert len(connector.prompts_by_server["test-server"]) == 1
+                assert mock_session.list_tools.call_count == 1
+                assert mock_session.list_tools.call_count == 1
+            assert mock_session.list_prompts.call_count == 1


### PR DESCRIPTION
This pull request improves capability-based feature detection and handling in the server connector, ensuring that tools and prompts are only queried if the server supports them. It also updates protocol version management to use the latest supported version from the SDK and adds comprehensive unit tests for these capability checks.

### Capability-based feature detection and error handling

* The `_connect_to_server` method in `connector.py` now checks server capabilities before attempting to list tools or prompts, preventing unnecessary calls and providing clearer feedback when capabilities are missing or errors occur. Warnings and informational messages are printed to the console as appropriate. [[1]](diffhunk://#diff-18edad15e35e8ea7693a7e915319bc3042f5dd0602e1a440607b2af158525fbaL201-L214) [[2]](diffhunk://#diff-18edad15e35e8ea7693a7e915319bc3042f5dd0602e1a440607b2af158525fbaR229-R257)

### Protocol version management

* `MCP_PROTOCOL_VERSION` in `constants.py` is now set to `LATEST_PROTOCOL_VERSION` from the SDK, allowing automatic support for the latest protocol and backward compatibility with servers using older versions. [[1]](diffhunk://#diff-2261f280eb3ba1a49d371241d9f301919589e8f5ab3a2fd2512cde105e95d9afR4) [[2]](diffhunk://#diff-2261f280eb3ba1a49d371241d9f301919589e8f5ab3a2fd2512cde105e95d9afL31-R35)

### Testing capability handling

* New unit tests in `test_connector.py` cover scenarios where a server lacks tools or prompts capability, as well as the case when all capabilities are present. These tests use mocks to ensure the connector behaves correctly and only queries supported features. [[1]](diffhunk://#diff-a2dad8e6cbf0a95d1109e08b2ce00f04da0f66baf7a1f84fb96e057d5f83f452R3-R4) [[2]](diffhunk://#diff-a2dad8e6cbf0a95d1109e08b2ce00f04da0f66baf7a1f84fb96e057d5f83f452R213-R357)

Fixes #167 