### PR TITLE
feat(any-llm): Refactor MCP Client to support multiple LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@
 - [Quick Start](#quick-start)
 - [Installation options](#installation-options)
   - ✨**NEW** [Managing MCP Servers via CLI](#managing-mcp-servers-via-cli)
+    - [mcp add options](#mcp-add-options)
+    - [Scopes](#scopes)
   - [Command-line Arguments](#command-line-arguments)
+  - ✨**NEW** [Supported Providers](#supported-providers)
   - [Usage Examples](#usage-examples)
   - [How Tool Calls Work](#how-tool-calls-work)
   - ✨**NEW** [Agent Mode](#agent-mode)
@@ -43,12 +46,18 @@
   - [Advanced Model Configuration](#advanced-model-configuration)
   - [Server Reloading for Development](#server-reloading-for-development)
   - [Human-in-the-Loop (HIL) Tool Execution](#human-in-the-loop-hil-tool-execution)
+    - [Human-in-the-Loop (HIL) Configuration](#human-in-the-loop-hil-configuration)
   - ✨**NEW** [MCP Prompts](#mcp-prompts)
   - ✨**NEW** [MCP Resources](#mcp-resources)
   - [Performance Metrics](#performance-metrics)
   - ✨**NEW** [History Management](#history-management)
 - [Autocomplete and Prompt Features](#autocomplete-and-prompt-features)
+  - [Typer Shell Autocompletion](#typer-shell-autocompletion)
+  - [FZF-style Autocomplete](#fzf-style-autocomplete)
+  - [MCP Prompts Autocomplete](#mcp-prompts-autocomplete)
+  - [Contextual Prompt](#contextual-prompt)
 - [Configuration Management](#configuration-management)
+  - ✨**NEW** [Per-provider profiles](#per-provider-profiles)
 - [Server Configuration Format](#server-configuration-format)
   - [Tips: Where to Put MCP Server Configs and a Working Example](#tips-where-to-put-mcp-server-configs-and-a-working-example)
 - [Compatible Models](#compatible-models)
@@ -70,6 +79,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 - 📋 **MCP Prompts Support**: Browse, invoke, and manage prompts from MCP servers with argument collection, preview, and safe rollback
 - 📦 **MCP Resources Support**: Browse and read contextual data from MCP servers including files, documents, and structured data
 - ☁️ **Ollama Cloud Support**: Works seamlessly with Ollama Cloud models for tool calling, enabling access to powerful cloud-hosted models while using local MCP tools
+- 🌍 **Multiple LLM Providers**: Use Ollama (default) or OpenAI-compatible providers (OpenAI, OpenRouter, DeepSeek, etc.), with connection settings remembered per provider
 - 🎨 **Rich Terminal Interface**: Interactive console UI with modern styling
 - 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
 - 📝 **Answer Display Modes**: Switch between Plain, Markdown, or Both response views while streaming
@@ -197,7 +207,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!NOTE]
 > Servers added via `ollmcp mcp add` are always loaded as the base layer. Any flags (`--mcp-server`, `--mcp-server-url`, `--servers-json`, `--claude-desktop`) add on top. To include servers from Claude Desktop, pass `--claude-desktop` explicitly.
 >
-> If a server with the same name is also provided via one of those flags, both connections are currently opened, but only one is kept active under that name — avoid reusing a registry server's name in `--mcp-server`/`--mcp-server-url`/`--servers-json`/`--claude-desktop`.
+> If a server with the same name is also provided via one of those flags, both connections are currently opened, but only one is kept active under that name. Avoid reusing a registry server's name in `--mcp-server`/`--mcp-server-url`/`--servers-json`/`--claude-desktop`.
 
 ### Command-line Arguments
 
@@ -218,7 +228,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--claude-desktop`: Load servers from Claude Desktop's config file (`~/Library/Application Support/Claude/claude_desktop_config.json`). Merged with servers added via `ollmcp mcp add` and any other flags.
 
 > [!IMPORTANT]
-> **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically — they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
+> **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically, they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
 
 #### LLM Provider Configuration:
 
@@ -236,6 +246,47 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--help`, `-h`: Show help message and exit
 - `--install-completion`: Install shell autocompletion scripts for the client
 - `--show-completion`: Show available shell completion options
+
+### Supported Providers
+
+> [!WARNING]
+> **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.
+
+ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` / `$OLLMCP_API_KEY`, or via the provider's own environment variable shown below.
+
+| Provider (`--provider`) | API key env var |
+|---|---|
+| [`ollama`](https://github.com/ollama/ollama) (default) | - (local) |
+| [`azureopenai`](https://learn.microsoft.com/en-us/azure/ai-foundry/) | `AZURE_OPENAI_API_KEY` |
+| [`dashscope`](https://bailian.console.aliyun.com/cn-beijing/?tab=api#/api) | `DASHSCOPE_API_KEY` |
+| [`databricks`](https://docs.databricks.com/) | `DATABRICKS_TOKEN` |
+| [`deepinfra`](https://deepinfra.com/docs/openai_api) | `DEEPINFRA_API_KEY` |
+| [`deepseek`](https://platform.deepseek.com/) | `DEEPSEEK_API_KEY` |
+| [`fireworks`](https://fireworks.ai/api) | `FIREWORKS_API_KEY` |
+| [`gateway`](https://github.com/mozilla-ai/any-llm) | `GATEWAY_API_KEY` |
+| [`inception`](https://inceptionlabs.ai/) | `INCEPTION_API_KEY` |
+| [`llama`](https://www.llama.com/products/llama-api/) | `LLAMA_API_KEY` |
+| [`llamacpp`](https://github.com/ggml-org/llama.cpp) | - (local) |
+| [`llamafile`](https://github.com/Mozilla-Ocho/llamafile) | - (local) |
+| [`lmstudio`](https://lmstudio.ai/) | `LM_STUDIO_API_KEY` |
+| [`minimax`](https://www.minimax.io/platform_overview) | `MINIMAX_API_KEY` |
+| [`moonshot`](https://platform.moonshot.ai/) | `MOONSHOT_API_KEY` |
+| [`mzai`](https://any-llm.ai) | `ANY_LLM_KEY` |
+| [`nebius`](https://studio.nebius.ai/) | `NEBIUS_API_KEY` |
+| [`openai`](https://platform.openai.com/docs/api-reference) | `OPENAI_API_KEY` |
+| [`openrouter`](https://openrouter.ai/docs) | `OPENROUTER_API_KEY` |
+| [`perplexity`](https://docs.perplexity.ai/) | `PERPLEXITY_API_KEY` |
+| [`portkey`](https://portkey.ai/docs) | `PORTKEY_API_KEY` |
+| [`qiniu`](https://developer.qiniu.com/aitokenapi) | `QINIU_API_KEY` |
+| [`sambanova`](https://sambanova.ai/) | `SAMBANOVA_API_KEY` |
+| [`vllm`](https://docs.vllm.ai/) | `VLLM_API_KEY` |
+| [`zai`](https://docs.z.ai/guides/develop/python/introduction) | `ZAI_API_KEY` |
+
+> [!NOTE]
+> Local OpenAI-compatible servers (`ollama`, `llamacpp`, `llamafile`, `lmstudio`, `vllm`) typically run without an API key, point ollmcp at them with `--host`. Providers any-llm offers that are **not** OpenAI-compatible (e.g. `anthropic`, `gemini`, `mistral`, `groq`, `cohere`) are not supported yet.
+
+> [!WARNING]
+> **Capability detection limitation:** ollmcp only reads real per-model capabilities (`tools`, `vision`, `thinking`) from Ollama. For every non-Ollama provider, all three capabilities are currently assumed available and shown as such in the model list and badges, so a model may be reported as supporting tools, vision, or thinking even when it doesn't. If a model lacks a capability, the provider's API will return an error when you try to use it.
 
 ### Usage Examples
 
@@ -284,6 +335,17 @@ ollmcp --host http://localhost:22545 --servers-json /path/to/servers.json
 # Or using short flags:
 ollmcp -H http://localhost:22545 -j /path/to/servers.json
 ```
+
+Use a different LLM provider (OpenAI or any OpenAI-compatible API):
+
+```bash
+ollmcp --provider openai --api-key $OPENAI_API_KEY --model gpt-5.5
+# OpenAI-compatible providers (e.g. OpenRouter, DeepSeek); override the endpoint with --host if needed:
+ollmcp --provider openrouter --api-key $OPENROUTER_API_KEY -m openrouter/free
+```
+
+> [!TIP]
+> Provider settings (model, host, API key) are remembered **per provider**. Once saved with `/save-config`, plain `ollmcp` resumes your last-used provider. See [Configuration Management](#configuration-management) for details.
 
 Connect to SSE or Streamable HTTP servers by URL:
 
@@ -813,18 +875,30 @@ This makes it easy to see your current context before entering a query.
 ## Configuration Management
 
 > [!TIP]
-> It will automatically load the default configuration from `~/.config/ollmcp/config.json` if it exists.
+> Running `ollmcp` with no flags automatically loads the default configuration from `~/.config/ollmcp/config.json` if it exists.
 
-The client supports saving and loading tool configurations between sessions:
+The client saves and loads your preferences between sessions:
 
-- When using `save-config`, you can provide a name for the configuration or use the default
-- Configurations are stored in `~/.config/ollmcp/` directory
+- When using `/save-config`, you can provide a name for the configuration or use the default
+- Configurations are stored in the `~/.config/ollmcp/` directory
 - The default configuration is saved as `~/.config/ollmcp/config.json`
 - Named configurations are saved as `~/.config/ollmcp/{name}.json`
 
-The configuration saves:
+### Per-provider profiles
 
-- Current model selection
+Connection settings are stored **per provider**, so switching providers never reuses another provider's model, host, or API key. Each provider keeps its own:
+
+- **Model** selection
+- **Host** / API base URL
+- **API key**
+
+The configuration also records a `defaultProvider`. When you run `ollmcp` with no `--provider` flag, it loads that provider's profile; a fresh install starts on `ollama`. Each time you `/save-config`, the provider you're currently using *becomes the new default*, so running plain `ollmcp` resumes wherever you left off. Pass `--provider <name>` at any time to switch to (and load) a different provider's profile, and `--model` / `--host` / `--api-key` override the saved values for that run.
+
+> [!NOTE]
+> API keys are stored in plain text in `~/.config/ollmcp/config.json`. Prefer the `$OLLMCP_API_KEY` environment variable or the default provider environment variable (for example `OPENROUTER_API_KEY`) if you don't want keys written to disk.
+
+The following settings are **shared** across all providers:
+
 - Advanced model parameters (system prompt, temperature, sampling settings, etc.)
 - Enabled/disabled status of all tools
 - Context retention settings
@@ -833,6 +907,24 @@ The configuration saves:
 - Tool execution display preferences
 - Performance metrics display preferences
 - Human-in-the-Loop confirmation settings
+
+**Example `~/.config/ollmcp/config.json`:**
+
+```json
+{
+  "defaultProvider": "openai",
+  "providers": {
+    "ollama": { "host": "http://localhost:11434", "model": "qwen3:1.7b", "apiKey": "" },
+    "openai": { "host": "", "model": "gpt-5.5", "apiKey": "sk-..." }
+  },
+  "enabledTools": {},
+  "modelConfig": {},
+  "...": "shared settings"
+}
+```
+
+> [!TIP]
+> Older flat config files (with top-level `host`/`model`/`provider`/`apiKey`) are migrated automatically the first time you run this version, and rewritten in the per-provider format on your next `/save-config`.
 
 ## Server Configuration Format
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--model`, `-m` MODEL: Model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
 - `--provider`, `-p` PROVIDER: LLM provider to use (e.g. `ollama`, `openai`, `openrouter`, `deepseek`). Default: `ollama`
 - `--host`, `-H` HOST: LLM host / API base URL. Defaults to Ollama's `http://localhost:11434` for the `ollama` provider, or the provider's own default endpoint otherwise.
-- `--api-key`, `-k` KEY: API key for the LLM provider (also read from the `$OLLMCP_API_KEY` environment variable). Not needed for `ollama`.
+- `--api-key`, `-k` KEY: API key for the LLM provider. Also read from the `$OLLMCP_API_KEY` environment variable, which is **provider-agnostic** (it applies to whichever provider you select with `--provider`). Keys passed via `$OLLMCP_API_KEY` are never written to the config file; only keys passed with `--api-key` are saved. Not needed for `ollama`.
 
 > [!NOTE]
 > Currently supported providers: `ollama`, `openai`, and any OpenAI-compatible provider (`openrouter`, `deepseek`, `perplexity`, etc.). More providers coming soon.
@@ -252,7 +252,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!WARNING]
 > **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.
 
-ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` / `$OLLMCP_API_KEY`, or via the provider's own environment variable shown below.
+ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` — both work for **any** selected provider — or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
 
 | Provider (`--provider`) | API key env var |
 |---|---|
@@ -287,6 +287,19 @@ ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-l
 
 > [!WARNING]
 > **Capability detection limitation:** ollmcp only reads real per-model capabilities (`tools`, `vision`, `thinking`) from Ollama. For every non-Ollama provider, all three capabilities are currently assumed available and shown as such in the model list and badges, so a model may be reported as supporting tools, vision, or thinking even when it doesn't. If a model lacks a capability, the provider's API will return an error when you try to use it.
+
+#### API key resolution order
+
+For the selected provider, ollmcp resolves the API key in this order, from **highest** to **lowest** precedence:
+
+1. The `--api-key` / `-k` flag.
+2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic — applies to whichever provider you selected with `--provider`).
+3. The per-provider key saved in `~/.config/ollmcp/config.json` (present only if it was once passed via `--api-key`).
+4. The provider's own native environment variable, detected by [any-llm](https://github.com/mozilla-ai/any-llm) (e.g. `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).
+
+> [!WARNING]
+> A saved per-provider key (3) takes precedence over the provider's native environment variable (4). So if you previously saved a **wrong or expired** key, setting `OPENAI_API_KEY` (or the equivalent) alone will **not** override it. To fix it, either pass the correct key with `--api-key`, or remove the stale `apiKey` from that provider's profile in `~/.config/ollmcp/config.json`.
+
 
 ### Usage Examples
 
@@ -895,7 +908,7 @@ Connection settings are stored **per provider**, so switching providers never re
 The configuration also records a `defaultProvider`. When you run `ollmcp` with no `--provider` flag, it loads that provider's profile; a fresh install starts on `ollama`. Each time you `/save-config`, the provider you're currently using *becomes the new default*, so running plain `ollmcp` resumes wherever you left off. Pass `--provider <name>` at any time to switch to (and load) a different provider's profile, and `--model` / `--host` / `--api-key` override the saved values for that run.
 
 > [!NOTE]
-> API keys are stored in plain text in `~/.config/ollmcp/config.json`. Prefer the `$OLLMCP_API_KEY` environment variable or the default provider environment variable (for example `OPENROUTER_API_KEY`) if you don't want keys written to disk.
+> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk — use one of those if you don't want your key persisted.
 
 The following settings are **shared** across all providers:
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,15 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!IMPORTANT]
 > **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically — they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
 
-#### Ollama Configuration:
+#### LLM Provider Configuration:
 
-- `--model`, `-m` MODEL: Ollama model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
-- `--host`, `-H` HOST: Ollama host URL. Default: `http://localhost:11434`
+- `--model`, `-m` MODEL: Model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
+- `--provider`, `-p` PROVIDER: LLM provider to use (e.g. `ollama`, `openai`, `openrouter`, `deepseek`). Default: `ollama`
+- `--host`, `-H` HOST: LLM host / API base URL. Defaults to Ollama's `http://localhost:11434` for the `ollama` provider, or the provider's own default endpoint otherwise.
+- `--api-key`, `-k` KEY: API key for the LLM provider (also read from the `$OLLMCP_API_KEY` environment variable). Not needed for `ollama`.
+
+> [!NOTE]
+> Currently supported providers: `ollama`, `openai`, and any OpenAI-compatible provider (`openrouter`, `deepseek`, `perplexity`, etc.). More providers coming soon.
 
 #### General Options:
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -68,12 +68,15 @@ class MCPClient:
         "multiline": "Multiline",
     }
 
-    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None):
+    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None, persist_api_key: bool = True):
         # Initialize session and client objects
         self.exit_stack = AsyncExitStack()
         self.host = host
         self.provider = provider
         self.api_key = api_key or ""
+        # Whether this key may be written to the config file. Keys coming from the
+        # OLLMCP_API_KEY env var (or a provider's native env var) are never persisted.
+        self.persist_api_key = persist_api_key
         self.llm = AnyLLM.create(provider, api_key=api_key, api_base=host)
         self.console = Console()
         self.config_manager = ConfigManager(self.console)
@@ -1435,11 +1438,13 @@ class MCPClient:
         else:
             config_data = default_config()
 
+        # Don't write env-var-sourced keys to disk; keep any previously saved key.
+        existing_profile = (config_data.get("providers") or {}).get(self.provider, {})
         config_data.setdefault("providers", {})
         config_data["providers"][self.provider] = {
             "host": self.host or "",
             "model": self.model_manager.get_current_model(),
-            "apiKey": self.api_key or "",
+            "apiKey": (self.api_key or "") if self.persist_api_key else existing_profile.get("apiKey", ""),
         }
         # Remember the last saved provider as the default for plain `ollmcp`.
         config_data["defaultProvider"] = self.provider
@@ -1883,9 +1888,8 @@ def main(
     ),
     api_key: Optional[str] = typer.Option(
         None, "--api-key", "-k",
-        help="API key for the LLM provider (also reads $OLLMCP_API_KEY env var)",
+        help="API key for the LLM provider. Also read from $OLLMCP_API_KEY (works with any --provider; not written to config). Not needed for ollama.",
         rich_help_panel="LLM Configuration",
-        envvar="OLLMCP_API_KEY"
     ),
 
     # General Options
@@ -1946,11 +1950,22 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
     else:
         resolved_host = None
 
-    resolved_api_key = api_key or profile.get("apiKey") or None
+    # API key precedence: --api-key flag > OLLMCP_API_KEY env var > saved profile.
+    # Keys from the env var are never written back to the config file.
+    env_api_key = os.environ.get("OLLMCP_API_KEY")
+    if api_key:
+        resolved_api_key = api_key
+        persist_api_key = True
+    elif env_api_key:
+        resolved_api_key = env_api_key
+        persist_api_key = False
+    else:
+        resolved_api_key = profile.get("apiKey") or None
+        persist_api_key = True
     resolved_model = model or profile.get("model") or DEFAULT_MODEL
 
     try:
-        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key)
+        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key, persist_api_key=persist_api_key)
     except MissingApiKeyError as e:
         console.print(Panel(
             f"[bold red]API key required:[/bold red] The [bold blue]{effective_provider}[/bold blue] provider needs an API key.\n\n"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -1,5 +1,6 @@
 """MCP Client for Ollama - A TUI client for interacting with Ollama models and MCP servers"""
 import asyncio
+import json
 import os
 import sys
 import select
@@ -22,14 +23,15 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
-import ollama
 import httpx
 
 from . import __version__
 from .config.manager import ConfigManager
 from .utils.version import check_for_updates
-from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
+from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
+from any_llm import AnyLLM
 from .utils.connection import preflight_ollama
+from .utils.images import apply_images
 from .server.connector import ServerConnector
 from .server import registry
 from .server.cli_commands import mcp_app
@@ -64,17 +66,19 @@ class MCPClient:
         "multiline": "Multiline",
     }
 
-    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST):
+    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None):
         # Initialize session and client objects
         self.exit_stack = AsyncExitStack()
         self.host = host
-        self.ollama = ollama.AsyncClient(host=host)
+        self.provider = provider
+        self.api_key = api_key or ""
+        self.llm = AnyLLM.create(provider, api_key=api_key, api_base=host)
         self.console = Console()
         self.config_manager = ConfigManager(self.console)
         # Initialize the server connector
         self.server_connector = ServerConnector(self.exit_stack, self.console)
         # Initialize the model manager
-        self.model_manager = ModelManager(console=self.console, default_model=model, ollama=self.ollama)
+        self.model_manager = ModelManager(console=self.console, default_model=model, llm=self.llm, provider=provider, api_base=host, api_key=api_key or "")
         # Initialize the model config manager
         self.model_config_manager = ModelConfigManager(console=self.console)
         # Initialize the tool manager with server connector reference
@@ -306,15 +310,9 @@ class MCPClient:
         try:
             current_model = self.model_manager.get_current_model()
             # Query the model's capabilities using ollama.show()
-            model_info = await self.ollama.show(current_model)
-
-            # Check if the model has 'thinking' capability
-            if 'capabilities' in model_info and model_info['capabilities']:
-                return 'thinking' in model_info['capabilities']
-
-            return False
+            caps = await self.model_manager.fetch_capabilities(current_model)
+            return 'thinking' in caps
         except Exception:
-            # If we can't determine capabilities, assume no thinking support
             return False
 
     async def supports_vision(self) -> bool:
@@ -325,12 +323,8 @@ class MCPClient:
         """
         try:
             current_model = self.model_manager.get_current_model()
-            model_info = await self.ollama.show(current_model)
-
-            if 'capabilities' in model_info and model_info['capabilities']:
-                return 'vision' in model_info['capabilities']
-
-            return False
+            caps = await self.model_manager.fetch_capabilities(current_model)
+            return 'vision' in caps
         except Exception:
             return False
 
@@ -535,28 +529,24 @@ class MCPClient:
         # Get current model from the model manager
         model = self.model_manager.get_current_model()
 
-        # Get model options in Ollama format
-        model_options = self.model_config_manager.get_ollama_options()
-
-        # Prepare chat parameters
-        chat_params = {
-            "model": model,
-            "messages": messages,
-            "stream": True,
-            "tools": available_tools,
-            "options": model_options
-        }
-
         # Add thinking parameter if thinking mode is enabled and model supports it
         supports_thinking = await self.supports_thinking_mode()
-        if supports_thinking:
-            chat_params["think"] = self.thinking_mode
 
         # Check vision capability once for the entire query
         has_vision = await self.supports_vision()
 
-        # Initial Ollama API call with the query and available tools
-        stream = await self.ollama.chat(**chat_params)
+        # Initial LLM API call with the query and available tools
+        stream = await self.llm.acompletion(
+            model=model,
+            messages=apply_images(messages),
+            stream=True,
+            stream_options={"include_usage": True},
+            tools=available_tools or None,
+            **({
+                "reasoning_effort": "high"
+            } if supports_thinking and self.thinking_mode else {}),
+            **self.model_config_manager.get_completion_kwargs(self.provider),
+        )
 
         # Process the streaming response with thinking mode support
         response_text = ""
@@ -582,8 +572,8 @@ class MCPClient:
         })
 
         # Update actual token count from metrics if available
-        if metrics and metrics.get('eval_count'):
-            self.actual_token_count += metrics['eval_count']
+        if metrics and metrics.get('completion_tokens'):
+            self.actual_token_count += metrics['completion_tokens']
 
         enabled_tools = self.tool_manager.get_enabled_tool_objects()
 
@@ -607,8 +597,9 @@ class MCPClient:
             loop_count += 1
 
             for tool in pending_tool_calls:
-                tool_name = tool.function.name
-                tool_args = tool.function.arguments
+                tool_name = tool["function"]["name"]
+                tool_call_id = tool["id"]
+                tool_args = json.loads(tool["function"]["arguments"]) if tool["function"]["arguments"] else {}
 
                 # Parse server name and actual tool name from the qualified name
                 server_name, actual_tool_name = tool_name.split('.', 1) if '.' in tool_name else (None, tool_name)
@@ -647,7 +638,7 @@ class MCPClient:
                     messages.append({
                         "role": "tool",
                         "content": tool_response,
-                        "tool_name": tool_name
+                        "tool_call_id": tool_call_id
                     })
                     continue
 
@@ -663,7 +654,7 @@ class MCPClient:
                         messages.append({
                             "role": "tool",
                             "content": error_msg,
-                            "tool_name": tool_name
+                            "tool_call_id": tool_call_id
                         })
                         # Continue with next tool call if any
                         continue
@@ -719,7 +710,7 @@ class MCPClient:
                 tool_message = {
                     "role": "tool",
                     "content": tool_response,
-                    "tool_name": tool_name
+                    "tool_call_id": tool_call_id
                 }
 
                 messages.append(tool_message)
@@ -737,20 +728,18 @@ class MCPClient:
                     self._warn_vision_not_supported(len(tool_images), f"The tool '{tool_name}'")
 
 
-            # Get stream response from Ollama with the tool results
-            chat_params_followup = {
-                "model": model,
-                "messages": messages,
-                "stream": True,
-                "tools": available_tools,
-                "options": model_options
-            }
-
-            # Add thinking parameter if thinking mode is enabled and model supports it
-            if supports_thinking:
-                chat_params_followup["think"] = self.thinking_mode
-
-            stream = await self.ollama.chat(**chat_params_followup)
+            # Get stream response from LLM with the tool results
+            stream = await self.llm.acompletion(
+                model=model,
+                messages=apply_images(messages),
+                stream=True,
+                stream_options={"include_usage": True},
+                tools=available_tools or None,
+                **({
+                    "reasoning_effort": "high"
+                } if supports_thinking and self.thinking_mode else {}),
+                **self.model_config_manager.get_completion_kwargs(self.provider),
+            )
 
             # Process the streaming response with thinking mode support
             followup_response, pending_tool_calls, followup_metrics = await self.streaming_manager.process_streaming_response(
@@ -772,8 +761,8 @@ class MCPClient:
             })
 
             # Update actual token count from followup metrics if available
-            if followup_metrics and followup_metrics.get('eval_count'):
-                self.actual_token_count += followup_metrics['eval_count']
+            if followup_metrics and followup_metrics.get('completion_tokens'):
+                self.actual_token_count += followup_metrics['completion_tokens']
 
             if followup_response:
                 response_text = followup_response
@@ -1052,7 +1041,7 @@ class MCPClient:
                         border_style="red", expand=False
                     ))
 
-                except ollama.ResponseError as e:
+                except Exception as e:
                     # Extract error message without the traceback
                     error_msg = str(e)
                     if "does not support tools" in error_msg.lower():
@@ -1065,7 +1054,7 @@ class MCPClient:
                             border_style="red", expand=False
                         ))
                     else:
-                        self.console.print(Panel(f"[bold red]Ollama Error:[/bold red] {error_msg}",
+                        self.console.print(Panel(f"[bold red]LLM Error:[/bold red] {error_msg}",
                                                  border_style="red", expand=False))
 
                     # If it's a "model not found" error, suggest how to fix it
@@ -1429,6 +1418,8 @@ class MCPClient:
         config_data = {
             "host": self.host,
             "model": self.model_manager.get_current_model(),
+            "provider": self.provider,
+            "apiKey": self.api_key,
             "enabledTools": self.tool_manager.get_enabled_tools(),
             "contextSettings": {
                 "retainContext": self.retain_context
@@ -1473,12 +1464,18 @@ class MCPClient:
             return False
 
         # Apply the loaded configuration
+        if "provider" in config_data:
+            self.provider = config_data["provider"]
+        if "apiKey" in config_data:
+            self.api_key = config_data["apiKey"]
+
         if "host" in config_data:
             new_host = config_data["host"]
             if new_host != self.host:
                 self.host = new_host
-                self.ollama = ollama.AsyncClient(host=new_host)
-                self.model_manager.ollama = self.ollama
+                self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+                self.model_manager.llm = self.llm
+                self.model_manager.api_base = new_host
 
         if "model" in config_data:
             self.model_manager.set_model(config_data["model"])
@@ -1555,12 +1552,18 @@ class MCPClient:
         self.server_connector.enable_all_tools()
 
         # Reset host from the default configuration
+        if "provider" in config_data:
+            self.provider = config_data.get("provider", DEFAULT_PROVIDER)
+        if "apiKey" in config_data:
+            self.api_key = config_data.get("apiKey", "")
+
         if "host" in config_data:
             new_host = config_data["host"]
             if new_host != self.host:
                 self.host = new_host
-                self.ollama = ollama.AsyncClient(host=new_host)
-                self.model_manager.ollama = self.ollama
+                self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+                self.model_manager.llm = self.llm
+                self.model_manager.api_base = new_host
 
         # Reset context settings from the default configuration
         if "contextSettings" in config_data:
@@ -1839,8 +1842,19 @@ def main(
     ),
     host: str = typer.Option(
         None, "--host", "-H",
-        help="Ollama host URL",
-        rich_help_panel="Ollama Configuration"
+        help="LLM host URL (Ollama host or API base URL for other providers)",
+        rich_help_panel="LLM Configuration"
+    ),
+    provider: str = typer.Option(
+        DEFAULT_PROVIDER, "--provider", "-p",
+        help="LLM provider (e.g., ollama, openai, anthropic, mistral, groq, deepseek, together, openrouter, etc.)",
+        rich_help_panel="LLM Configuration"
+    ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", "-k",
+        help="API key for the LLM provider (also reads $OLLMCP_API_KEY env var)",
+        rich_help_panel="LLM Configuration",
+        envvar="OLLMCP_API_KEY"
     ),
 
     # General Options
@@ -1863,7 +1877,7 @@ def main(
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host))
+        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key))
     finally:
         try:
             # Ensure executor cleanup completes before closing loop
@@ -1872,14 +1886,14 @@ def main(
         finally:
             loop.close()
 
-async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host):
+async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key):
     """Asynchronous main function to run the MCP Client for Ollama"""
 
     console = Console()
 
     # Create a temporary client to check if Ollama is running
     initial_host = host if host is not None else DEFAULT_OLLAMA_HOST
-    client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host)
+    client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host, provider=provider, api_key=api_key)
 
     # Show startup banner before server discovery messages.
     client.print_welcome_ascii()
@@ -1920,10 +1934,24 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
         await client.connect_to_servers(mcp_server, mcp_server_url, config_path, claude_desktop, server_configs)
         client.auto_load_default_config()
 
-        if host != client.host and host is not None:
+        # CLI args take precedence over loaded config
+        cli_changed = False
+        if provider != DEFAULT_PROVIDER:
+            client.provider = provider
+            cli_changed = True
+        if api_key:
+            client.api_key = api_key
+            cli_changed = True
+        if host is not None and host != client.host:
             client.host = host
-            client.ollama = ollama.AsyncClient(host=host)
-            client.model_manager.ollama = client.ollama
+            cli_changed = True
+
+        if cli_changed:
+            client.llm = AnyLLM.create(client.provider, api_key=client.api_key, api_base=client.host)
+            client.model_manager.llm = client.llm
+            client.model_manager.provider = client.provider
+            client.model_manager.api_base = client.host
+            client.model_manager.api_key = client.api_key
 
         # Resolve the model to use: --model flag > saved config > first available
         # model, validated against what's actually installed (auto_load_default_config()

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -24,13 +24,13 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
 import httpx
+from any_llm import AnyLLM
+from any_llm.exceptions import MissingApiKeyError
 
 from . import __version__
 from .config.manager import ConfigManager
 from .utils.version import check_for_updates
 from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
-from any_llm import AnyLLM
-from any_llm.exceptions import MissingApiKeyError
 from .utils.connection import preflight_ollama
 from .utils.images import apply_images
 from .server.connector import ServerConnector

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -29,9 +29,10 @@ from any_llm.exceptions import MissingApiKeyError
 
 from . import __version__
 from .config.manager import ConfigManager
+from .config.defaults import default_config, default_provider_profile
 from .utils.version import check_for_updates
-from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
-from .utils.connection import preflight_ollama
+from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
+from .utils.connection import preflight_ollama, validate_provider
 from .utils.images import apply_images
 from .server.connector import ServerConnector
 from .server import registry
@@ -587,6 +588,7 @@ class MCPClient:
                 break
 
             if loop_count >= self.loop_limit:
+                self.console.print()  # Add spacing before the panel
                 self.console.print(Panel(
                     f"[yellow]Your current loop limit is set to [bold]{self.loop_limit}[/bold] and has been reached. Skipping additional tool calls.[/yellow]\n"
                     f"You will probably want to increase this limit if your model requires more tool interactions to complete tasks.\n"
@@ -1063,6 +1065,7 @@ class MCPClient:
                             title="Authentication Failed", border_style="red", expand=False
                         ))
                     else:
+                        self.console.print() # Add spacing before the panel
                         self.console.print(Panel(f"[bold red]LLM Error:[/bold red] {error_msg}",
                                                  border_style="red", expand=False))
 
@@ -1409,7 +1412,9 @@ class MCPClient:
         """Automatically load the default configuration if it exists."""
         if self.config_manager.config_exists("default"):
             # self.console.print("[cyan]Default configuration found, loading...[/cyan]")
-            self.default_configuration_status = self.load_configuration("default")
+            # Connection identity (host/model/apiKey) is already resolved in
+            # async_main before the client was built, so only apply shared settings.
+            self.default_configuration_status = self.load_configuration("default", apply_connection=False)
 
     def print_auto_load_default_config_status(self):
         """Print the status of the auto-load default configuration."""
@@ -1423,12 +1428,24 @@ class MCPClient:
         Args:
             config_name: Optional name for the config (defaults to 'default')
         """
-        # Build config data
-        config_data = {
-            "host": self.host,
+        # Start from the existing config so other providers' profiles are kept,
+        # then update this provider's connection profile and the shared settings.
+        if self.config_manager.config_exists(config_name):
+            config_data = self.config_manager.load_configuration(config_name)
+        else:
+            config_data = default_config()
+
+        config_data.setdefault("providers", {})
+        config_data["providers"][self.provider] = {
+            "host": self.host or "",
             "model": self.model_manager.get_current_model(),
-            "provider": self.provider,
-            "apiKey": self.api_key,
+            "apiKey": self.api_key or "",
+        }
+        # Remember the last saved provider as the default for plain `ollmcp`.
+        config_data["defaultProvider"] = self.provider
+
+        # Shared settings (apply across all providers)
+        config_data.update({
             "enabledTools": self.tool_manager.get_enabled_tools(),
             "contextSettings": {
                 "retainContext": self.retain_context
@@ -1452,16 +1469,20 @@ class MCPClient:
             "hilSettings": {
                 "enabled": self.hil_manager.is_enabled()
             }
-        }
+        })
 
         # Use the ConfigManager to save the configuration
         return self.config_manager.save_configuration(config_data, config_name)
 
-    def load_configuration(self, config_name=None):
+    def load_configuration(self, config_name=None, apply_connection=True):
         """Load tool configuration and model settings from a file
 
         Args:
             config_name: Optional name of the config to load (defaults to 'default')
+            apply_connection: When True, apply the active provider's saved
+                connection profile (host/model/apiKey). At startup this is set
+                to False because the connection identity is already resolved in
+                async_main (with CLI flags taking precedence over the profile).
 
         Returns:
             bool: True if loaded successfully, False otherwise
@@ -1472,22 +1493,23 @@ class MCPClient:
         if not config_data:
             return False
 
-        # Apply the loaded configuration
-        if "provider" in config_data:
-            self.provider = config_data["provider"]
-        if "apiKey" in config_data:
-            self.api_key = config_data["apiKey"]
-
-        if "host" in config_data:
-            new_host = config_data["host"]
-            if new_host != self.host:
-                self.host = new_host
-                self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
-                self.model_manager.llm = self.llm
-                self.model_manager.api_base = new_host
-
-        if "model" in config_data:
-            self.model_manager.set_model(config_data["model"])
+        # Apply the active provider's saved connection profile. The provider
+        # itself is fixed for the session (chosen at startup), so we only update
+        # host/model/apiKey for self.provider.
+        if apply_connection:
+            profile = (config_data.get("providers") or {}).get(self.provider)
+            if profile:
+                new_host = profile.get("host") or self.host
+                new_key = profile.get("apiKey") or self.api_key
+                if new_host != self.host or new_key != self.api_key:
+                    self.host = new_host
+                    self.api_key = new_key
+                    self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+                    self.model_manager.llm = self.llm
+                    self.model_manager.api_base = new_host
+                    self.model_manager.api_key = self.api_key
+                if profile.get("model"):
+                    self.model_manager.set_model(profile["model"])
 
         # Load enabled tools if specified
         if "enabledTools" in config_data:
@@ -1560,19 +1582,19 @@ class MCPClient:
         # Enable all tools in the server connector
         self.server_connector.enable_all_tools()
 
-        # Reset host from the default configuration
-        if "provider" in config_data:
-            self.provider = config_data.get("provider", DEFAULT_PROVIDER)
-        if "apiKey" in config_data:
-            self.api_key = config_data.get("apiKey", "")
-
-        if "host" in config_data:
-            new_host = config_data["host"]
-            if new_host != self.host:
-                self.host = new_host
-                self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
-                self.model_manager.llm = self.llm
-                self.model_manager.api_base = new_host
+        # Reset the active provider's connection profile to its defaults.
+        # The provider itself stays fixed for the session.
+        profile = (config_data.get("providers") or {}).get(self.provider) or default_provider_profile(self.provider)
+        self.api_key = profile.get("apiKey", "")
+        new_host = profile.get("host") or None
+        if new_host != self.host:
+            self.host = new_host
+            self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+            self.model_manager.llm = self.llm
+            self.model_manager.api_base = new_host
+            self.model_manager.api_key = self.api_key
+        if profile.get("model"):
+            self.model_manager.set_model(profile["model"])
 
         # Reset context settings from the default configuration
         if "contextSettings" in config_data:
@@ -1851,12 +1873,12 @@ def main(
     ),
     host: str = typer.Option(
         None, "--host", "-H",
-        help="LLM host URL (Ollama host or API base URL for other providers)",
+        help="LLM host / API base URL. Defaults to Ollama's localhost:11434 for the ollama provider, or the provider's own default endpoint otherwise.",
         rich_help_panel="LLM Configuration"
     ),
-    provider: str = typer.Option(
-        DEFAULT_PROVIDER, "--provider", "-p",
-        help="LLM provider (e.g., ollama, openai, anthropic, mistral, groq, deepseek, together, openrouter, etc.)",
+    provider: Optional[str] = typer.Option(
+        None, "--provider", "-p",
+        help="LLM provider (e.g., ollama, openai, deepseek, openrouter). Defaults to your saved configuration's provider, or ollama.",
         rich_help_panel="LLM Configuration"
     ),
     api_key: Optional[str] = typer.Option(
@@ -1900,13 +1922,38 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
 
     console = Console()
 
-    # Create a temporary client to check if Ollama is running
-    initial_host = host if host is not None else DEFAULT_OLLAMA_HOST
+    # Resolve the provider and its saved connection profile before building the
+    # client, so the preflight check targets the right endpoint on the first try.
+    # `provider`/`model`/`host`/`api_key` are None unless the flag was actually
+    # passed, so CLI values cleanly take precedence over the saved profile
+    # (and `--provider` picks the provider; plain `ollmcp` resumes the last saved).
+    config_mgr = ConfigManager(console)
+    saved = config_mgr.load_configuration("default") if config_mgr.config_exists("default") else {}
+
+    effective_provider = provider or saved.get("defaultProvider") or DEFAULT_PROVIDER
+    if not validate_provider(effective_provider, console):
+        return
+
+    profile = (saved.get("providers") or {}).get(effective_provider) or default_provider_profile(effective_provider)
+
+    # Host: CLI flag > saved profile host > ollama local default / provider default.
+    if host is not None:
+        resolved_host = host
+    elif profile.get("host"):
+        resolved_host = profile["host"]
+    elif effective_provider == "ollama":
+        resolved_host = DEFAULT_OLLAMA_HOST
+    else:
+        resolved_host = None
+
+    resolved_api_key = api_key or profile.get("apiKey") or None
+    resolved_model = model or profile.get("model") or DEFAULT_MODEL
+
     try:
-        client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host, provider=provider, api_key=api_key)
+        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key)
     except MissingApiKeyError as e:
         console.print(Panel(
-            f"[bold red]API key required:[/bold red] The [bold blue]{provider}[/bold blue] provider needs an API key.\n\n"
+            f"[bold red]API key required:[/bold red] The [bold blue]{effective_provider}[/bold blue] provider needs an API key.\n\n"
             f"Provide one with [bold cyan]--api-key[/bold cyan] / [bold cyan]-k[/bold cyan], "
             f"or set [bold cyan]$OLLMCP_API_KEY[/bold cyan] or [bold cyan]${e.env_var_name}[/bold cyan].\n\n"
             "[dim]Tip: if you pass a shell variable, quote it (e.g. [/dim][bold cyan]--api-key \"$MY_KEY\"[/bold cyan][dim]) "
@@ -1918,7 +1965,7 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
     # Show startup banner before server discovery messages.
     client.print_welcome_ascii()
 
-    if not await preflight_ollama(client, host):
+    if not await preflight_ollama(client):
         return
 
     # Registry is always the base layer — merge with any flag-provided sources
@@ -1952,32 +1999,14 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
                 return
     try:
         await client.connect_to_servers(mcp_server, mcp_server_url, config_path, claude_desktop, server_configs)
+        # Connection identity (provider/host/model/apiKey) was already resolved
+        # above; this only applies the shared settings from the saved config.
         client.auto_load_default_config()
 
-        # CLI args take precedence over loaded config
-        cli_changed = False
-        if provider != DEFAULT_PROVIDER:
-            client.provider = provider
-            cli_changed = True
-        if api_key:
-            client.api_key = api_key
-            cli_changed = True
-        if host is not None and host != client.host:
-            client.host = host
-            cli_changed = True
-
-        if cli_changed:
-            client.llm = AnyLLM.create(client.provider, api_key=client.api_key, api_base=client.host)
-            client.model_manager.llm = client.llm
-            client.model_manager.provider = client.provider
-            client.model_manager.api_base = client.host
-            client.model_manager.api_key = client.api_key
-
-        # Resolve the model to use: --model flag > saved config > first available
-        # model, validated against what's actually installed (auto_load_default_config()
-        # above already applied any saved model to model_manager when a config existed).
-        # `model` is None unless --model was actually passed, so this is unambiguous
-        # (unlike comparing against the DEFAULT_MODEL sentinel).
+        # Resolve the model to use: --model flag > saved profile model > first
+        # available model, validated against what's actually installed. The model
+        # resolved before construction is already in model_manager as its current
+        # model, so use it as the saved candidate.
         saved_model = client.model_manager.get_current_model() if client.default_configuration_status else None
         client.model_resolution_status = await client.model_manager.resolve_initial_model(model, saved_model)
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -30,6 +30,7 @@ from .config.manager import ConfigManager
 from .utils.version import check_for_updates
 from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
 from any_llm import AnyLLM
+from any_llm.exceptions import MissingApiKeyError
 from .utils.connection import preflight_ollama
 from .utils.images import apply_images
 from .server.connector import ServerConnector
@@ -1053,6 +1054,14 @@ class MCPClient:
                             title="Tools Not Supported",
                             border_style="red", expand=False
                         ))
+                    elif "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower():
+                        self.console.print(Panel(
+                            f"[bold red]Authentication Error:[/bold red] The [bold blue]{self.provider}[/bold blue] provider rejected the request.\n\n"
+                            + ("No API key is set. " if not self.api_key else "The API key may be invalid or lack access to this model. ")
+                            + "Set a valid key with [bold cyan]--api-key[/bold cyan] or [bold cyan]$OLLMCP_API_KEY[/bold cyan].\n\n"
+                            f"[dim]Provider response: {error_msg}[/dim]",
+                            title="Authentication Failed", border_style="red", expand=False
+                        ))
                     else:
                         self.console.print(Panel(f"[bold red]LLM Error:[/bold red] {error_msg}",
                                                  border_style="red", expand=False))
@@ -1893,7 +1902,18 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
 
     # Create a temporary client to check if Ollama is running
     initial_host = host if host is not None else DEFAULT_OLLAMA_HOST
-    client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host, provider=provider, api_key=api_key)
+    try:
+        client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host, provider=provider, api_key=api_key)
+    except MissingApiKeyError as e:
+        console.print(Panel(
+            f"[bold red]API key required:[/bold red] The [bold blue]{provider}[/bold blue] provider needs an API key.\n\n"
+            f"Provide one with [bold cyan]--api-key[/bold cyan] / [bold cyan]-k[/bold cyan], "
+            f"or set [bold cyan]$OLLMCP_API_KEY[/bold cyan] or [bold cyan]${e.env_var_name}[/bold cyan].\n\n"
+            "[dim]Tip: if you pass a shell variable, quote it (e.g. [/dim][bold cyan]--api-key \"$MY_KEY\"[/bold cyan][dim]) "
+            "so an unset value isn't silently dropped.[/dim]",
+            title="Missing API Key", border_style="red", expand=False
+        ))
+        return
 
     # Show startup banner before server discovery messages.
     client.print_welcome_ascii()

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -16,6 +16,8 @@ def default_config() -> dict:
     return {
         "host": DEFAULT_OLLAMA_HOST,
         "model": DEFAULT_MODEL,
+        "provider": "ollama",
+        "apiKey": "",
         "enabledTools": {},  # Will be populated with available tools
         "contextSettings": {
             "retainContext": True

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -6,6 +6,25 @@ This module provides default settings and paths used throughout the application.
 import os
 from ..utils.constants import DEFAULT_MODEL, DEFAULT_CONFIG_FILE, DEFAULT_CONFIG_DIR, DEFAULT_OLLAMA_HOST
 
+def default_provider_profile(provider: str = "ollama") -> dict:
+    """Get the default connection profile for a provider.
+
+    Args:
+        provider: Provider name (e.g., "ollama", "openai")
+
+    Returns:
+        dict: Default per-provider connection identity (host, model, apiKey).
+              An empty host means "use the provider's own default endpoint";
+              for ollama we seed the local default. An empty model means
+              "resolve to the first available model at startup".
+    """
+    return {
+        "host": DEFAULT_OLLAMA_HOST if provider == "ollama" else "",
+        "model": DEFAULT_MODEL if provider == "ollama" else "",
+        "apiKey": "",
+    }
+
+
 def default_config() -> dict:
     """Get default configuration settings.
 
@@ -14,10 +33,10 @@ def default_config() -> dict:
     """
 
     return {
-        "host": DEFAULT_OLLAMA_HOST,
-        "model": DEFAULT_MODEL,
-        "provider": "ollama",
-        "apiKey": "",
+        "defaultProvider": "ollama",
+        "providers": {
+            "ollama": default_provider_profile("ollama"),
+        },
         "enabledTools": {},  # Will be populated with available tools
         "contextSettings": {
             "retainContext": True

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -10,7 +10,7 @@ from typing import Dict, Any, Optional
 from rich.console import Console
 from rich.panel import Panel
 from ..utils.constants import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE
-from .defaults import default_config
+from .defaults import default_config, default_provider_profile
 
 class ConfigManager:
     """Manages configuration for the MCP Client for Ollama.
@@ -197,17 +197,35 @@ class ConfigManager:
         # Start with default configuration
         validated = default_config()
 
-        # Remove default host - only include if explicitly in config file
-        # This allows CLI arguments to take precedence when config file
-        # doesn't have a host field (e.g., older config files)
-        del validated["host"]
+        # Resolve per-provider connection profiles.
+        # New format: a "providers" map keyed by provider name plus a
+        # "defaultProvider". Legacy format: flat top-level host/model/provider/
+        # apiKey, which we migrate into a single provider profile so old config
+        # files keep working and are rewritten in the new shape on next save.
+        validated["providers"] = {}
+        if isinstance(config_data.get("providers"), dict):
+            default_provider = config_data.get("defaultProvider") or "ollama"
+            for name, profile in config_data["providers"].items():
+                if isinstance(profile, dict):
+                    validated["providers"][name] = {
+                        "host": profile.get("host", ""),
+                        "model": profile.get("model", ""),
+                        "apiKey": profile.get("apiKey", ""),
+                    }
+        elif any(k in config_data for k in ("host", "model", "provider", "apiKey")):
+            default_provider = config_data.get("provider") or "ollama"
+            validated["providers"][default_provider] = {
+                "host": config_data.get("host", ""),
+                "model": config_data.get("model", ""),
+                "apiKey": config_data.get("apiKey", ""),
+            }
+        else:
+            default_provider = "ollama"
 
-        # Apply values from the loaded configuration if they exist
-        if "host" in config_data:
-            validated["host"] = config_data["host"]
-
-        if "model" in config_data:
-            validated["model"] = config_data["model"]
+        # Ensure the default provider always has at least a seed profile.
+        if default_provider not in validated["providers"]:
+            validated["providers"][default_provider] = default_provider_profile(default_provider)
+        validated["defaultProvider"] = default_provider
 
         if "enabledTools" in config_data and isinstance(config_data["enabledTools"], dict):
             validated["enabledTools"] = config_data["enabledTools"]

--- a/mcp_client_for_ollama/models/config_manager.py
+++ b/mcp_client_for_ollama/models/config_manager.py
@@ -210,6 +210,40 @@ class ModelConfigManager:
             options["num_batch"] = self.num_batch
         return options
 
+    def get_completion_kwargs(self, provider: str = "ollama") -> Dict[str, Any]:
+        """Get model options as kwargs for AnyLLM.acompletion().
+
+        For ollama: returns all 15 options using native names. They flow
+        through acompletion's **kwargs into the Ollama SDK's options dict.
+
+        For other providers: returns only the 7 standard OpenAI-compatible
+        options, remapping num_predict → max_tokens. Ollama-specific params
+        are omitted since they would cause errors on other SDKs.
+
+        Returns:
+            Dict containing only the configured options as keyword arguments
+        """
+        if provider == "ollama":
+            return self.get_ollama_options()
+
+        # Standard OpenAI-compatible options only
+        kwargs: Dict[str, Any] = {}
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        if self.top_p is not None:
+            kwargs["top_p"] = self.top_p
+        if self.num_predict is not None:
+            kwargs["max_tokens"] = self.num_predict
+        if self.stop is not None:
+            kwargs["stop"] = self.stop
+        if self.seed is not None:
+            kwargs["seed"] = self.seed
+        if self.presence_penalty is not None:
+            kwargs["presence_penalty"] = self.presence_penalty
+        if self.frequency_penalty is not None:
+            kwargs["frequency_penalty"] = self.frequency_penalty
+        return kwargs
+
     def get_system_prompt(self) -> str:
         """Get the current system prompt.
 

--- a/mcp_client_for_ollama/models/manager.py
+++ b/mcp_client_for_ollama/models/manager.py
@@ -166,7 +166,10 @@ class ModelManager:
         """Display the currently selected model in the console."""
         capabilities = self._capabilities_cache.get(self.model, [])
         badges = self.format_capabilities_badges(capabilities)
-        content = f"[bold blue]Current model:[/bold blue] [bold green]{self.model}[/bold green]"
+        content = (
+            f"[bold blue]Current model:[/bold blue] [bold green]{self.model}[/bold green]"
+            f" [bold yellow]({self.provider})[/bold yellow]"
+        )
         if badges:
             content += f"\n[bold blue]Capabilities:[/bold blue] {badges}"
         self.console.print(Panel(content, border_style="blue", expand=False))

--- a/mcp_client_for_ollama/models/manager.py
+++ b/mcp_client_for_ollama/models/manager.py
@@ -405,7 +405,7 @@ class ModelManager:
                 "[bold yellow]No Ollama models found on this host.[/bold yellow]\n\n"
                 "Pull one in another terminal, for example:\n"
                 "[bold cyan]ollama pull qwen3:0.6b[/bold cyan]\n\n"
-                "Then restart ollmcp, or run [bold cyan]/model[/bold cyan] once a model is installed.",
+                "Then restart ollmcp, or run [bold cyan]/model[/bold cyan] once a model is available.",
                 title="No Models Available", border_style="yellow", expand=False
             ))
             self.console.print()
@@ -420,7 +420,7 @@ class ModelManager:
         else:
             requested, used = status
             self.console.print(Panel(
-                f"Requested model [bold yellow]{requested}[/bold yellow] is not installed — "
+                f"Requested model [bold yellow]{requested}[/bold yellow] is not available — "
                 f"using [bold green]{used}[/bold green] instead.\n\n"
                 f"Pull it with [bold cyan]ollama pull {requested}[/bold cyan] to use it, or:\n"
                 "• Switch models: [bold cyan]/model[/bold cyan] or [bold cyan]/m[/bold cyan]\n"

--- a/mcp_client_for_ollama/models/manager.py
+++ b/mcp_client_for_ollama/models/manager.py
@@ -3,7 +3,10 @@
 This module handles listing, selecting, and managing Ollama models.
 """
 import asyncio
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Tuple
+
+import httpx
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -18,45 +21,79 @@ class ModelManager:
     Ollama is running, and selecting models to use with the client.
     """
 
-    def __init__(self, console: Optional[Console] = None, default_model: str = DEFAULT_MODEL, ollama: Optional[Any] = None):
+    def __init__(self, console: Optional[Console] = None, default_model: str = DEFAULT_MODEL, llm: Optional[Any] = None, provider: str = "ollama", api_base: Optional[str] = None, api_key: Optional[str] = None):
         """Initialize the ModelManager.
 
         Args:
             console: Rich console for output (optional)
             default_model: Default model to use if none is specified
+            llm: AnyLLM instance for provider access
+            provider: Provider name (e.g. 'ollama', 'openai')
+            api_base: Provider base URL
+            api_key: Provider API key
         """
         self.console = console or Console()
         self.model = default_model
-        self.ollama = ollama
+        self.llm = llm
+        self.provider = provider
+        self.api_base = api_base
+        self.api_key = api_key
         self._capabilities_cache: Dict[str, List[str]] = {}
 
     async def check_ollama_running(self) -> bool:
-        """Check if Ollama is running by making a request to its API.
+        """Check if the LLM provider is reachable.
 
         Returns:
-            bool: True if Ollama is running, False otherwise
+            bool: True if the provider is reachable, False otherwise
         """
         try:
-            result = await self.ollama.list()
-            if result:
-                return True
+            await self._list_models()
+            return True
         except Exception:
             return False
 
     async def list_ollama_models(self) -> List[Dict[str, Any]]:
-        """Get a list of available Ollama models.
+        """Get a list of available models from the provider.
 
         Returns:
             List[Dict[str, Any]]: List of model objects each with name and other metadata
         """
         try:
-            result = await self.ollama.list()
-            if result:
-                models = result.get("models", [])
-                return models
+            return await self._list_models()
         except Exception as e:
-            self.console.print(f"[red]Error getting models from Ollama: {str(e)}[/red]")
+            self.console.print(f"[red]Error getting models: {str(e)}[/red]")
             return []
+
+    async def _list_models(self) -> List[Dict[str, Any]]:
+        """Fetch models from the provider, returning a list of dicts with 'name' etc."""
+        if self.provider == "ollama":
+            return await self._ollama_list_models()
+        return await self._generic_list_models()
+
+    async def _ollama_list_models(self) -> List[Dict[str, Any]]:
+        """Call ollama's native /api/tags for full model metadata."""
+        base = (self.api_base or "http://localhost:11434").rstrip("/")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{base}/api/tags")
+            resp.raise_for_status()
+            return resp.json().get("models", [])
+
+    async def _generic_list_models(self) -> List[Dict[str, Any]]:
+        """List models via any-llm for OpenAI-compatible providers."""
+        if self.llm is None:
+            return []
+        result = await self.llm.alist_models()
+        items = result.data if hasattr(result, "data") else result
+        models = []
+        for m in (items or []):
+            model_id = getattr(m, "id", str(m))
+            created = getattr(m, "created", None)
+            modified_at = (
+                datetime.fromtimestamp(created, tz=timezone.utc).isoformat()
+                if created else ""
+            )
+            models.append({"name": model_id, "model": model_id, "modified_at": modified_at, "size": 0, "digest": "", "details": {}})
+        return models
 
     def get_current_model(self) -> str:
         """Get the currently selected model.
@@ -86,12 +123,27 @@ class ModelManager:
         if model_name in self._capabilities_cache:
             return self._capabilities_cache[model_name]
         try:
-            model_info = await self.ollama.show(model_name)
-            caps = model_info.get('capabilities') or []
+            caps = await self._fetch_capabilities(model_name)
             self._capabilities_cache[model_name] = list(caps)
         except Exception:
             self._capabilities_cache[model_name] = []
         return self._capabilities_cache[model_name]
+
+    async def _fetch_capabilities(self, model_name: str) -> List[str]:
+        """Fetch raw capabilities for a model from the provider."""
+        if self.provider == "ollama":
+            return await self._ollama_fetch_capabilities(model_name)
+        # For non-ollama providers, assume all capabilities are available.
+        # The provider API will surface an error if a specific capability is unsupported.
+        return ["tools", "vision", "thinking"]
+
+    async def _ollama_fetch_capabilities(self, model_name: str) -> List[str]:
+        """Call ollama's /api/show endpoint for real capability data."""
+        base = (self.api_base or "http://localhost:11434").rstrip("/")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(f"{base}/api/show", json={"name": model_name})
+            resp.raise_for_status()
+            return resp.json().get("capabilities", [])
 
     def format_capabilities_badges(self, capabilities: List[str]) -> str:
         """Format model capabilities as colored emoji+word badges.
@@ -143,12 +195,20 @@ class ModelManager:
 
         # Format the date if available
         modified_at = model.get("modified_at", "Unknown")
-        if modified_at != "Unknown":
+        if modified_at and modified_at != "Unknown":
             try:
-                # Directly format the datetime object
-                modified_at = modified_at.strftime("%Y-%m-%d %H:%M:%S")
+                if hasattr(modified_at, "strftime"):
+                    # datetime object (e.g. from non-ollama providers)
+                    modified_at = modified_at.strftime("%Y-%m-%d %H:%M:%S")
+                elif isinstance(modified_at, str):
+                    # ISO string from ollama native API — parse then format
+                    from datetime import datetime
+                    dt = datetime.fromisoformat(modified_at)
+                    modified_at = dt.strftime("%Y-%m-%d %H:%M:%S")
             except Exception:
                 modified_at = "Unknown date"
+        else:
+            modified_at = "Unknown"
 
         return model_name, size_str, modified_at
 

--- a/mcp_client_for_ollama/utils/connection.py
+++ b/mcp_client_for_ollama/utils/connection.py
@@ -1,10 +1,11 @@
 """Utility to test connectivity"""
 from typing import Any, Optional
 
-import ollama
 from rich.panel import Panel
 import urllib.request
 import urllib.error
+
+from any_llm import AnyLLM
 
 def check_url_connectivity(url):
     """
@@ -48,29 +49,46 @@ async def preflight_ollama(client: Any, cli_host: Optional[str] = None) -> bool:
         bool: True when Ollama is reachable, otherwise False.
     """
     preflight_host = cli_host if cli_host is not None else client.host
+    preflight_provider = client.provider
+    preflight_api_key = client.api_key
 
     if cli_host is None and client.config_manager.config_exists("default"):
         default_config = client.config_manager.load_configuration("default")
         config_host = default_config.get("host")
         if config_host:
             preflight_host = config_host
+        config_provider = default_config.get("provider")
+        if config_provider:
+            preflight_provider = config_provider
+        config_api_key = default_config.get("apiKey")
+        if config_api_key:
+            preflight_api_key = config_api_key
 
-    if preflight_host != client.host:
+    if preflight_host != client.host or preflight_provider != client.provider:
         client.host = preflight_host
-        client.ollama = ollama.AsyncClient(host=preflight_host)
-        client.model_manager.ollama = client.ollama
+        client.provider = preflight_provider
+        client.api_key = preflight_api_key
+        client.llm = AnyLLM.create(preflight_provider, api_key=preflight_api_key, api_base=preflight_host)
+        client.model_manager.llm = client.llm
+        client.model_manager.provider = preflight_provider
+        client.model_manager.api_base = preflight_host
+        client.model_manager.api_key = preflight_api_key
 
     is_running = await client.model_manager.check_ollama_running()
     if not is_running:
         client.console.print(Panel(
-            "[bold red]Error: Ollama is not running![/bold red]\n\n"
-            f"[yellow]Ollama current configured host: {client.host}[/yellow]\n\n"
-            "This client requires Ollama to be running to process queries.\n\n"
-            "Please start Ollama by running the 'ollama serve' command in a terminal.\n\n"
-            "💡 [bold magenta]Tip:[/bold magenta] If you configured a different host in a saved default configuration you can\n\n"
-            "   1. Use --host flag to override the configured host for example: ollmcp --host http://localhost:11434\n"
-            "   2. Once done, you can save a new default configuration to avoid needing to specify it each time.",
-            title="Ollama Not Running", border_style="red", expand=False
+            "[bold red]Error: Cannot connect to the LLM provider![/bold red]\n\n"
+            f"[yellow]Current configured host: {client.host}[/yellow]\n"
+            f"[yellow]Current provider: {client.provider}[/yellow]\n\n"
+            "Possible causes:\n"
+            "• LLM provider is not running or unreachable\n"
+            "• Incorrect host/port configuration\n"
+            "• Invalid API key\n\n"
+            "Solutions:\n"
+            "• For local Ollama: start it with [bold cyan]ollama serve[/bold cyan]\n"
+            "• Use [bold cyan]--host[/bold cyan] flag to specify a different host\n"
+            "• Use [bold cyan]--provider[/bold cyan] and [bold cyan]--api-key[/bold cyan] for remote providers",
+            title="LLM Provider Not Available", border_style="red", expand=False
         ))
 
     return is_running

--- a/mcp_client_for_ollama/utils/connection.py
+++ b/mcp_client_for_ollama/utils/connection.py
@@ -1,11 +1,50 @@
-"""Utility to test connectivity"""
-from typing import Any, Optional
+"""Utility to test connectivity and provider validation"""
+from typing import Any
 
+from rich.console import Console
 from rich.panel import Panel
 import urllib.request
 import urllib.error
 
 from any_llm import AnyLLM
+from any_llm.exceptions import UnsupportedProviderError
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+from .constants import SUPPORTED_PROVIDERS
+
+
+def validate_provider(provider: str, console: Console) -> bool:
+    """Validate that a provider is known and supported by ollmcp.
+
+    Returns True if the provider is usable, False otherwise (after printing
+    a user-facing error panel).
+    """
+    try:
+        provider_class = AnyLLM.get_provider_class(provider)
+    except UnsupportedProviderError:
+        console.print() # newline for spacing
+        console.print(Panel(
+            f"[bold red]Unknown provider:[/bold red] [bold blue]{provider}[/bold blue] is not a valid provider name.\n\n"
+            f"Currently supported: {SUPPORTED_PROVIDERS}.\n\n"
+            f"[dim]More providers coming soon.[/dim]",
+            title="Unknown Provider", border_style="red", expand=False
+        ))
+        return False
+    except ImportError:
+        provider_class = None
+
+    if provider_class is None or (provider != "ollama" and not issubclass(provider_class, BaseOpenAIProvider)):
+        console.print() # newline for spacing
+        console.print(Panel(
+            f"[bold yellow]Provider not available yet:[/bold yellow] [bold blue]{provider}[/bold blue] isn't supported by ollmcp yet.\n\n"
+            f"Currently supported: {SUPPORTED_PROVIDERS}.\n\n"
+            f"[dim]More providers coming soon.[/dim]",
+            title="Provider Not Supported", border_style="yellow", expand=False
+        ))
+        return False
+
+    return True
+
 
 def check_url_connectivity(url):
     """
@@ -30,65 +69,48 @@ def check_url_connectivity(url):
         return False
 
 
-async def preflight_ollama(client: Any, cli_host: Optional[str] = None) -> bool:
-    """Resolve preflight host and check Ollama availability.
+async def preflight_ollama(client: Any) -> bool:
+    """Check that the client's configured LLM provider is reachable.
 
-    Host resolution order:
-    1) CLI host (`cli_host`) if provided
-    2) default saved config host (if present)
-    3) current client host
-
-    This function mutates `client.host`, `client.ollama`, and
-    `client.model_manager.ollama` when host resolution changes.
+    The provider, host, and API key are already resolved on the client before
+    this runs, so this only performs the reachability check and renders a
+    provider-appropriate error panel when it fails.
 
     Args:
-        client: MCPClient-like object with config/model manager members.
-        cli_host: Optional host provided from CLI args.
+        client: MCPClient-like object with a `model_manager` member.
 
     Returns:
-        bool: True when Ollama is reachable, otherwise False.
+        bool: True when the provider is reachable, otherwise False.
     """
-    preflight_host = cli_host if cli_host is not None else client.host
-    preflight_provider = client.provider
-    preflight_api_key = client.api_key
-
-    if cli_host is None and client.config_manager.config_exists("default"):
-        default_config = client.config_manager.load_configuration("default")
-        config_host = default_config.get("host")
-        if config_host:
-            preflight_host = config_host
-        config_provider = default_config.get("provider")
-        if config_provider:
-            preflight_provider = config_provider
-        config_api_key = default_config.get("apiKey")
-        if config_api_key:
-            preflight_api_key = config_api_key
-
-    if preflight_host != client.host or preflight_provider != client.provider:
-        client.host = preflight_host
-        client.provider = preflight_provider
-        client.api_key = preflight_api_key
-        client.llm = AnyLLM.create(preflight_provider, api_key=preflight_api_key, api_base=preflight_host)
-        client.model_manager.llm = client.llm
-        client.model_manager.provider = preflight_provider
-        client.model_manager.api_base = preflight_host
-        client.model_manager.api_key = preflight_api_key
-
     is_running = await client.model_manager.check_ollama_running()
     if not is_running:
-        client.console.print(Panel(
-            "[bold red]Error: Cannot connect to the LLM provider![/bold red]\n\n"
-            f"[yellow]Current configured host: {client.host}[/yellow]\n"
-            f"[yellow]Current provider: {client.provider}[/yellow]\n\n"
-            "Possible causes:\n"
-            "• LLM provider is not running or unreachable\n"
-            "• Incorrect host/port configuration\n"
-            "• Invalid API key\n\n"
-            "Solutions:\n"
-            "• For local Ollama: start it with [bold cyan]ollama serve[/bold cyan]\n"
-            "• Use [bold cyan]--host[/bold cyan] flag to specify a different host\n"
-            "• Use [bold cyan]--provider[/bold cyan] and [bold cyan]--api-key[/bold cyan] for remote providers",
-            title="LLM Provider Not Available", border_style="red", expand=False
-        ))
+        if client.provider == "ollama":
+            client.console.print(Panel(
+                "[bold red]Error: Cannot connect to Ollama![/bold red]\n\n"
+                f"[yellow]Configured host: {client.host}[/yellow]\n\n"
+                "Possible causes:\n"
+                "• Ollama is not running or unreachable\n"
+                "• Incorrect host/port configuration\n\n"
+                "Solutions:\n"
+                "• Start it with [bold cyan]ollama serve[/bold cyan]\n"
+                "• Use [bold cyan]--host[/bold cyan] to point at a different Ollama host\n"
+                "• Use [bold cyan]--provider[/bold cyan] and [bold cyan]--api-key[/bold cyan] for a remote provider",
+                title="Ollama Not Available", border_style="red", expand=False
+            ))
+        else:
+            host_line = f"[yellow]API base URL: {client.host}[/yellow]\n\n" if client.host else ""
+            client.console.print(Panel(
+                f"[bold red]Error: Cannot reach the {client.provider} provider![/bold red]\n\n"
+                f"{host_line}"
+                "Possible causes:\n"
+                "• Invalid or missing API key\n"
+                "• Network/connectivity issue\n"
+                "• Wrong API base URL\n\n"
+                "Solutions:\n"
+                "• Check your [bold cyan]--api-key[/bold cyan] / [bold cyan]$OLLMCP_API_KEY[/bold cyan]\n"
+                "• Use [bold cyan]--host[/bold cyan] to override the API base URL if needed\n"
+                "• Verify the provider name and that its package is installed",
+                title="LLM Provider Not Available", border_style="red", expand=False
+            ))
 
     return is_running

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -30,6 +30,13 @@ DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 # Default LLM provider
 DEFAULT_PROVIDER = "ollama"
 
+# Providers ollmcp currently supports: Ollama (native) plus OpenAI and any
+# OpenAI-compatible provider (they all use the bundled openai package).
+SUPPORTED_PROVIDERS = (
+    "ollama, openai, and OpenAI-compatible providers "
+    "(openrouter, deepseek, perplexity, etc.)"
+)
+
 # Default number of history entries to display when returning from menus
 DEFAULT_HISTORY_DISPLAY_LIMIT = 5
 

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -27,6 +27,9 @@ DEFAULT_MODEL = "qwen3:0.6b"
 # Default ollama lcoal url for API requests
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
+# Default LLM provider
+DEFAULT_PROVIDER = "ollama"
+
 # Default number of history entries to display when returning from menus
 DEFAULT_HISTORY_DISPLAY_LIMIT = 5
 

--- a/mcp_client_for_ollama/utils/images.py
+++ b/mcp_client_for_ollama/utils/images.py
@@ -1,0 +1,27 @@
+"""Image format conversion for LLM provider compatibility."""
+
+from typing import Any, Dict, List
+
+
+def apply_images(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert Ollama-style `images` fields to OpenAI content arrays.
+
+    All any-llm providers expect the OpenAI content-array format for images.
+    Providers that use a different native format (e.g. Ollama) convert
+    internally from this universal representation.
+    """
+    result = []
+    for msg in messages:
+        if msg.get("images") and msg.get("role") == "user":
+            content_parts = [{"type": "text", "text": msg.get("content", "")}]
+            for img in msg["images"]:
+                content_parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{img}"},
+                })
+            new_msg = {k: v for k, v in msg.items() if k not in ("images", "content")}
+            new_msg["content"] = content_parts
+            result.append(new_msg)
+        else:
+            result.append(msg)
+    return result

--- a/mcp_client_for_ollama/utils/metrics.py
+++ b/mcp_client_for_ollama/utils/metrics.py
@@ -1,87 +1,61 @@
 """
-Metrics display utilities for the MCP client for Ollama.
+Metrics display utilities for the MCP client.
 
-This module provides functions for extracting and displaying performance metrics from Ollama responses.
+This module provides functions for extracting and displaying token usage
+from streaming LLM responses.
 """
 from rich.panel import Panel
 
+
 def extract_metrics(chunk):
-    """Extract metrics from an Ollama response chunk
+    """Extract token usage from a streaming chunk.
 
     Args:
-        chunk: Response chunk from Ollama that may contain metrics
+        chunk: A ChatCompletionChunk that may carry a usage field.
 
     Returns:
-        dict: Dictionary containing extracted metrics, or None if no metrics available
+        dict: Token usage counts, or None if the chunk has no usage data.
     """
-    if not (hasattr(chunk, 'done') and chunk.done):
+    usage = getattr(chunk, "usage", None)
+    if usage is None:
         return None
-
     return {
-        'total_duration': getattr(chunk, 'total_duration', None),
-        'load_duration': getattr(chunk, 'load_duration', None),
-        'prompt_eval_count': getattr(chunk, 'prompt_eval_count', None),
-        'prompt_eval_duration': getattr(chunk, 'prompt_eval_duration', None),
-        'eval_count': getattr(chunk, 'eval_count', None),
-        'eval_duration': getattr(chunk, 'eval_duration', None)
+        "prompt_tokens": getattr(usage, "prompt_tokens", None),
+        "completion_tokens": getattr(usage, "completion_tokens", None),
+        "total_tokens": getattr(usage, "total_tokens", None),
     }
 
+
 def display_metrics(console, metrics):
-    """Display performance metrics in a formatted way
+    """Display token usage in a formatted panel.
 
     Args:
         console: Rich console for output
-        metrics: Dictionary containing metrics from Ollama response
+        metrics: Dictionary containing token usage from the response
     """
     if not metrics:
         return
 
-    # Convert nanoseconds to seconds for durations
-    def ns_to_seconds(ns_value):
-        return ns_value / 1_000_000_000 if ns_value else 0
+    prompt_tokens = metrics.get("prompt_tokens") or 0
+    completion_tokens = metrics.get("completion_tokens") or 0
+    total_tokens = metrics.get("total_tokens") or 0
 
-    total_duration = ns_to_seconds(metrics.get('total_duration'))
-    load_duration = ns_to_seconds(metrics.get('load_duration'))
-    prompt_eval_duration = ns_to_seconds(metrics.get('prompt_eval_duration'))
-    eval_duration = ns_to_seconds(metrics.get('eval_duration'))
+    if not any([prompt_tokens, completion_tokens, total_tokens]):
+        return
 
-    prompt_eval_count = metrics.get('prompt_eval_count', 0)
-    eval_count = metrics.get('eval_count', 0)
+    lines = []
+    if prompt_tokens:
+        lines.append(f"[cyan]prompt tokens:[/cyan]     {prompt_tokens}")
+    if completion_tokens:
+        lines.append(f"[cyan]completion tokens:[/cyan] {completion_tokens}")
+    if total_tokens:
+        lines.append(f"[cyan]total tokens:[/cyan]      {total_tokens}")
 
-    # Build metrics content
-    metrics_lines = []
-
-    # Display basic metrics
-    if total_duration > 0:
-        metrics_lines.append(f"[cyan]total duration:[/cyan]       {total_duration:.9f}s")
-    if load_duration > 0:
-        metrics_lines.append(f"[cyan]load duration:[/cyan]        {load_duration * 1000:.6f}ms")
-    if prompt_eval_count:
-        metrics_lines.append(f"[cyan]prompt eval count:[/cyan]    {prompt_eval_count} token(s)")
-    if prompt_eval_duration > 0:
-        metrics_lines.append(f"[cyan]prompt eval duration:[/cyan] {prompt_eval_duration * 1000:.6f}ms")
-    if eval_count:
-        metrics_lines.append(f"[cyan]eval count:[/cyan]           {eval_count} token(s)")
-    if eval_duration > 0:
-        metrics_lines.append(f"[cyan]eval duration:[/cyan]        {eval_duration:.9f}s")
-
-    # Calculate and display rates
-    if prompt_eval_count and prompt_eval_duration > 0:
-        prompt_eval_rate = prompt_eval_count / prompt_eval_duration
-        metrics_lines.append(f"[green]prompt eval rate:[/green]     {prompt_eval_rate:.2f} tokens/s")
-
-    if eval_count and eval_duration > 0:
-        eval_rate = eval_count / eval_duration
-        metrics_lines.append(f"[green]eval rate:[/green]            {eval_rate:.2f} tokens/s")
-
-    # Display metrics in a panel
-    if metrics_lines:
-        console.print()  # Add spacing before panel
-        metrics_content = "\n".join(metrics_lines)
-        console.print(Panel(
-            metrics_content,
-            title="📊 Performance Metrics",
-            border_style="violet",
-            expand=False
-        ))
-        console.print()  # Add spacing after panel
+    console.print()
+    console.print(Panel(
+        "\n".join(lines),
+        title="📊 Token Usage",
+        border_style="violet",
+        expand=False,
+    ))
+    console.print()

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -203,7 +203,7 @@ class StreamingManager:
         """Process a streaming response from Ollama with status spinner and content updates
 
         Args:
-            stream: Async iterator of response chunks
+            stream: Async iterator of ChatCompletionChunk objects
             print_response: Flag to control live updating of response text
             thinking_mode: Whether to handle thinking mode responses
             show_thinking: Whether to keep thinking text visible in final output
@@ -234,27 +234,47 @@ class StreamingManager:
             status = self.console.status("[cyan]working...", spinner="dots")
             status.start()
 
+            # Buffer for incremental tool call deltas
+            tool_call_buffers = {}
 
             try:
-                async for chunk in stream:
+                stream_iter = stream.__aiter__()
+                while True:
+                    try:
+                        chunk = await stream_iter.__anext__()
+                    except StopAsyncIteration:
+                        break
+                    except Exception as e:
+                        import logging
+                        logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
+                        continue
+
                     # Check for cancellation
                     if cancellation_check and cancellation_check():
                         self.console.print("\n[yellow]Generation aborted by user.[/yellow]")
                         return accumulated_text, tool_calls, metrics
 
-                    # Capture metrics when chunk is done
+                    # Capture metrics when chunk carries usage data
                     extracted_metrics = extract_metrics(chunk)
                     if extracted_metrics:
                         metrics = extracted_metrics
 
+                    if not getattr(chunk, "choices", None):
+                        continue
+
+                    choice = chunk.choices[0]
+                    delta = choice.delta
+
                     # Handle thinking content
-                    if (thinking_mode and hasattr(chunk, 'message') and
-                        hasattr(chunk.message, 'thinking') and chunk.message.thinking):
-                        # Stop spinner on first thinking chunk ONLY if show_thinking is True
+                    thinking = None
+                    reasoning = getattr(delta, "reasoning", None)
+                    if reasoning is not None:
+                        thinking = reasoning.content if hasattr(reasoning, "content") else (reasoning if isinstance(reasoning, str) else None)
+
+                    if thinking_mode and thinking:
                         if first_chunk and show_thinking:
                             status.stop()
                             first_chunk = False
-
                         if not thinking_content:
                             thinking_content = "🤔 **Thinking:**\n\n"
                             if not thinking_started and show_thinking:
@@ -262,45 +282,57 @@ class StreamingManager:
                                 self.console.print(Markdown("---"))
                                 self.console.print()
                                 thinking_started = True
-                        thinking_content += chunk.message.thinking
-                        # Print thinking content as plain text only if show_thinking is True
+                        thinking_content += thinking
                         if show_thinking:
-                            self.console.print(chunk.message.thinking, end="")
+                            self.console.print(thinking, end="")
 
                     # Handle regular content
-                    if (hasattr(chunk, 'message') and hasattr(chunk.message, 'content') and
-                        chunk.message.content):
-                        # Stop spinner on first content chunk (always)
+                    content = getattr(delta, "content", None) or ""
+                    if content:
                         if first_chunk:
                             status.stop()
                             first_chunk = False
-
-                        # Print separator and Answer label when transitioning from thinking to content
                         if not accumulated_text and stream_plain_text:
                             self._print_answer_transition_header(show_thinking, "plain")
-
-                        accumulated_text += chunk.message.content
-
-                        # Print only new content as plain text (will render full markdown at end)
+                        accumulated_text += content
                         if stream_plain_text:
-                            self.console.print(chunk.message.content, end="")
+                            self.console.print(content, end="")
                         elif render_mode == "markdown":
                             if progressive_renderer is None:
                                 self._print_answer_transition_header(show_thinking, "markdown")
                                 progressive_renderer = ProgressiveMarkdownRenderer(self.console)
                                 progressive_renderer.start()
-                            progressive_renderer.update(chunk.message.content)
+                            progressive_renderer.update(content)
 
-                    # Handle tool calls
-                    if (hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and
-                        chunk.message.tool_calls):
-                        # Stop spinner on first tool call chunk (always) - just in case no content arrives
+                    # Buffer incremental tool call deltas
+                    delta_tool_calls = getattr(delta, "tool_calls", None)
+                    if delta_tool_calls:
                         if first_chunk:
                             status.stop()
                             first_chunk = False
+                        for tc in delta_tool_calls:
+                            idx = tc.index if hasattr(tc, "index") else 0
+                            if idx not in tool_call_buffers:
+                                tool_call_buffers[idx] = {"id": "", "name": "", "arguments": ""}
+                            buf = tool_call_buffers[idx]
+                            if getattr(tc, "id", None):
+                                buf["id"] = tc.id
+                            if hasattr(tc, "function") and tc.function:
+                                if getattr(tc.function, "name", None):
+                                    buf["name"] += tc.function.name
+                                if getattr(tc.function, "arguments", None):
+                                    buf["arguments"] += tc.function.arguments
 
-                        for tool in chunk.message.tool_calls:
-                            tool_calls.append(tool)
+                    # On finish, emit completed tool calls
+                    if getattr(choice, "finish_reason", None) and tool_call_buffers:
+                        for idx, buf in sorted(tool_call_buffers.items()):
+                            tool_calls.append({
+                                "id": buf["id"] or f"call_{idx}",
+                                "type": "function",
+                                "function": {"name": buf["name"], "arguments": buf["arguments"]},
+                            })
+                        tool_call_buffers.clear()
+
             finally:
                 if progressive_renderer is not None:
                     progressive_renderer.finish()
@@ -315,28 +347,65 @@ class StreamingManager:
 
         else:
             # Silent processing without display
-            async for chunk in stream:
+            tool_call_buffers = {}
+            stream_iter = stream.__aiter__()
+            while True:
+                try:
+                    chunk = await stream_iter.__anext__()
+                except StopAsyncIteration:
+                    break
+                except Exception as e:
+                    import logging
+                    logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
+                    continue
+
                 # Check for cancellation
                 if cancellation_check and cancellation_check():
                     return accumulated_text, tool_calls, metrics
 
-                # Capture metrics when chunk is done
                 extracted_metrics = extract_metrics(chunk)
                 if extracted_metrics:
                     metrics = extracted_metrics
 
-                if (thinking_mode and hasattr(chunk, 'message') and
-                    hasattr(chunk.message, 'thinking') and chunk.message.thinking):
-                    thinking_content += chunk.message.thinking
+                if not getattr(chunk, "choices", None):
+                    continue
 
-                if (hasattr(chunk, 'message') and hasattr(chunk.message, 'content') and
-                    chunk.message.content):
-                    accumulated_text += chunk.message.content
+                choice = chunk.choices[0]
+                delta = choice.delta
 
-                if (hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and
-                    chunk.message.tool_calls):
-                    for tool in chunk.message.tool_calls:
-                        tool_calls.append(tool)
+                reasoning = getattr(delta, "reasoning", None)
+                if thinking_mode and reasoning is not None:
+                    thinking = reasoning.content if hasattr(reasoning, "content") else (reasoning if isinstance(reasoning, str) else None)
+                    if thinking:
+                        thinking_content += thinking
+
+                content = getattr(delta, "content", None) or ""
+                if content:
+                    accumulated_text += content
+
+                delta_tool_calls = getattr(delta, "tool_calls", None)
+                if delta_tool_calls:
+                    for tc in delta_tool_calls:
+                        idx = tc.index if hasattr(tc, "index") else 0
+                        if idx not in tool_call_buffers:
+                            tool_call_buffers[idx] = {"id": "", "name": "", "arguments": ""}
+                        buf = tool_call_buffers[idx]
+                        if getattr(tc, "id", None):
+                            buf["id"] = tc.id
+                        if hasattr(tc, "function") and tc.function:
+                            if getattr(tc.function, "name", None):
+                                buf["name"] += tc.function.name
+                            if getattr(tc.function, "arguments", None):
+                                buf["arguments"] += tc.function.arguments
+
+                if getattr(choice, "finish_reason", None) and tool_call_buffers:
+                    for idx, buf in sorted(tool_call_buffers.items()):
+                        tool_calls.append({
+                            "id": buf["id"] or f"call_{idx}",
+                            "type": "function",
+                            "function": {"name": buf["name"], "arguments": buf["arguments"]},
+                        })
+                    tool_call_buffers.clear()
 
         # Display metrics if requested
         if show_metrics and metrics:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "any-llm-sdk[ollama] @ git+https://github.com/jonigl/any-llm.git@fix/ollama-streaming-tools",
+    "any-llm-sdk[ollama] ~=1.18.0",
     "mcp>=1.25,<1.28",
     "prompt-toolkit~=3.0.52",
     "rich>=14.2.0,<14.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "any-llm-sdk[ollama] ~=1.18.0",
+    "any-llm-sdk[ollama,openai] ~=1.18.0",
     "mcp>=1.25,<1.28",
     "prompt-toolkit~=3.0.52",
     "rich>=14.2.0,<14.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
+    "any-llm-sdk[ollama] @ git+https://github.com/jonigl/any-llm.git@fix/ollama-streaming-tools",
     "mcp>=1.25,<1.28",
-    "ollama~=0.6.0",
     "prompt-toolkit~=3.0.52",
     "rich>=14.2.0,<14.3",
     "typer~=0.21.0",

--- a/tests/test_api_key_persistence.py
+++ b/tests/test_api_key_persistence.py
@@ -1,0 +1,62 @@
+"""Tests for API key persistence in MCPClient.save_configuration().
+
+Keys supplied through the OLLMCP_API_KEY env var (persist_api_key=False) must
+never be written to the config file, while keys passed via --api-key
+(persist_api_key=True) are saved. A previously saved key is preserved when a
+non-persistable key is in use.
+"""
+
+import json
+
+from mcp_client_for_ollama.client import MCPClient
+from mcp_client_for_ollama.config import manager as config_manager
+
+
+def _saved_api_key(config_dir, provider="ollama"):
+    with open(config_dir / "config.json") as f:
+        return json.load(f)["providers"][provider]["apiKey"]
+
+
+def _make_client():
+    client = MCPClient()
+    client.model_manager.set_model("test-model")
+    return client
+
+
+def test_flag_key_is_persisted(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    client = _make_client()
+    client.api_key = "sk-flag"
+    client.persist_api_key = True
+
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == "sk-flag"
+
+
+def test_env_key_is_not_persisted(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    client = _make_client()
+    client.api_key = "sk-env"
+    client.persist_api_key = False
+
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == ""
+
+
+def test_env_key_preserves_previously_saved_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+
+    # First run saves a key from the --api-key flag.
+    client = _make_client()
+    client.api_key = "sk-saved"
+    client.persist_api_key = True
+    client.save_configuration()
+
+    # A later run uses an env-var key, which must not overwrite the saved one.
+    client.api_key = "sk-env"
+    client.persist_api_key = False
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == "sk-saved"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -5,37 +5,82 @@ from mcp_client_for_ollama.config.defaults import default_config
 from rich.console import Console
 
 
-def test_validate_config_preserves_host():
-    """Test that _validate_config preserves the host field from loaded config."""
+def test_validate_config_preserves_providers_map():
+    """A new-format config keeps its per-provider profiles and defaultProvider."""
     mgr = ConfigManager(Console())
 
-    config_data = {
-        "host": "http://remote-server:11434",
-        "model": "test-model"
-    }
+    validated = mgr._validate_config({
+        "defaultProvider": "openai",
+        "providers": {
+            "ollama": {"host": "http://localhost:11434", "model": "qwen3:0.6b", "apiKey": ""},
+            "openai": {"host": "", "model": "gpt-4o", "apiKey": "sk-test"},
+        },
+    })
 
-    validated = mgr._validate_config(config_data)
+    assert validated["defaultProvider"] == "openai"
+    assert validated["providers"]["openai"] == {"host": "", "model": "gpt-4o", "apiKey": "sk-test"}
+    assert validated["providers"]["ollama"]["model"] == "qwen3:0.6b"
 
-    assert validated["host"] == "http://remote-server:11434"
 
-
-def test_validate_config_omits_host_when_missing():
-    """Test that _validate_config omits host when not in config file.
-
-    This allows CLI arguments to take precedence over defaults when
-    the config file doesn't have a host field (e.g., older config files).
-    """
+def test_validate_config_migrates_legacy_flat_config():
+    """A legacy flat config is migrated into a single provider profile."""
     mgr = ConfigManager(Console())
 
-    config_data = {
-        "model": "test-model"
+    validated = mgr._validate_config({
+        "host": "https://api.atlascloud.ai/v1",
+        "model": "deepseek",
+        "provider": "openai",
+        "apiKey": "sk-legacy",
+    })
+
+    assert validated["defaultProvider"] == "openai"
+    assert validated["providers"]["openai"] == {
+        "host": "https://api.atlascloud.ai/v1",
+        "model": "deepseek",
+        "apiKey": "sk-legacy",
     }
 
-    validated = mgr._validate_config(config_data)
 
-    # Host should NOT be in the validated config when not in original
-    # This allows CLI arguments to take precedence
-    assert "host" not in validated
+def test_validate_config_legacy_without_provider_defaults_to_ollama():
+    """A legacy config lacking a provider migrates under ollama."""
+    mgr = ConfigManager(Console())
+
+    validated = mgr._validate_config({"model": "test-model"})
+
+    assert validated["defaultProvider"] == "ollama"
+    assert validated["providers"]["ollama"]["model"] == "test-model"
+
+
+def test_validate_config_seeds_default_provider_when_absent():
+    """A config with neither providers nor connection fields still seeds ollama."""
+    mgr = ConfigManager(Console())
+
+    validated = mgr._validate_config({"displaySettings": {"answerRenderMode": "both"}})
+
+    assert validated["defaultProvider"] == "ollama"
+    assert "ollama" in validated["providers"]
+
+
+def test_save_load_round_trip_preserves_all_providers(monkeypatch, tmp_path):
+    """Saving and reloading keeps every provider profile and the default."""
+    import mcp_client_for_ollama.config.manager as manager_module
+
+    monkeypatch.setattr(manager_module, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(manager_module, "DEFAULT_CONFIG_FILE", "config.json")
+
+    mgr = ConfigManager(Console())
+    cfg = default_config()
+    cfg["providers"]["openai"] = {"host": "", "model": "gpt-4o", "apiKey": "sk-test"}
+    cfg["defaultProvider"] = "openai"
+
+    assert mgr.save_configuration(cfg, "default") is True
+
+    loaded = mgr.load_configuration("default")
+    assert loaded["defaultProvider"] == "openai"
+    assert loaded["providers"]["openai"]["model"] == "gpt-4o"
+    assert loaded["providers"]["openai"]["apiKey"] == "sk-test"
+    # The pre-existing ollama profile is not dropped.
+    assert "ollama" in loaded["providers"]
 
 
 def test_default_config_shows_thinking_text():

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -10,10 +10,10 @@ from mcp_client_for_ollama.models.manager import ModelManager
 
 
 def _make_manager(models):
-    """Build a ModelManager with a fake ollama client returning the given models."""
-    fake_ollama = AsyncMock()
-    fake_ollama.list = AsyncMock(return_value={"models": models})
-    return ModelManager(console=Console(), default_model="placeholder:1b", ollama=fake_ollama)
+    """Build a ModelManager whose provider reports the given installed models."""
+    mgr = ModelManager(console=Console(), default_model="placeholder:1b")
+    mgr._list_models = AsyncMock(return_value=models)
+    return mgr
 
 
 class TestResolveInitialModel(unittest.IsolatedAsyncioTestCase):
@@ -79,15 +79,15 @@ class TestResolveInitialModel(unittest.IsolatedAsyncioTestCase):
 
 
 class TestProcessQueryWithNoModel(unittest.IsolatedAsyncioTestCase):
-    async def test_returns_early_without_calling_ollama(self):
+    async def test_returns_early_without_calling_llm(self):
         client = MCPClient()
         client.model_manager.set_model("")
-        client.ollama.chat = AsyncMock(side_effect=AssertionError("ollama.chat should not be called"))
+        client.llm.acompletion = AsyncMock(side_effect=AssertionError("llm.acompletion should not be called"))
 
         response = await client.process_query("hi")
 
         self.assertEqual(response, "")
-        client.ollama.chat.assert_not_called()
+        client.llm.acompletion.assert_not_called()
 
 
 class TestPrintResolutionStatus(unittest.TestCase):

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -8,19 +8,28 @@ from mcp_client_for_ollama.utils.streaming import ProgressiveMarkdownRenderer, S
 
 
 @dataclass
-class DummyMessage:
-    """Minimal message double for streaming tests."""
+class DummyDelta:
+    """Minimal delta double for streaming tests."""
 
     content: str = ""
-    thinking: str = ""
+    reasoning: str = None
     tool_calls: list = None
+
+
+@dataclass
+class DummyChoice:
+    """Minimal choice double for streaming tests."""
+
+    delta: DummyDelta
+    finish_reason: str = None
 
 
 @dataclass
 class DummyChunk:
     """Minimal chunk double for streaming tests."""
 
-    message: DummyMessage
+    choices: list
+    usage: object = None
 
 
 async def _stream_chunks(*chunks):
@@ -83,7 +92,7 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
             return_value=None,
         ):
             response_text, tool_calls, metrics = await manager.process_streaming_response(
-                _stream_chunks(DummyChunk(DummyMessage(content="hello **world**"))),
+                _stream_chunks(DummyChunk(choices=[DummyChoice(DummyDelta(content="hello **world**"))])),
                 answer_render_mode="plain",
             )
 
@@ -104,7 +113,7 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
             return_value=None,
         ):
             response_text, _, _ = await manager.process_streaming_response(
-                _stream_chunks(DummyChunk(DummyMessage(content="hello **world**"))),
+                _stream_chunks(DummyChunk(choices=[DummyChoice(DummyDelta(content="hello **world**"))])),
                 answer_render_mode="both",
             )
 
@@ -133,8 +142,8 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         ):
             response_text, _, _ = await manager.process_streaming_response(
                 _stream_chunks(
-                    DummyChunk(DummyMessage(content="hello ")),
-                    DummyChunk(DummyMessage(content="**world**")),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="hello "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="**world**"))]),
                 ),
                 answer_render_mode="markdown",
             )
@@ -167,8 +176,8 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         ):
             response_text, _, _ = await manager.process_streaming_response(
                 _stream_chunks(
-                    DummyChunk(DummyMessage(thinking="planning")),
-                    DummyChunk(DummyMessage(content="answer")),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="planning"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="answer"))]),
                 ),
                 thinking_mode=True,
                 show_thinking=True,


### PR DESCRIPTION
## Summary

Refactors the MCP client from an Ollama-only tool into a **multi-provider LLM client** by integrating the [`any-llm-sdk`](https://pypi.org/project/any-llm-sdk/). Ollama remains the default provider, but the client can now talk to any provider that any-llm supports (OpenAI, etc.) using the same MCP tools, prompts, and resources.

## Motivation

The client was tightly coupled to Ollama's native API and metrics format. This PR introduces a provider abstraction so users can point `ollmcp` at different LLM backends without changing their MCP workflow, while keeping Ollama as a first-class, zero-config default.

## What's changed

### Provider abstraction
- Integrated **AnyLLM SDK** as the LLM backend (`self.llm = AnyLLM.create(...)`).
- `MCPClient` now accepts `provider` and `api_key` parameters (CLI flags `--provider/-p`, `--api-key/-k`, plus `$OLLMCP_API_KEY`).
- `ModelManager` handles model listing and capability/thinking detection per provider — native Ollama API vs. any-llm `list_models`. Current-model display now includes provider info.
- Connection utilities updated for provider-specific configuration.

### Compatibility & data shapes
- **Image handling:** convert images to the OpenAI content-array format so vision works across providers.
- **Streaming:** reworked streaming response processing to support the new delta structures returned by any-llm providers.
- **Metrics:** switched from Ollama-specific metrics to generic token-usage reporting.

### Config & error handling
- Refactored configuration management to support multiple providers, with **migration of legacy (Ollama-only) settings**.
- Graceful handling of **missing API keys** and **401 auth errors**.
- Added API key persistence logic.

### Docs & tests
- Expanded README with multi-provider setup and configuration guidance.
- Added tests for API key persistence and config migration; updated streaming, model manager, and config tests for the new formats.

## Notes
- Despite the multi-provider support, **Ollama stays the default** — existing single-provider users should see no behavior change.
- Targets the `release/v0.31.0` branch.