### PR TITLE
Update client.py

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -25,6 +25,7 @@ import httpx
 
 from . import __version__
 from .config.manager import ConfigManager
+from .config.defaults import get_config_path
 from .utils.version import check_for_updates
 from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS
 from .server.connector import ServerConnector
@@ -1427,7 +1428,7 @@ async def async_main(mcp_server, mcp_server_url, servers_json, auto_discovery, m
     client = MCPClient(model=model, host=host)
 
     # Handle server configuration options - only use one source to prevent duplicates
-    config_path = None
+    config_path = get_config_path()
     auto_discovery_final = auto_discovery
 
     if servers_json:


### PR DESCRIPTION
Updated config_path to return configuration file as default before any logic operation regarding configuration. By this way this beautiful app will directly capture config.json with its default config path instead of None. This configuration file issue was giving me headaches for last couple of days and default configuration was not working before, however, after this little adjustment, it works very nicely.

(This is one of my very first PR so if I did something wrong please let me know.)