### PR TITLE
Fix Windows crash caused by unconditional tty/termios imports

### DIFF
--- a/mcp_client_for_ollama/utils/input.py
+++ b/mcp_client_for_ollama/utils/input.py
@@ -82,3 +82,4 @@ async def get_input_no_autocomplete(prompt_text: str) -> str:
 
     except (KeyboardInterrupt, EOFError):
         return "quit"
+        

--- a/mcp_client_for_ollama/utils/input.py
+++ b/mcp_client_for_ollama/utils/input.py
@@ -82,4 +82,3 @@ async def get_input_no_autocomplete(prompt_text: str) -> str:
 
     except (KeyboardInterrupt, EOFError):
         return "quit"
-        

--- a/mcp_client_for_ollama/utils/input.py
+++ b/mcp_client_for_ollama/utils/input.py
@@ -1,50 +1,84 @@
 """
 Input utilities for the MCP client for Ollama.
 
-This module provides functions for getting user input without autocomplete.
+This module provides functions for getting user input without autocomplete
+and reading a single keypress in a cross-platform manner.
 """
+
+from __future__ import annotations
+
+import os
 import sys
-import tty
-import termios
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.styles import Style
+
 from .constants import DEFAULT_COMPLETION_STYLE
 
 
-def read_single_keypress() -> str:
-    """Read a single keypress without requiring Enter."""
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return ch
+if os.name == "nt":
+    import msvcrt
+
+    def read_single_keypress() -> str:
+        """
+        Read a single keypress without requiring Enter.
+
+        Uses the Windows console API via ``msvcrt``.
+        Function keys and arrow keys emit a two-byte sequence; those
+        prefixes are discarded so only meaningful key presses are returned.
+        """
+        while True:
+            ch = msvcrt.getwch()
+
+            # Function keys / arrow keys
+            if ch in ("\x00", "\xe0"):
+                msvcrt.getwch()
+                continue
+
+            # Normalize Ctrl+C behaviour
+            if ch == "\x03":
+                raise KeyboardInterrupt
+
+            return ch
+
+else:
+    import termios
+    import tty
+
+    def read_single_keypress() -> str:
+        """
+        Read a single keypress without requiring Enter.
+
+        Uses POSIX terminal raw mode.
+        """
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+
+        try:
+            tty.setraw(fd)
+            return sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
 
 async def get_input_no_autocomplete(prompt_text: str) -> str:
-    """Get user input without autocomplete (for file paths, config names, etc.)
+    """
+    Prompt the user without autocomplete.
 
-    This is useful for inputs where prompt/command autocomplete would be distracting
-    or inappropriate, such as file paths, config names, or prompt arguments.
+    Useful for file paths, configuration names and other free-form input.
 
     Args:
-        prompt_text: The prompt text to display (without the ❯ symbol)
+        prompt_text: Prompt displayed to the user.
 
     Returns:
-        str: User input or 'quit' if cancelled
+        The user's input, or ``"quit"`` if the prompt is cancelled.
     """
     try:
-        # Create a temporary session without completer
-        temp_session = PromptSession(
+        session = PromptSession(
             style=Style.from_dict(DEFAULT_COMPLETION_STYLE)
         )
-        user_input = await temp_session.prompt_async(
-            f"{prompt_text}❯ "
-        )
-        return user_input
-    except KeyboardInterrupt:
-        return "quit"
-    except EOFError:
+
+        return await session.prompt_async(f"{prompt_text}❯ ")
+
+    except (KeyboardInterrupt, EOFError):
         return "quit"


### PR DESCRIPTION
## Summary

This PR fixes a Windows startup crash caused by unconditional imports of the POSIX-only `tty` and `termios` modules in `mcp_client_for_ollama/utils/input.py`.

## Changes

- Add Windows-specific implementation using `msvcrt`
- Preserve existing POSIX implementation
- Keep behavior unchanged on Linux/macOS

---
### Before: 
<img width="1085" height="448" alt="image" src="https://github.com/user-attachments/assets/a935f83b-4e89-45c4-b449-4b32a82e3236" />

### After
<img width="1073" height="603" alt="image" src="https://github.com/user-attachments/assets/48d5c9f2-c5af-4c7f-ad3d-09c034553d72" />

---
## Testing been done on 

- Windows 10
- Python 3.12
- Verified that `ollmcp` no longer crashes with: `ModuleNotFoundError: No module named 'termios'`