### PR TITLE
feat: Add y{n} approval count to HIL confirmation dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,13 +401,17 @@ When HIL is enabled, you'll see a confirmation prompt before each tool execution
 When prompted, you can choose from the following options:
 
 - **y/yes**: Execute this specific tool call
-- **n/no**: Skip this tool call and continue with the query
 - **s/session**: Execute this and all subsequent tool calls for the current query without further prompts
+- **n/no**: Skip this tool call and continue with the query
+- **y{n}/yes approval count**: Execute this tool call and approve the next {n} executions of this specific tool automatically (where {n} is any positive integer, e.g., `y10`)
 - **d/disable**: Permanently disable HIL confirmations (can be re-enabled with `hil` command)
 - **a/abort**: Abort the entire query immediately without saving to history
 
 > [!TIP]
-> The **session** option is particularly useful when the model needs to execute multiple tools in sequence. Instead of confirming each one individually, you can approve all tools for the current query session, then HIL will reset automatically for the next query.
+> For batch processing of tool calls, you can use approval counts:
+> - **y{N}**: Approve this specific tool call and the next {N} executions of the same tool (e.g., `y10` approves 10 instances of this tool)
+>
+> Simply type `y10`, `y20`, or any positive number after y to auto-approve that many future executions. This is especially helpful when the model needs to make multiple similar tool calls.
 
 ### Human-in-the-Loop (HIL) Configuration
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -36,6 +36,7 @@ from .prompts.handler import PromptHandler
 from .utils.streaming import StreamingManager
 from .utils.tool_display import ToolDisplayManager
 from .utils.hil_manager import HumanInTheLoopManager, AbortQueryException
+from .utils.tool_approval import ToolApprovalManager
 from .utils.fzf_style_completion import FZFStyleCompleter
 from .utils.history import display_full_history, export_history, import_history
 from .utils.input import get_input_no_autocomplete
@@ -69,6 +70,9 @@ class MCPClient:
         self.tool_display_manager = ToolDisplayManager(console=self.console)
         # Initialize the HIL manager
         self.hil_manager = HumanInTheLoopManager(console=self.console)
+        # Initialize and set up the tool approval manager for the HIL manager
+        self.tool_approval_manager = ToolApprovalManager()
+        self.hil_manager.set_tool_approval_manager(self.tool_approval_manager)
         # Store server and tool data
         self.sessions = {}  # Dict to store multiple sessions
         # UI components

--- a/mcp_client_for_ollama/utils/__init__.py
+++ b/mcp_client_for_ollama/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility modules for the MCP client."""
+
+from .tool_approval import ToolApprovalManager
+from .hil_manager import HumanInTheLoopManager, AbortQueryException
+
+__all__ = ['ToolApprovalManager', 'HumanInTheLoopManager', 'AbortQueryException']

--- a/mcp_client_for_ollama/utils/hil_manager.py
+++ b/mcp_client_for_ollama/utils/hil_manager.py
@@ -6,6 +6,8 @@ approve, or skip tool executions before they are performed.
 
 from rich.prompt import Prompt
 from rich.console import Console
+from typing import Optional
+import re
 
 
 class AbortQueryException(Exception):
@@ -32,6 +34,8 @@ class HumanInTheLoopManager:
         # the remainder of the current model/query process. This is not
         # persisted and resets between queries.
         self._session_auto_execute = False
+        # Tool approval manager for temporary approvals with counters
+        self._tool_approval_manager = None
 
     def is_enabled(self) -> bool:
         """Check if HIL confirmations are enabled"""
@@ -65,6 +69,14 @@ class HumanInTheLoopManager:
         options don't leak into subsequent queries.
         """
         self._session_auto_execute = False
+    
+    def set_tool_approval_manager(self, manager: 'ToolApprovalManager') -> None:
+        """Set the tool approval manager.
+        
+        Args:
+            manager: ToolApprovalManager instance
+        """
+        self._tool_approval_manager = manager
 
     async def request_tool_confirmation(self, tool_name: str, tool_args: dict) -> bool:
         """
@@ -86,6 +98,13 @@ class HumanInTheLoopManager:
         if self._session_auto_execute:
             return True
 
+        # Check if tool is approved via individual tool approval
+        if self._tool_approval_manager is not None:
+            if self._tool_approval_manager.is_approved(tool_name):
+                self._tool_approval_manager.decrement_approval(tool_name)
+                self.console.print(f"[green]✅ Tool approved via tool approval counter - {self._tool_approval_manager.get_remaining_approvals(tool_name)} remaining[/green]")
+                return True
+
         self.console.print("\n[bold yellow]🧑‍💻 Human-in-the-Loop Confirmation[/bold yellow]")
 
         # Show tool information
@@ -105,38 +124,67 @@ class HumanInTheLoopManager:
 
         self.console.print()
 
-        # Display options
+        # Display options with approval count formats
         self._display_confirmation_options()
 
+        # Get raw input without validation - we'll validate manually to accept formats like y3.
         choice = Prompt.ask(
             "[bold]What would you like to do?[/bold]",
-            choices=["y", "yes", "n", "no", "s", "session", "d", "disable", "a", "abort"],
             default="y",
             show_choices=False
-        ).lower()
+        ).lower().strip()
+        
+        # If user entered just a number, treat it as "y" + number (since y is the default)
+        if choice.isdigit():
+            choice = "y" + choice
+        
+        # Validate input format - must be one of the accepted patterns
+        valid_patterns = r'^(y\d+|y|yes|s|n|no|d|disable|a|abort)$'
+        if not re.match(valid_patterns, choice):
+            self.console.print("[red]Please select one of the available options[/red]")
+            return await self.request_tool_confirmation(tool_name, tool_args)
 
-        return self._handle_user_choice(choice)
+        return self._handle_user_choice(choice, tool_name)
 
     def _display_confirmation_options(self) -> None:
         """Display available confirmation options"""
         self.console.print("[bold cyan]Options:[/bold cyan]")
-        self.console.print("  [green]y/yes[/green] - Execute the tool call")
+        self.console.print("  [green]y{N}/yes[/green] - Execute tool and approve for N executions (N>0)")
         self.console.print("  [red]n/no[/red] - Skip this tool call")
         self.console.print("  [magenta]s/session[/magenta] - Execute without asking for this session")
         self.console.print("  [yellow]d/disable[/yellow] - Disable HIL confirmations permanently")
         self.console.print("  [bold red]a/abort[/bold red] - Abort this query (won't save to history)")
         self.console.print()
 
-    def _handle_user_choice(self, choice: str) -> bool:
+    def _handle_user_choice(self, choice: str, tool_name: str = None) -> bool:
         """
         Handle user's confirmation choice
 
         Args:
             choice: User's choice string
+            tool_name: Name of the tool being confirmed (for tool approval)
 
         Returns:
             bool: should_execute
         """
+        # Check if user entered y{n} format
+        import re
+        y_pattern = re.match(r'^y(\d+)$', choice, re.IGNORECASE)
+        
+        if y_pattern:
+            # Handle y{count} format - approve this specific tool for n times
+            count = int(y_pattern.group(1))
+            if count > 0:
+                if self._tool_approval_manager is not None:
+                    self._tool_approval_manager.add_approval(tool_name, count)
+                    self.console.print(f"[green]✅ Tool '{tool_name}' approved for {count} more execution(s)[/green]")
+                else:
+                    self.console.print(f"[green]✅ Tool '{tool_name}' will execute (approval counter not active - use 'hil' to enable)[/green]")
+                return True
+            else:
+                self.console.print("[yellow]⚠️  Invalid y{n} format - n must be > 0[/yellow]")
+                return self._handle_user_choice("y", tool_name)
+        
         if choice in ["d", "disable"]:
             # Notify user that it can be re-enabled
             self.console.print("\n[yellow]Tool calls will proceed automatically without confirmation.[/yellow]")
@@ -169,6 +217,10 @@ class HumanInTheLoopManager:
             self.console.print("[dim]Tip: Use 'human-in-loop' or 'hil' to disable these confirmations permanently[/dim]")
             return False
 
-        else:  # y/yes
+        else:
+            # Direct execution, no additional approval input needed
+            if tool_name and self._tool_approval_manager is not None:
+                self.console.print("[green]✅ Tool approved for execution[/green]")
+            
             self.console.print("[dim]Tip: Use 'human-in-loop' or 'hil' to disable these confirmations[/dim]")
             return True

--- a/mcp_client_for_ollama/utils/tool_approval.py
+++ b/mcp_client_for_ollama/utils/tool_approval.py
@@ -1,0 +1,215 @@
+"""Tool approval manager for temporary tool execution approvals.
+
+This module manages temporary approvals for tool executions, allowing users to
+approve a tool multiple times without being prompted each time.
+"""
+
+from typing import Dict, Optional
+
+
+class ToolApprovalManager:
+    """Manages temporary tool execution approvals with counters.
+    
+    Users can approve tools individually with a counter. Each approval has a counter
+    that decrements with each use until it reaches zero.
+    """
+    
+    def __init__(self):
+        """Initialize the tool approval manager."""
+        # Per-tool approvals: {"tool_name": remaining_approvals}
+        self._tool_approvals: Dict[str, int] = {}
+        
+        # Per-group approvals: {"tool_group": remaining_approvals}
+        # Group names don't include the trailing dot
+        self._group_approvals: Dict[str, int] = {}
+    
+    def _get_tool_group(self, tool_name: str) -> str:
+        """Extract the tool group from a tool name.
+        
+        Args:
+            tool_name: Full tool name (e.g., "filesystem.read_file")
+            
+        Returns:
+            Tool group name (e.g., "filesystem")
+        """
+        if '.' in tool_name:
+            return tool_name.split('.', 1)[0]
+        return tool_name
+    
+    def _is_group_tool(self, tool_name: str) -> bool:
+        """Check if a tool name represents a tool group (ends with .*)"""
+        return tool_name.endswith('.*')
+    
+    def get_remaining_approvals(self, tool_name: str) -> int:
+        """Get the number of remaining approvals for a tool or group.
+        
+        Args:
+            tool_name: Full tool name or group pattern
+            
+        Returns:
+            Number of remaining approvals (0 if not approved or exhausted)
+        """
+        # Check exact tool approval
+        if tool_name in self._tool_approvals:
+            return self._tool_approvals[tool_name]
+        
+        # Check group approval
+        if self._is_group_tool(tool_name):
+            group = tool_name[:-2]  # Remove trailing .*
+            if group in self._group_approvals:
+                return self._group_approvals[group]
+        
+        # Check if this tool belongs to a group
+        group = self._get_tool_group(tool_name)
+        if group in self._group_approvals:
+            return self._group_approvals[group]
+        
+        return 0
+    
+    def is_approved(self, tool_name: str) -> bool:
+        """Check if a tool is currently approved (has remaining approvals).
+        
+        Args:
+            tool_name: Full tool name
+            
+        Returns:
+            True if tool is approved, False otherwise
+        """
+        return self.get_remaining_approvals(tool_name) > 0
+    
+    def decrement_approval(self, tool_name: str) -> None:
+        """Decrement the approval counter for a tool.
+        
+        Args:
+            tool_name: Full tool name
+        """
+        # Try exact tool approval
+        if tool_name in self._tool_approvals:
+            self._tool_approvals[tool_name] -= 1
+            if self._tool_approvals[tool_name] <= 0:
+                del self._tool_approvals[tool_name]
+            return
+        
+        # Try group approval
+        group = self._get_tool_group(tool_name)
+        if group in self._group_approvals:
+            self._group_approvals[group] -= 1
+            if self._group_approvals[group] <= 0:
+                del self._group_approvals[group]
+    
+    def add_approval(self, tool_name: str, count: int) -> None:
+        """Add an approval with the given count.
+        
+        Args:
+            tool_name: Tool name or group pattern (e.g., "filesystem" or "filesystem.*")
+            count: Number of approvals to add
+        """
+        if self._is_group_tool(tool_name):
+            group = tool_name[:-2]  # Remove trailing .*
+            self._group_approvals[group] = count
+        else:
+            self._tool_approvals[tool_name] = count
+    
+    def remove_approval(self, tool_name: str) -> None:
+        """Remove an approval for a tool or group.
+        
+        Args:
+            tool_name: Tool name or group pattern
+        """
+        if tool_name in self._tool_approvals:
+            del self._tool_approvals[tool_name]
+        
+        if self._is_group_tool(tool_name):
+            group = tool_name[:-2]
+            if group in self._group_approvals:
+                del self._group_approvals[group]
+    
+    def clear_all(self) -> None:
+        """Clear all approvals."""
+        self._tool_approvals.clear()
+        self._group_approvals.clear()
+    
+    def parse_approval_input(self, input_str: str) -> tuple[str, int]:
+        """Parse user input for tool approval.
+        
+        Supports formats:
+        - "10" - approval with counter (old format)
+        - "y10" or "Y10" - single tool approval with 'y' prefix
+        
+        Args:
+            input_str: User input (e.g., "10", "y10", "Y10")
+            
+        Returns:
+            Tuple of (tool_name, count) where tool_name is either the tool name
+            or a special marker like "Y{count}" for single tools
+            
+        Raises:
+            ValueError: If input is invalid
+        """
+        input_str = input_str.strip()
+        
+        if not input_str:
+            raise ValueError("Empty input")
+        
+        # Check for single tool approval with 'y' prefix (y10, Y10 format)
+        if input_str[0].upper() == 'Y':
+            try:
+                count = int(input_str[1:])
+                if count <= 0:
+                    raise ValueError("Count must be positive")
+                return (f"Y{count}", count)  # Special marker for single tool approval
+            except ValueError:
+                raise ValueError("Invalid count for single tool approval with 'y' prefix")
+        
+        # Fallback to old format without prefix (just a number like "10")
+        try:
+            count = int(input_str)
+            if count <= 0:
+                raise ValueError("Count must be positive")
+            return (str(count), count)
+        except ValueError:
+            raise ValueError("Invalid count - expected format: '10' or 'y10'")
+    
+    def process_approval_input(self, input_str: str, tool_name: str) -> bool:
+        """Process user approval input and update approval state.
+        
+        Supports formats:
+        - "10" or "y10" - single tool approval with counter (old numeric format or y-prefix format)
+        
+        Args:
+            input_str: User input (e.g., "10", "y10", "Y10")
+            tool_name: Name of the tool being approved
+            
+        Returns:
+            True if approval was successful, False otherwise
+        """
+        try:
+            parsed_input, count = self.parse_approval_input(input_str)
+            
+            # Check for y-prefix to determine type
+            if parsed_input.startswith('Y'):
+                # Single tool approval with y-prefix (y10 or Y10 format)
+                self.add_approval(tool_name, count)
+            else:
+                # Old format without prefix - single tool approval (e.g., "10")
+                self.add_approval(tool_name, count)
+            
+            return True
+        except ValueError:
+            return False
+    
+    def get_all_approvals(self) -> dict:
+        """Get all current approvals as a dictionary.
+        
+        Returns:
+            Dictionary with tool names/groups and their approval counts
+        """
+        approvals = {}
+        
+        for tool, count in self._tool_approvals.items():
+            approvals[tool] = count
+        
+        for group, count in self._group_approvals.items():
+            approvals[f"{group}.*"] = count
+        
+        return approvals


### PR DESCRIPTION
## Feature: Batch Auto-Confirmation for Human-in-the-Loop Tool Execution

### Description
This PR introduces an enhancement to the Human-in-the-Loop workflow, allowing users to auto-confirm specific tools for multiple consecutive executions. Instead of typing 'y' to confirm a single execution, users can now enter `y<count>` (e.g., `y10`) to automatically confirm the next `<count>` executions of that tool without requiring manual confirmation each time.

### Use Case
This feature is particularly useful when integrating many tools into a workflow where full trust is placed in some tools but not others. For example:
- **Read-only tools**: Users can assign a high confirmation count since these tools don't modify any state.
- **Write/modify tools**: Users can continue to require manual confirmation for each execution to maintain safety and control.

- Fine-grained control over which tools receive batch auto-confirmation

This feature is in contrast to the session approval, which has an irritating description, because it approves all tools.