### PR TITLE
Document Armorer Guard stdio proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,31 @@ The JSON configuration file supports STDIO, SSE, and Streamable HTTP server type
 > [!NOTE]
 > **MCP 1.10.1 Transport Support**: The client now supports the latest Streamable HTTP transport with improved performance and reliability. If you specify a URL without a type, the client will default to using Streamable HTTP transport.
 
+For local STDIO servers, you can add prompt-injection, credential, exfiltration,
+and risky tool-call checks by wrapping the server command with
+[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "armorer-guard",
+      "args": [
+        "mcp-proxy",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp"
+      ],
+      "disabled": false
+    }
+  }
+}
+```
+
+Armorer Guard runs locally and forwards safe MCP tool calls unchanged.
+
 ### Tips: where to put MCP server configs and a working example
 
 A common point of confusion is where to store MCP server configuration files and how the TUI's save/load feature is used. Here's a short, practical guide that has helped other users:


### PR DESCRIPTION
Adds an optional STDIO server configuration example showing how to wrap a local MCP server with `armorer-guard mcp-proxy -- ...`.

This keeps the existing `mcpServers` JSON format and gives users a local guardrail for prompt injection, credential leakage, exfiltration risk, and dangerous tool-call checks before requests reach the underlying server.
