### PR TITLE
feat(any-llm): support multiple LLM providers via any-llm (v0.31.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v6
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -74,7 +74,7 @@ jobs:
     name: Check build packages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -105,7 +105,7 @@ jobs:
     name: Check version consistency
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Check version consistency
       run: |
         MAIN_VERSION=$(grep -E '^version\s*=\s*"[^"]+"' pyproject.toml | sed -E 's/^version\s*=\s*"([^"]+)".*/\1/')

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,6 @@ jobs:
         with:
           tag_name: "v${{ needs.extract-version.outputs.version }}"
           name: "Release v${{ needs.extract-version.outputs.version }}"
-          draft: false
+          draft: true
           prerelease: ${{ steps.release-type.outputs.type == 'prerelease' }}
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract version from pyproject.toml
         id: get-version
@@ -45,7 +45,7 @@ jobs:
       name: pypi
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -1,0 +1,29 @@
+name: windows-smoke-test
+
+# Smoke test to verify the CLI starts correctly on Windows
+# (e.g. no crashes from unconditional tty/termios imports).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install package
+        run: uv tool install --upgrade ollmcp
+
+      - name: Verify CLI starts
+        run: ollmcp --help

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   smoke:
+    name: Smoke test on Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install package
-        run: uv tool install --upgrade ollmcp
+        run: uv sync
 
       - name: Verify CLI starts
-        run: ollmcp --help
+        run: uv run ollmcp --help

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: windows-latest

--- a/.github/workflows/windows-smoke-test.yml
+++ b/.github/workflows/windows-smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Smoke test on Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/DEV.md
+++ b/DEV.md
@@ -47,7 +47,7 @@ This project uses GitHub Actions for automated testing, building, publishing, an
    - Triggered by pushing a version tag (e.g., `v0.1.11`) or manually from GitHub
    - Extracts the version from project files
    - Builds and publishes both packages to PyPI
-   - Creates a GitHub release with informative release notes
+   - Creates a GitHub release draft with informative release notes
 
 To create a new release:
 
@@ -71,6 +71,8 @@ To create a new release:
 4. The GitHub Actions workflow will automatically:
    - Build both packages
    - Publish to PyPI
-   - Create a release on GitHub
+   - Create a release draft on GitHub
 
-Alternatively, you can manually trigger the release workflow from the GitHub Actions tab after pushing the version changes.
+5. Review the release draft:
+   - Check the release notes and make any necessary edits
+   - Publish the release on GitHub

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # MCP Client for Ollama (ollmcp)
 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/mcp-client-for-ollama?cacheSeconds=1)
-[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI - Python Version](https://img.shields.io/pypi/v/ollmcp?label=ollmcp)](https://pypi.org/project/ollmcp/)
 [![PyPI - Python Version](https://img.shields.io/pypi/v/mcp-client-for-ollama?label=mcp-client-for-ollama)](https://pypi.org/project/mcp-client-for-ollama/)
 [![CI](https://github.com/jonigl/mcp-client-for-ollama/actions/workflows/ci.yml/badge.svg)](https://github.com/jonigl/mcp-client-for-ollama/actions/workflows/ci.yml)
@@ -108,7 +108,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 
 ## Requirements
 
-- **Python 3.10+** ([Installation guide](https://www.python.org/downloads/))
+- **Python 3.11+** ([Installation guide](https://www.python.org/downloads/))
 - **Ollama** running locally ([Installation guide](https://ollama.com/download))
   - After installation, run `ollama list` to see available models. If no models are installed, you can pull one using `ollama pull <model_name>`. For example, `ollama pull gemma4:latest`.
 - **UV package manager** ([Installation guide](https://github.com/astral-sh/uv))

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@
 - [Quick Start](#quick-start)
 - [Installation options](#installation-options)
   - ✨**NEW** [Managing MCP Servers via CLI](#managing-mcp-servers-via-cli)
+    - [mcp add options](#mcp-add-options)
+    - [Scopes](#scopes)
   - [Command-line Arguments](#command-line-arguments)
+  - ✨**NEW** [Supported Providers](#supported-providers)
   - [Usage Examples](#usage-examples)
   - [How Tool Calls Work](#how-tool-calls-work)
   - ✨**NEW** [Agent Mode](#agent-mode)
@@ -43,12 +46,18 @@
   - [Advanced Model Configuration](#advanced-model-configuration)
   - [Server Reloading for Development](#server-reloading-for-development)
   - [Human-in-the-Loop (HIL) Tool Execution](#human-in-the-loop-hil-tool-execution)
+    - [Human-in-the-Loop (HIL) Configuration](#human-in-the-loop-hil-configuration)
   - ✨**NEW** [MCP Prompts](#mcp-prompts)
   - ✨**NEW** [MCP Resources](#mcp-resources)
   - [Performance Metrics](#performance-metrics)
   - ✨**NEW** [History Management](#history-management)
 - [Autocomplete and Prompt Features](#autocomplete-and-prompt-features)
+  - [Typer Shell Autocompletion](#typer-shell-autocompletion)
+  - [FZF-style Autocomplete](#fzf-style-autocomplete)
+  - [MCP Prompts Autocomplete](#mcp-prompts-autocomplete)
+  - [Contextual Prompt](#contextual-prompt)
 - [Configuration Management](#configuration-management)
+  - ✨**NEW** [Per-provider profiles](#per-provider-profiles)
 - [Server Configuration Format](#server-configuration-format)
   - [Tips: Where to Put MCP Server Configs and a Working Example](#tips-where-to-put-mcp-server-configs-and-a-working-example)
 - [Compatible Models](#compatible-models)
@@ -70,6 +79,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 - 📋 **MCP Prompts Support**: Browse, invoke, and manage prompts from MCP servers with argument collection, preview, and safe rollback
 - 📦 **MCP Resources Support**: Browse and read contextual data from MCP servers including files, documents, and structured data
 - ☁️ **Ollama Cloud Support**: Works seamlessly with Ollama Cloud models for tool calling, enabling access to powerful cloud-hosted models while using local MCP tools
+- 🌍 **Multiple LLM Providers**: Use Ollama (default) or OpenAI-compatible providers (OpenAI, OpenRouter, DeepSeek, etc.), with connection settings remembered per provider
 - 🎨 **Rich Terminal Interface**: Interactive console UI with modern styling
 - 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
 - 📝 **Answer Display Modes**: Switch between Plain, Markdown, or Both response views while streaming
@@ -197,7 +207,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!NOTE]
 > Servers added via `ollmcp mcp add` are always loaded as the base layer. Any flags (`--mcp-server`, `--mcp-server-url`, `--servers-json`, `--claude-desktop`) add on top. To include servers from Claude Desktop, pass `--claude-desktop` explicitly.
 >
-> If a server with the same name is also provided via one of those flags, both connections are currently opened, but only one is kept active under that name — avoid reusing a registry server's name in `--mcp-server`/`--mcp-server-url`/`--servers-json`/`--claude-desktop`.
+> If a server with the same name is also provided via one of those flags, both connections are currently opened, but only one is kept active under that name. Avoid reusing a registry server's name in `--mcp-server`/`--mcp-server-url`/`--servers-json`/`--claude-desktop`.
 
 ### Command-line Arguments
 
@@ -218,12 +228,17 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--claude-desktop`: Load servers from Claude Desktop's config file (`~/Library/Application Support/Claude/claude_desktop_config.json`). Merged with servers added via `ollmcp mcp add` and any other flags.
 
 > [!IMPORTANT]
-> **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically — they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
+> **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically, they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
 
-#### Ollama Configuration:
+#### LLM Provider Configuration:
 
-- `--model`, `-m` MODEL: Ollama model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
-- `--host`, `-H` HOST: Ollama host URL. Default: `http://localhost:11434`
+- `--model`, `-m` MODEL: Model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
+- `--provider`, `-p` PROVIDER: LLM provider to use (e.g. `ollama`, `openai`, `openrouter`, `deepseek`). Default: `ollama`
+- `--host`, `-H` HOST: LLM host / API base URL. Defaults to Ollama's `http://localhost:11434` for the `ollama` provider, or the provider's own default endpoint otherwise.
+- `--api-key`, `-k` KEY: API key for the LLM provider. Also read from the `$OLLMCP_API_KEY` environment variable, which is **provider-agnostic** (it applies to whichever provider you select with `--provider`). Keys passed via `$OLLMCP_API_KEY` are never written to the config file; only keys passed with `--api-key` are saved. Not needed for `ollama`.
+
+> [!NOTE]
+> Currently supported providers: `ollama`, `openai`, and any OpenAI-compatible provider (`openrouter`, `deepseek`, `perplexity`, etc.). More providers coming soon.
 
 #### General Options:
 
@@ -231,6 +246,60 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--help`, `-h`: Show help message and exit
 - `--install-completion`: Install shell autocompletion scripts for the client
 - `--show-completion`: Show available shell completion options
+
+### Supported Providers
+
+> [!WARNING]
+> **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.
+
+ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` — both work for **any** selected provider — or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
+
+| Provider (`--provider`) | API key env var |
+|---|---|
+| [`ollama`](https://github.com/ollama/ollama) (default) | - (local) |
+| [`azureopenai`](https://learn.microsoft.com/en-us/azure/ai-foundry/) | `AZURE_OPENAI_API_KEY` |
+| [`dashscope`](https://bailian.console.aliyun.com/cn-beijing/?tab=api#/api) | `DASHSCOPE_API_KEY` |
+| [`databricks`](https://docs.databricks.com/) | `DATABRICKS_TOKEN` |
+| [`deepinfra`](https://deepinfra.com/docs/openai_api) | `DEEPINFRA_API_KEY` |
+| [`deepseek`](https://platform.deepseek.com/) | `DEEPSEEK_API_KEY` |
+| [`fireworks`](https://fireworks.ai/api) | `FIREWORKS_API_KEY` |
+| [`gateway`](https://github.com/mozilla-ai/any-llm) | `GATEWAY_API_KEY` |
+| [`inception`](https://inceptionlabs.ai/) | `INCEPTION_API_KEY` |
+| [`llama`](https://www.llama.com/products/llama-api/) | `LLAMA_API_KEY` |
+| [`llamacpp`](https://github.com/ggml-org/llama.cpp) | - (local) |
+| [`llamafile`](https://github.com/Mozilla-Ocho/llamafile) | - (local) |
+| [`lmstudio`](https://lmstudio.ai/) | `LM_STUDIO_API_KEY` |
+| [`minimax`](https://www.minimax.io/platform_overview) | `MINIMAX_API_KEY` |
+| [`moonshot`](https://platform.moonshot.ai/) | `MOONSHOT_API_KEY` |
+| [`mzai`](https://any-llm.ai) | `ANY_LLM_KEY` |
+| [`nebius`](https://studio.nebius.ai/) | `NEBIUS_API_KEY` |
+| [`openai`](https://platform.openai.com/docs/api-reference) | `OPENAI_API_KEY` |
+| [`openrouter`](https://openrouter.ai/docs) | `OPENROUTER_API_KEY` |
+| [`perplexity`](https://docs.perplexity.ai/) | `PERPLEXITY_API_KEY` |
+| [`portkey`](https://portkey.ai/docs) | `PORTKEY_API_KEY` |
+| [`qiniu`](https://developer.qiniu.com/aitokenapi) | `QINIU_API_KEY` |
+| [`sambanova`](https://sambanova.ai/) | `SAMBANOVA_API_KEY` |
+| [`vllm`](https://docs.vllm.ai/) | `VLLM_API_KEY` |
+| [`zai`](https://docs.z.ai/guides/develop/python/introduction) | `ZAI_API_KEY` |
+
+> [!NOTE]
+> Local OpenAI-compatible servers (`ollama`, `llamacpp`, `llamafile`, `lmstudio`, `vllm`) typically run without an API key, point ollmcp at them with `--host`. Providers any-llm offers that are **not** OpenAI-compatible (e.g. `anthropic`, `gemini`, `mistral`, `groq`, `cohere`) are not supported yet.
+
+> [!WARNING]
+> **Capability detection limitation:** ollmcp only reads real per-model capabilities (`tools`, `vision`, `thinking`) from Ollama. For every non-Ollama provider, all three capabilities are currently assumed available and shown as such in the model list and badges, so a model may be reported as supporting tools, vision, or thinking even when it doesn't. If a model lacks a capability, the provider's API will return an error when you try to use it.
+
+#### API key resolution order
+
+For the selected provider, ollmcp resolves the API key in this order, from **highest** to **lowest** precedence:
+
+1. The `--api-key` / `-k` flag.
+2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic — applies to whichever provider you selected with `--provider`).
+3. The per-provider key saved in `~/.config/ollmcp/config.json` (present only if it was once passed via `--api-key`).
+4. The provider's own native environment variable, detected by [any-llm](https://github.com/mozilla-ai/any-llm) (e.g. `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).
+
+> [!WARNING]
+> A saved per-provider key (3) takes precedence over the provider's native environment variable (4). So if you previously saved a **wrong or expired** key, setting `OPENAI_API_KEY` (or the equivalent) alone will **not** override it. To fix it, either pass the correct key with `--api-key`, or remove the stale `apiKey` from that provider's profile in `~/.config/ollmcp/config.json`.
+
 
 ### Usage Examples
 
@@ -279,6 +348,17 @@ ollmcp --host http://localhost:22545 --servers-json /path/to/servers.json
 # Or using short flags:
 ollmcp -H http://localhost:22545 -j /path/to/servers.json
 ```
+
+Use a different LLM provider (OpenAI or any OpenAI-compatible API):
+
+```bash
+ollmcp --provider openai --api-key $OPENAI_API_KEY --model gpt-5.5
+# OpenAI-compatible providers (e.g. OpenRouter, DeepSeek); override the endpoint with --host if needed:
+ollmcp --provider openrouter --api-key $OPENROUTER_API_KEY -m openrouter/free
+```
+
+> [!TIP]
+> Provider settings (model, host, API key) are remembered **per provider**. Once saved with `/save-config`, plain `ollmcp` resumes your last-used provider. See [Configuration Management](#configuration-management) for details.
 
 Connect to SSE or Streamable HTTP servers by URL:
 
@@ -808,18 +888,30 @@ This makes it easy to see your current context before entering a query.
 ## Configuration Management
 
 > [!TIP]
-> It will automatically load the default configuration from `~/.config/ollmcp/config.json` if it exists.
+> Running `ollmcp` with no flags automatically loads the default configuration from `~/.config/ollmcp/config.json` if it exists.
 
-The client supports saving and loading tool configurations between sessions:
+The client saves and loads your preferences between sessions:
 
-- When using `save-config`, you can provide a name for the configuration or use the default
-- Configurations are stored in `~/.config/ollmcp/` directory
+- When using `/save-config`, you can provide a name for the configuration or use the default
+- Configurations are stored in the `~/.config/ollmcp/` directory
 - The default configuration is saved as `~/.config/ollmcp/config.json`
 - Named configurations are saved as `~/.config/ollmcp/{name}.json`
 
-The configuration saves:
+### Per-provider profiles
 
-- Current model selection
+Connection settings are stored **per provider**, so switching providers never reuses another provider's model, host, or API key. Each provider keeps its own:
+
+- **Model** selection
+- **Host** / API base URL
+- **API key**
+
+The configuration also records a `defaultProvider`. When you run `ollmcp` with no `--provider` flag, it loads that provider's profile; a fresh install starts on `ollama`. Each time you `/save-config`, the provider you're currently using *becomes the new default*, so running plain `ollmcp` resumes wherever you left off. Pass `--provider <name>` at any time to switch to (and load) a different provider's profile, and `--model` / `--host` / `--api-key` override the saved values for that run.
+
+> [!NOTE]
+> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk — use one of those if you don't want your key persisted.
+
+The following settings are **shared** across all providers:
+
 - Advanced model parameters (system prompt, temperature, sampling settings, etc.)
 - Enabled/disabled status of all tools
 - Context retention settings
@@ -828,6 +920,24 @@ The configuration saves:
 - Tool execution display preferences
 - Performance metrics display preferences
 - Human-in-the-Loop confirmation settings
+
+**Example `~/.config/ollmcp/config.json`:**
+
+```json
+{
+  "defaultProvider": "openai",
+  "providers": {
+    "ollama": { "host": "http://localhost:11434", "model": "qwen3:1.7b", "apiKey": "" },
+    "openai": { "host": "", "model": "gpt-5.5", "apiKey": "sk-..." }
+  },
+  "enabledTools": {},
+  "modelConfig": {},
+  "...": "shared settings"
+}
+```
+
+> [!TIP]
+> Older flat config files (with top-level `host`/`model`/`provider`/`apiKey`) are migrated automatically the first time you run this version, and rewritten in the per-provider format on your next `/save-config`.
 
 ## Server Configuration Format
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 - 🌍 **Multiple LLM Providers**: Use Ollama (default) or OpenAI-compatible providers (OpenAI, OpenRouter, DeepSeek, etc.), with connection settings remembered per provider
 - 🎨 **Rich Terminal Interface**: Interactive console UI with modern styling
 - 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
-- 📝 **Answer Display Modes**: Switch between Plain, Markdown, or Both response views while streaming
+- 📝 **Answer Display Modes**: Switch between Plain, Markdown, Both, or Markdown (blocks) response views while streaming
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧑‍💻 **Human-in-the-Loop (HIL)**: Review and approve tool executions before they run for enhanced control and safety
 - 🎮 **Advanced Model Configuration**: Fine-tune 15+ model parameters including context window size, temperature, sampling, repetition control, and more
@@ -305,7 +305,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!WARNING]
 > **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.
 
-ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` — both work for **any** selected provider — or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
+ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` (both work for **any** selected provider) or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
 
 | Provider (`--provider`) | API key env var |
 |---|---|
@@ -346,7 +346,7 @@ ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-l
 For the selected provider, ollmcp resolves the API key in this order, from **highest** to **lowest** precedence:
 
 1. The `--api-key` / `-k` flag.
-2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic — applies to whichever provider you selected with `--provider`).
+2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic, applies to whichever provider you selected with `--provider`).
 3. The per-provider key saved in `~/.config/ollmcp/config.json` (present only if it was once passed via `--api-key`).
 4. The provider's own native environment variable, detected by [any-llm](https://github.com/mozilla-ai/any-llm) (e.g. `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).
 
@@ -473,7 +473,7 @@ During chat, use these commands:
 | `/loop-limit`    | `/ll`            | Set maximum iterative tool-loop iterations (Agent Mode). Default: 7 |
 | `/model`         | `/m`             | List and select a different Ollama model            |
 | `/model-config`  | `/mc`            | Configure advanced model parameters and system prompt |
-| `/display-mode`  | `/dm`            | Choose Plain, Markdown, or Both answer display modes |
+| `/display-mode`  | `/dm`            | Choose Plain, Markdown, Both, or Markdown (blocks) answer display modes |
 | `/input-mode`    | `/im`            | Choose Single-line or Multiline chat input mode     |
 | `/prompts`       | `/pr`            | Browse and view all available MCP prompts             |
 | `/server:prompt_name`   | `/prompt_name`      | Invoke a prompt (qualified is recommended) |
@@ -495,16 +495,18 @@ During chat, use these commands:
 The `display-mode` (`dm`) command lets you choose how model answers are shown while they stream:
 
 - **Plain**: Streams the response once as plain text with no final markdown re-render
-- **Markdown**: Renders the response as markdown during streaming with throttled redraws
-- **Both**: Streams plain text first, then renders the completed response again as markdown
+- **Markdown**: Renders the response as markdown during streaming with throttled redraws (live; can flicker or duplicate lines with emojis or when you resize the terminal)
+- **Both** (default): Streams plain text first, then renders the completed response again as markdown
+- ✨**NEW** **Markdown (blocks)**: Renders the response as markdown one block at a time, append-only each paragraph/list/table/code block prints once when it completes and is never redrawn, so it cannot duplicate lines
 
 Use `/display-mode` or `/dm` during chat to open the interactive picker.
 
 **Why you might switch modes:**
 
 - **Plain** is the least noisy option if you want minimal redraw or flicker
-- **Markdown** is useful when formatting matters more than raw token-by-token output
+- **Markdown** shows live markdown formatting, but its in-place redraws can flicker or duplicate lines with emojis/resizes
 - **Both** gives you fast streaming feedback plus a clean final markdown rendering
+- **Markdown (blocks)** is the most stable way to see formatted markdown while streaming, at the cost of block-by-block (rather than token-by-token) updates
 
 > [!TIP]
 > Your selected display mode is saved with `save-config` and restored with `load-config`, so you can keep different viewing preferences for different workflows.
@@ -961,7 +963,7 @@ Connection settings are stored **per provider**, so switching providers never re
 The configuration also records a `defaultProvider`. When you run `ollmcp` with no `--provider` flag, it loads that provider's profile; a fresh install starts on `ollama`. Each time you `/save-config`, the provider you're currently using *becomes the new default*, so running plain `ollmcp` resumes wherever you left off. Pass `--provider <name>` at any time to switch to (and load) a different provider's profile, and `--model` / `--host` / `--api-key` override the saved values for that run.
 
 > [!NOTE]
-> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk — use one of those if you don't want your key persisted.
+> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk, use one of those if you don't want your key persisted.
 
 The following settings are **shared** across all providers:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 
 ## Features
 
-- 🤖 **Agent Mode**: Iterative tool execution when models request multiple tool calls, with a configurable loop limit to prevent infinite loops
+- 🤖 **Agent Mode**: Iterative tool execution when models request multiple tool calls, with a configurable loop limit and interactive choices when the limit is reached (continue, wrap up, or abort)
 - 🌐 **Multi-Server Support**: Connect to multiple MCP servers simultaneously
 - 🚀 **Multiple Transport Types**: Supports STDIO, SSE, and Streamable HTTP server connections
 - 📋 **MCP Prompts Support**: Browse, invoke, and manage prompts from MCP servers with argument collection, preview, and safe rollback
@@ -1151,6 +1151,18 @@ Some models may request multiple tool calls in a single conversation. The client
 - This process repeats until the model provides a final answer or reaches the configured loop limit
 - You can set the maximum number of iterations using the `loop-limit` (`ll`) command
 - The default loop limit is `7` to prevent infinite loops
+
+#### When the loop limit is reached
+
+Instead of silently stopping, the client pauses and asks you how to proceed:
+
+| Choice | Key | Description |
+|--------|-----|-------------|
+| **Continue** | `c` *(default)* | Grant another batch of iterations (same size as the current limit) |
+| **Number** | `n` | Choose exactly how many more iterations to allow |
+| **Unlimited** | `u` | Remove the cap and run until the model stops requesting tools |
+| **Wrap up** | `w` | Ask the model to summarise what it gathered so far and produce a final answer — preserves all tool results collected before the limit |
+| **Abort** | `a` | Discard the turn entirely (nothing saved to history) |
 
 > [!NOTE]
 > If you want to prevent using Agent Mode, simply set the loop limit to `1`.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,16 @@
 - [Requirements](#requirements)
 - [Quick Start](#quick-start)
 - [Installation options](#installation-options)
-  - ✨**NEW** [Managing MCP Servers via CLI](#managing-mcp-servers-via-cli)
+  - [Troubleshooting](#troubleshooting)
+- ✨**NEW** [Managing MCP Servers via CLI](#managing-mcp-servers-via-cli)
     - [mcp add options](#mcp-add-options)
     - [Scopes](#scopes)
   - [Command-line Arguments](#command-line-arguments)
-  - ✨**NEW** [Supported Providers](#supported-providers)
+    - [MCP Server Configuration](#mcp-server-configuration)
+    - ✨**NEW** [Inference Provider Configuration](#inference-provider-configuration)
+    - [General Options](#general-options)
+  - ✨**NEW** [Supported Inference Providers](#supported-inference-providers)
+    - [API key resolution order](#api-key-resolution-order)
   - [Usage Examples](#usage-examples)
   - [How Tool Calls Work](#how-tool-calls-work)
   - ✨**NEW** [Agent Mode](#agent-mode)
@@ -118,17 +123,26 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 Install `ollmcp` via pip, add an MCP server, and run the client:
 
 ```bash
-# Install ollmcp via pip
+# Install ollmcp via uv
+uv tool install --upgrade ollmcp
+# or via pip
 pip install --upgrade ollmcp
 # Add an MCP server (example: playwright stdio server)
 ollmcp mcp add playwright -- npx @playwright/mcp@latest
-# Run the client
-ollmcp
+# Run the client (check optional flags with `ollmcp --help`)
+ollmcp # once running, use /help for interactive commands
 ```
 
 ## Installation Options
 
-**Option 1:** Install with pip and run
+**Option 1:** Install with uv and run (recommended)
+
+```bash
+uv tool install --upgrade ollmcp
+ollmcp
+```
+
+**Option 2:** Install with pip and run
 
 ```bash
 pip install --upgrade ollmcp
@@ -146,10 +160,49 @@ uvx ollmcp
 ```bash
 git clone https://github.com/jonigl/mcp-client-for-ollama.git
 cd mcp-client-for-ollama
-uv venv && source .venv/bin/activate
-uv pip install .
 uv run -m mcp_client_for_ollama
 ```
+
+## Troubleshooting
+
+### `Could not find a version that satisfies the requirement ollmcp (from versions: none)`
+
+This almost always means the Python you are using is **older than the required 3.11+**. This is common on macOS, where the system Python (`/usr/bin/python3`) or the Xcode-bundled Python can be 3.9 or older. When no release matches `requires-python >= 3.11`, pip filters out every version and reports the misleading "from versions: none".
+
+First check your version:
+
+```bash
+python3 --version   # must be 3.11 or newer
+```
+
+Then install with a modern Python. The simplest option is `uv`, which fetches a suitable Python for you automatically:
+
+```bash
+uv tool install --upgrade ollmcp   # recommended, installs the CLI in an isolated environment
+# or, if you prefer pip, make sure to use a Python 3.11+ interpreter:
+python3.11 -m pip install --upgrade ollmcp
+# Then run the client:
+ollmcp
+```
+Take a look to the [Installation Options](#installation-options).
+
+### `error: externally-managed-environment` (PEP 668)
+
+On recent Debian/Ubuntu (Python 3.12+), the system `pip` is intentionally locked to protect OS-managed packages, so `pip install ollmcp` is blocked. This is a system policy ([PEP 668](https://peps.python.org/pep-0668/)), not an issue with ollmcp. Install it into an isolated environment instead:
+
+```bash
+uv tool install --upgrade ollmcp   # recommended, installs the CLI in an isolated environment
+# or, if you prefer pip, use a virtual environment:
+python3.11 -m venv ollmcp-env
+source ollmcp-env/bin/activate
+python3.11 -m pip install --upgrade ollmcp
+# Then run the client:
+ollmcp
+```
+Take a look to the [Installation Options](#installation-options).
+
+> [!WARNING]
+> Avoid `pip install --break-system-packages ollmcp`. It works, but it installs into the system Python and can break packages your OS depends on.
 
 ## Managing MCP Servers via CLI
 
@@ -230,7 +283,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!IMPORTANT]
 > **Breaking change:** `--auto-discovery` / `-a` has been replaced by `--claude-desktop`. Additionally, servers added via `ollmcp mcp add` are now always loaded automatically, they are no longer a fallback that disappears when other flags are used. Claude Desktop servers are never loaded automatically; use `--claude-desktop` to include them.
 
-#### LLM Provider Configuration:
+#### Inference Provider Configuration:
 
 - `--model`, `-m` MODEL: Model to use. Default: your saved configuration's model if set, otherwise the first model available in Ollama
 - `--provider`, `-p` PROVIDER: LLM provider to use (e.g. `ollama`, `openai`, `openrouter`, `deepseek`). Default: `ollama`
@@ -247,7 +300,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--install-completion`: Install shell autocompletion scripts for the client
 - `--show-completion`: Show available shell completion options
 
-### Supported Providers
+### Supported Inference Providers
 
 > [!WARNING]
 > **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
   - [MCP Tools](#mcp-tools)
   - [Model Selection](#model-selection)
   - [Advanced Model Configuration](#advanced-model-configuration)
+  - ✨**NEW** [Thinking Mode and Reasoning Effort](#thinking-mode-and-reasoning-effort)
   - [Server Reloading for Development](#server-reloading-for-development)
   - [Human-in-the-Loop (HIL) Tool Execution](#human-in-the-loop-hil-tool-execution)
     - [Human-in-the-Loop (HIL) Configuration](#human-in-the-loop-hil-configuration)
@@ -96,6 +97,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 - 🎨 **Enhanced Tool Display**: Beautiful, structured visualization of tool executions with JSON syntax highlighting
 - 🧠 **Context Management**: Control conversation memory with configurable retention settings
 - 🤔 **Thinking Mode**: Advanced reasoning capabilities with visible thought processes for supported models (e.g., gpt-oss, deepseek-r1, qwen3, etc.)
+- 💪 **Reasoning Effort Levels**: Set reasoning effort to auto, minimal, low, medium, high, or xhigh for supported models
 - 🖼️ **Vision Tool Support**: Images returned by tools are automatically forwarded to vision-capable models
  - 🗣️ **Cross-Language Support**: Seamlessly work with both Python and JavaScript MCP servers
  - 📜 **History Management**: View full conversation history, export to JSON for backup/analysis, and import previous sessions for continuity
@@ -486,6 +488,7 @@ During chat, use these commands:
 | `/show-metrics`  | `/sm`            | Toggle performance metrics display                  |
 | `/show-thinking` | `/st`            | Toggle thinking text visibility (visible by default) |
 | `/thinking-mode` | `/tm`            | Toggle thinking mode on supported models            |
+| `/reasoning-effort` | `/re`         | Set reasoning effort level (auto/minimal/low/medium/high/xhigh) when thinking mode is on. Default: medium |
 | `/show-tool-execution` | `/ste`      | Toggle tool execution display visibility            |
 | `/tools`         | `/t`             | Open the tool selection interface                   |
 
@@ -596,6 +599,25 @@ The `model-config` (`mc`) command opens the advanced model settings interface, a
 
 > [!TIP]
 > All parameters default to unset, letting Ollama use its own optimized values. Use `help` in the config menu for details and recommendations. Changes are saved with your configuration.
+
+
+### Thinking Mode and Reasoning Effort
+
+Enable thinking mode with `/thinking-mode` (`/tm`) to activate extended reasoning on supported models (e.g., `qwen3`, `deepseek-r1`, Claude with extended thinking). Use `/show-thinking` (`/st`) to toggle whether the reasoning process is visible in the response.
+
+Use `/reasoning-effort` (`/re`) to control **how much reasoning effort** the model applies when thinking mode is on:
+
+| Level | Description |
+|-------|-------------|
+| `auto` | Provider's default effort (recommended for cloud) |
+| `minimal` | Fastest, least reasoning |
+| `low` | Light reasoning |
+| `medium` | Balanced — **default** |
+| `high` | More thorough reasoning |
+| `xhigh` | Maximum reasoning effort |
+
+> [!NOTE]
+> Some providers or models may ignore reasoning effort settings.
 
 
 ### Server Reloading for Development

--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@
     - [API key resolution order](#api-key-resolution-order)
   - [Usage Examples](#usage-examples)
   - [How Tool Calls Work](#how-tool-calls-work)
-  - ✨**NEW** [Agent Mode](#agent-mode)
+  - [Agent Mode](#agent-mode)
 - [Interactive Commands](#interactive-commands)
-  - ✨**NEW** [Answer Display Modes](#answer-display-modes)
-  - ✨**NEW** [Input Mode](#input-mode)
   - [MCP Tools](#mcp-tools)
+  - [MCP Prompts](#mcp-prompts)
+  - [MCP Resources](#mcp-resources)
+  - ✨**NEW** [Answer Display Modes](#answer-display-modes)
+  - [Input Mode](#input-mode)
   - [Model Selection](#model-selection)
   - [Advanced Model Configuration](#advanced-model-configuration)
   - ✨**NEW** [Thinking Mode and Reasoning Effort](#thinking-mode-and-reasoning-effort)
   - [Server Reloading for Development](#server-reloading-for-development)
   - [Human-in-the-Loop (HIL) Tool Execution](#human-in-the-loop-hil-tool-execution)
     - [Human-in-the-Loop (HIL) Configuration](#human-in-the-loop-hil-configuration)
-  - ✨**NEW** [MCP Prompts](#mcp-prompts)
-  - ✨**NEW** [MCP Resources](#mcp-resources)
   - [Performance Metrics](#performance-metrics)
-  - ✨**NEW** [History Management](#history-management)
+  - [History Management](#history-management)
 - [Autocomplete and Prompt Features](#autocomplete-and-prompt-features)
   - [Typer Shell Autocompletion](#typer-shell-autocompletion)
   - [FZF-style Autocomplete](#fzf-style-autocomplete)
@@ -493,6 +493,168 @@ During chat, use these commands:
 | `/tools`         | `/t`             | Open the tool selection interface                   |
 
 
+### MCP Tools
+
+The tool and server selection interface allows you to enable or disable specific tools:
+
+![ollmcp tool and server selection interface](https://github.com/jonigl/mcp-client-for-ollama/blob/main/misc/ollmpc-tool-and-server-selection.png?raw=true)
+
+- Enter **numbers** separated by commas (e.g. `1,3,5`) to toggle specific tools
+- Enter **ranges** of numbers (e.g. `5-8`) to toggle multiple consecutive tools
+- Enter **S + number** (e.g. `S1`) to toggle all tools in a specific server
+- `a` or `all` - Enable all tools
+- `n` or `none` - Disable all tools
+- `d` or `desc` - Show/hide tool descriptions
+- `j` or `json` - Show detailed tool JSON schemas on enabled tools for debugging purposes
+- `s` or `save` - Save changes and return to chat
+- `q` or `quit` - Cancel changes and return to chat
+
+
+### MCP Prompts
+
+MCP Prompts provide reusable, server-defined conversation starters and context templates. Servers can expose prompts with descriptions, required arguments, and pre-formatted messages that help you quickly start specific types of conversations or inject structured context into your chat.
+
+#### Features
+
+- 📋 **Browse Prompts**: View all available prompts from connected servers with descriptions and argument requirements
+- ⚡️ **Quick Invocation**: Use slash syntax to invoke prompts (`/server:prompt_name` recommended)
+- 🔤 **Autocomplete**: Type `/` to see prompt suggestions with fuzzy matching
+- 📝 **Argument Collection**: Interactive prompts guide you through required parameters
+- 👁️ **Preview**: Review prompt content before injection to ensure it fits your needs
+- 🎯 **Flexible Injection**: Choose to execute immediately or inject-only (add to history without triggering model)
+- 🧠 **Context-Aware**: Automatically adapts behavior based on whether prompt ends with user or assistant message
+- 🔄 **Safe Rollback**: Automatic history cleanup if you abort or encounter errors
+- 💬 **Text Content**: Supports text-based prompt messages (image/audio/resource support coming soon)
+
+#### How to Use MCP Prompts
+
+**Browse Available Prompts:**
+```
+/prompts  # or '/pr'
+```
+This displays all prompts grouped by server, showing their names, required arguments, and descriptions.
+
+**Invoke a Prompt:**
+```
+/server:prompt_name
+```
+For example, if a server named `docs` provides a "summarize" prompt:
+```
+/docs:summarize
+```
+
+If a prompt name is unique across connected servers, you can use the short form:
+```
+/summarize
+```
+
+If multiple servers expose the same prompt name, the client will ask you to use the qualified form and suggest valid `/server:prompt_name` options.
+
+**Autocomplete:**
+- Type `/` to see all available prompts with descriptions
+- Continue typing to filter prompts with fuzzy matching
+- Use arrow keys to navigate and press Enter to select
+
+> [!TIP]
+> Prompts are discovered automatically when you connect to MCP servers. If a server supports prompts, they'll be available immediately in the `prompts` list and autocomplete.
+
+**Workflow:**
+1. Type `/server:prompt_name` (recommended) or select from autocomplete
+2. If the prompt requires arguments, you'll be prompted to provide them
+3. Review the prompt preview showing what will be injected
+4. Choose how to use the prompt:
+   - **y/yes** (default): Send the prompt to the model and get a response
+     - For prompts ending with a **user message**: Uses that message as the query
+     - For prompts ending with an **assistant message**: Adds "Please respond based on the above context." as the query
+   - **i/inject**: Just add the prompt to conversation history without triggering the model (lets you type your own query afterward)
+   - **n/no**: Cancel and return to chat
+5. The prompt is injected based on your choice
+6. If you abort during model generation (press 'a'), changes are automatically rolled back
+
+**Example:**
+![ollmcp prompt feature screenshot](https://github.com/jonigl/mcp-client-for-ollama/blob/main/misc/ollmcp-prompt-feature.png?raw=true)
+
+> [!WARNING]
+> **Content Type Limitations**: MCP Prompts currently support **text content only**. The following content types are not yet supported and will be automatically skipped:
+> - 🖼️ **Images** - Image content in prompts
+> - 🎵 **Audio** - Audio content in prompts
+> - 📦 **Resources** - Embedded resource content
+
+### MCP Resources
+
+MCP Resources provide access to contextual data exposed by MCP servers-files, documents, structured data, and more. Servers can expose resources with metadata (name, description, MIME type) that you can browse and read into your conversation context.
+
+#### Features
+
+- 📋 **Browse Resources**: View all available resources from connected servers with URIs, names, MIME types, and descriptions
+- 📖 **Read Resources**: Use `@uri` syntax to read resource content, standalone or inline within a query
+- 📝 **Text Content**: Full support for text-based resources (markdown, code, logs, etc.)
+- 🖼️ **Vision Image Support**: Image resources (`image/*`) are automatically forwarded as base64 images to vision-capable models
+- 🎯 **Context Injection**: Resource content is buffered and injected as context alongside your next query
+- 🔍 **Autocomplete**: Type `@` to see available resource and template suggestions with fuzzy matching
+- 🛡️ **Binary Safety**: Non-image binary content (audio, video, PDFs, archives) is detected and gracefully skipped with informative messages
+
+#### How to Use MCP Resources
+
+**Browse Available Resources:**
+```
+/resources  # or '/res'
+```
+This displays all resources and templates grouped by server, showing URIs, names, MIME types, and descriptions. Binary resources are marked with a `[binary]` tag and templates with a `[template]` tag.
+
+**Read a Resource:**
+```
+@<uri>
+```
+For example, to read a file resource:
+```
+@file:///path/to/document.md
+```
+
+There are two ways to use `@uri`:
+
+**1. Standalone (buffer then query):** Type `@uri` on its own. The resource is fetched and buffered. Then type your query on the next prompt. The resource content is injected as context automatically.
+
+**2. Inline (single turn):** Include `@uri` anywhere inside your query text. The resource is fetched and the query is processed immediately in one step.
+
+**Standalone example:**
+```
+qwen3/show-thinking/6-tools❯ @server://info
+✅ Read resource 'get_server_info' (197 chars)
+
+Preview:
+This is a simple MCP server with streamable HTTP transport. It supports tools for greeting, adding numbers, generating
+random numbers, and calculating BMI. It also provides a BMI calculator prompt.
+
+1 resource(s) buffered. Type your query, or include @another_uri inline.
+
+qwen3/show-thinking/6-tools❯ Next question here
+```
+
+**Inline example:**
+```
+qwen3/show-thinking/6-tools❯ summarize the key features from @server://info
+✅ Read resource 'get_server_info' (197 chars)
+
+Preview:
+This is a simple MCP server with streamable HTTP transport. It supports tools for greeting, adding numbers, generating
+random numbers, and calculating BMI. It also provides a BMI calculator prompt.
+[model response]
+```
+
+> [!TIP]
+> Resources are discovered automatically when you connect to MCP servers. If a server supports resources, they'll be available immediately in the `resources` list and `@` autocomplete.
+
+> [!NOTE]
+> 🖼️ **Images** (`image/*`) **are** supported, they are passed directly to vision-capable models as base64 data.
+> **Binary Content**: The following resource types are **not** supported as context and will be skipped with an informative message:
+> - 🎵 **Audio** - `audio/*` MIME types
+> - 📹 **Video** - `video/*` MIME types
+> - 📄 **PDFs** - `application/pdf`
+> - 🗜️ **Archives** - `application/zip`, `application/octet-stream`
+>
+
+
 ### Answer Display Modes
 
 The `display-mode` (`dm`) command lets you choose how model answers are shown while they stream:
@@ -527,22 +689,6 @@ Use `/input-mode` or `/im` during chat to open the interactive picker.
 > [!IMPORTANT]
 > Multiline send shortcuts can vary by terminal emulator and OS keyboard handling. This client relies on **Esc then Enter** as the portable submit shortcut in multiline mode. **Shift+Enter** and **Meta+Enter** may work in some terminals, but they are not guaranteed.
 
-
-### MCP Tools
-
-The tool and server selection interface allows you to enable or disable specific tools:
-
-![ollmcp tool and server selection interface](https://github.com/jonigl/mcp-client-for-ollama/blob/main/misc/ollmpc-tool-and-server-selection.png?raw=true)
-
-- Enter **numbers** separated by commas (e.g. `1,3,5`) to toggle specific tools
-- Enter **ranges** of numbers (e.g. `5-8`) to toggle multiple consecutive tools
-- Enter **S + number** (e.g. `S1`) to toggle all tools in a specific server
-- `a` or `all` - Enable all tools
-- `n` or `none` - Disable all tools
-- `d` or `desc` - Show/hide tool descriptions
-- `j` or `json` - Show detailed tool JSON schemas on enabled tools for debugging purposes
-- `s` or `save` - Save changes and return to chat
-- `q` or `quit` - Cancel changes and return to chat
 
 ### Model Selection
 
@@ -694,150 +840,6 @@ When prompted, you can choose from the following options:
 - **Flexible Workflow**: Session mode for efficient multi-tool queries, individual approval for sensitive operations
 - **Clean Abort**: Stop problematic queries immediately without polluting conversation history
 - **Peace of Mind**: Full visibility and control over automated actions
-
-### MCP Prompts
-
-MCP Prompts provide reusable, server-defined conversation starters and context templates. Servers can expose prompts with descriptions, required arguments, and pre-formatted messages that help you quickly start specific types of conversations or inject structured context into your chat.
-
-#### Features
-
-- 📋 **Browse Prompts**: View all available prompts from connected servers with descriptions and argument requirements
-- ⚡️ **Quick Invocation**: Use slash syntax to invoke prompts (`/server:prompt_name` recommended)
-- 🔤 **Autocomplete**: Type `/` to see prompt suggestions with fuzzy matching
-- 📝 **Argument Collection**: Interactive prompts guide you through required parameters
-- 👁️ **Preview**: Review prompt content before injection to ensure it fits your needs
-- 🎯 **Flexible Injection**: Choose to execute immediately or inject-only (add to history without triggering model)
-- 🧠 **Context-Aware**: Automatically adapts behavior based on whether prompt ends with user or assistant message
-- 🔄 **Safe Rollback**: Automatic history cleanup if you abort or encounter errors
-- 💬 **Text Content**: Supports text-based prompt messages (image/audio/resource support coming soon)
-
-#### How to Use MCP Prompts
-
-**Browse Available Prompts:**
-```
-/prompts  # or '/pr'
-```
-This displays all prompts grouped by server, showing their names, required arguments, and descriptions.
-
-**Invoke a Prompt:**
-```
-/server:prompt_name
-```
-For example, if a server named `docs` provides a "summarize" prompt:
-```
-/docs:summarize
-```
-
-If a prompt name is unique across connected servers, you can use the short form:
-```
-/summarize
-```
-
-If multiple servers expose the same prompt name, the client will ask you to use the qualified form and suggest valid `/server:prompt_name` options.
-
-**Autocomplete:**
-- Type `/` to see all available prompts with descriptions
-- Continue typing to filter prompts with fuzzy matching
-- Use arrow keys to navigate and press Enter to select
-
-> [!TIP]
-> Prompts are discovered automatically when you connect to MCP servers. If a server supports prompts, they'll be available immediately in the `prompts` list and autocomplete.
-
-**Workflow:**
-1. Type `/server:prompt_name` (recommended) or select from autocomplete
-2. If the prompt requires arguments, you'll be prompted to provide them
-3. Review the prompt preview showing what will be injected
-4. Choose how to use the prompt:
-   - **y/yes** (default): Send the prompt to the model and get a response
-     - For prompts ending with a **user message**: Uses that message as the query
-     - For prompts ending with an **assistant message**: Adds "Please respond based on the above context." as the query
-   - **i/inject**: Just add the prompt to conversation history without triggering the model (lets you type your own query afterward)
-   - **n/no**: Cancel and return to chat
-5. The prompt is injected based on your choice
-6. If you abort during model generation (press 'a'), changes are automatically rolled back
-
-**Example:**
-![ollmcp prompt feature screenshot](https://github.com/jonigl/mcp-client-for-ollama/blob/main/misc/ollmcp-prompt-feature.png?raw=true)
-
-> [!WARNING]
-> **Content Type Limitations**: MCP Prompts currently support **text content only**. The following content types are not yet supported and will be automatically skipped:
-> - 🖼️ **Images** - Image content in prompts
-> - 🎵 **Audio** - Audio content in prompts
-> - 📦 **Resources** - Embedded resource content
-
-### MCP Resources
-
-MCP Resources provide access to contextual data exposed by MCP servers-files, documents, structured data, and more. Servers can expose resources with metadata (name, description, MIME type) that you can browse and read into your conversation context.
-
-#### Features
-
-- 📋 **Browse Resources**: View all available resources from connected servers with URIs, names, MIME types, and descriptions
-- 📖 **Read Resources**: Use `@uri` syntax to read resource content, standalone or inline within a query
-- 📝 **Text Content**: Full support for text-based resources (markdown, code, logs, etc.)
-- 🖼️ **Vision Image Support**: Image resources (`image/*`) are automatically forwarded as base64 images to vision-capable models
-- 🎯 **Context Injection**: Resource content is buffered and injected as context alongside your next query
-- 🔍 **Autocomplete**: Type `@` to see available resource and template suggestions with fuzzy matching
-- 🛡️ **Binary Safety**: Non-image binary content (audio, video, PDFs, archives) is detected and gracefully skipped with informative messages
-
-#### How to Use MCP Resources
-
-**Browse Available Resources:**
-```
-/resources  # or '/res'
-```
-This displays all resources and templates grouped by server, showing URIs, names, MIME types, and descriptions. Binary resources are marked with a `[binary]` tag and templates with a `[template]` tag.
-
-**Read a Resource:**
-```
-@<uri>
-```
-For example, to read a file resource:
-```
-@file:///path/to/document.md
-```
-
-There are two ways to use `@uri`:
-
-**1. Standalone (buffer then query):** Type `@uri` on its own. The resource is fetched and buffered. Then type your query on the next prompt. The resource content is injected as context automatically.
-
-**2. Inline (single turn):** Include `@uri` anywhere inside your query text. The resource is fetched and the query is processed immediately in one step.
-
-**Standalone example:**
-```
-qwen3/show-thinking/6-tools❯ @server://info
-✅ Read resource 'get_server_info' (197 chars)
-
-Preview:
-This is a simple MCP server with streamable HTTP transport. It supports tools for greeting, adding numbers, generating
-random numbers, and calculating BMI. It also provides a BMI calculator prompt.
-
-1 resource(s) buffered. Type your query, or include @another_uri inline.
-
-qwen3/show-thinking/6-tools❯ Next question here
-```
-
-**Inline example:**
-```
-qwen3/show-thinking/6-tools❯ summarize the key features from @server://info
-✅ Read resource 'get_server_info' (197 chars)
-
-Preview:
-This is a simple MCP server with streamable HTTP transport. It supports tools for greeting, adding numbers, generating
-random numbers, and calculating BMI. It also provides a BMI calculator prompt.
-[model response]
-```
-
-> [!TIP]
-> Resources are discovered automatically when you connect to MCP servers. If a server supports resources, they'll be available immediately in the `resources` list and `@` autocomplete.
-
-> [!NOTE]
-> 🖼️ **Images** (`image/*`) **are** supported, they are passed directly to vision-capable models as base64 data.
-> **Binary Content**: The following resource types are **not** supported as context and will be skipped with an informative message:
-> - 🎵 **Audio** - `audio/*` MIME types
-> - 📹 **Video** - `video/*` MIME types
-> - 📄 **PDFs** - `application/pdf`
-> - 🗜️ **Archives** - `application/zip`, `application/octet-stream`
->
 
 
 ### Performance Metrics

--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -3,7 +3,7 @@ name = "ollmcp"
 version = "0.30.0"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "MIT"
 authors = [
     {name = "Jonathan Löwenstern"}

--- a/cli-package/pyproject.toml
+++ b/cli-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ollmcp"
-version = "0.30.0"
+version = "0.31.0"
 description = "CLI for MCP Client for Ollama - An easy-to-use command for interacting with Ollama through MCP"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "mcp-client-for-ollama==0.30.0"
+    "mcp-client-for-ollama==0.31.0"
 ]
 
 [project.scripts]

--- a/mcp_client_for_ollama/__init__.py
+++ b/mcp_client_for_ollama/__init__.py
@@ -1,3 +1,3 @@
 """MCP Client for Ollama package."""
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -1,5 +1,6 @@
 """MCP Client for Ollama - A TUI client for interacting with Ollama models and MCP servers"""
 import asyncio
+import json
 import os
 import sys
 import select
@@ -22,14 +23,17 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
-import ollama
 import httpx
+from any_llm import AnyLLM
+from any_llm.exceptions import MissingApiKeyError
 
 from . import __version__
 from .config.manager import ConfigManager
+from .config.defaults import default_config, default_provider_profile
 from .utils.version import check_for_updates
-from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
-from .utils.connection import preflight_ollama
+from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
+from .utils.connection import preflight_ollama, validate_provider
+from .utils.images import apply_images
 from .server.connector import ServerConnector
 from .server import registry
 from .server.cli_commands import mcp_app
@@ -64,17 +68,22 @@ class MCPClient:
         "multiline": "Multiline",
     }
 
-    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST):
+    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None, persist_api_key: bool = True):
         # Initialize session and client objects
         self.exit_stack = AsyncExitStack()
         self.host = host
-        self.ollama = ollama.AsyncClient(host=host)
+        self.provider = provider
+        self.api_key = api_key or ""
+        # Whether this key may be written to the config file. Keys coming from the
+        # OLLMCP_API_KEY env var (or a provider's native env var) are never persisted.
+        self.persist_api_key = persist_api_key
+        self.llm = AnyLLM.create(provider, api_key=api_key, api_base=host)
         self.console = Console()
         self.config_manager = ConfigManager(self.console)
         # Initialize the server connector
         self.server_connector = ServerConnector(self.exit_stack, self.console)
         # Initialize the model manager
-        self.model_manager = ModelManager(console=self.console, default_model=model, ollama=self.ollama)
+        self.model_manager = ModelManager(console=self.console, default_model=model, llm=self.llm, provider=provider, api_base=host, api_key=api_key or "")
         # Initialize the model config manager
         self.model_config_manager = ModelConfigManager(console=self.console)
         # Initialize the tool manager with server connector reference
@@ -306,15 +315,9 @@ class MCPClient:
         try:
             current_model = self.model_manager.get_current_model()
             # Query the model's capabilities using ollama.show()
-            model_info = await self.ollama.show(current_model)
-
-            # Check if the model has 'thinking' capability
-            if 'capabilities' in model_info and model_info['capabilities']:
-                return 'thinking' in model_info['capabilities']
-
-            return False
+            caps = await self.model_manager.fetch_capabilities(current_model)
+            return 'thinking' in caps
         except Exception:
-            # If we can't determine capabilities, assume no thinking support
             return False
 
     async def supports_vision(self) -> bool:
@@ -325,12 +328,8 @@ class MCPClient:
         """
         try:
             current_model = self.model_manager.get_current_model()
-            model_info = await self.ollama.show(current_model)
-
-            if 'capabilities' in model_info and model_info['capabilities']:
-                return 'vision' in model_info['capabilities']
-
-            return False
+            caps = await self.model_manager.fetch_capabilities(current_model)
+            return 'vision' in caps
         except Exception:
             return False
 
@@ -535,28 +534,24 @@ class MCPClient:
         # Get current model from the model manager
         model = self.model_manager.get_current_model()
 
-        # Get model options in Ollama format
-        model_options = self.model_config_manager.get_ollama_options()
-
-        # Prepare chat parameters
-        chat_params = {
-            "model": model,
-            "messages": messages,
-            "stream": True,
-            "tools": available_tools,
-            "options": model_options
-        }
-
         # Add thinking parameter if thinking mode is enabled and model supports it
         supports_thinking = await self.supports_thinking_mode()
-        if supports_thinking:
-            chat_params["think"] = self.thinking_mode
 
         # Check vision capability once for the entire query
         has_vision = await self.supports_vision()
 
-        # Initial Ollama API call with the query and available tools
-        stream = await self.ollama.chat(**chat_params)
+        # Initial LLM API call with the query and available tools
+        stream = await self.llm.acompletion(
+            model=model,
+            messages=apply_images(messages),
+            stream=True,
+            stream_options={"include_usage": True},
+            tools=available_tools or None,
+            **({
+                "reasoning_effort": "high"
+            } if supports_thinking and self.thinking_mode else {}),
+            **self.model_config_manager.get_completion_kwargs(self.provider),
+        )
 
         # Process the streaming response with thinking mode support
         response_text = ""
@@ -582,8 +577,8 @@ class MCPClient:
         })
 
         # Update actual token count from metrics if available
-        if metrics and metrics.get('eval_count'):
-            self.actual_token_count += metrics['eval_count']
+        if metrics and metrics.get('completion_tokens'):
+            self.actual_token_count += metrics['completion_tokens']
 
         enabled_tools = self.tool_manager.get_enabled_tool_objects()
 
@@ -596,6 +591,7 @@ class MCPClient:
                 break
 
             if loop_count >= self.loop_limit:
+                self.console.print()  # Add spacing before the panel
                 self.console.print(Panel(
                     f"[yellow]Your current loop limit is set to [bold]{self.loop_limit}[/bold] and has been reached. Skipping additional tool calls.[/yellow]\n"
                     f"You will probably want to increase this limit if your model requires more tool interactions to complete tasks.\n"
@@ -607,8 +603,9 @@ class MCPClient:
             loop_count += 1
 
             for tool in pending_tool_calls:
-                tool_name = tool.function.name
-                tool_args = tool.function.arguments
+                tool_name = tool["function"]["name"]
+                tool_call_id = tool["id"]
+                tool_args = json.loads(tool["function"]["arguments"]) if tool["function"]["arguments"] else {}
 
                 # Parse server name and actual tool name from the qualified name
                 server_name, actual_tool_name = tool_name.split('.', 1) if '.' in tool_name else (None, tool_name)
@@ -647,7 +644,7 @@ class MCPClient:
                     messages.append({
                         "role": "tool",
                         "content": tool_response,
-                        "tool_name": tool_name
+                        "tool_call_id": tool_call_id
                     })
                     continue
 
@@ -663,7 +660,7 @@ class MCPClient:
                         messages.append({
                             "role": "tool",
                             "content": error_msg,
-                            "tool_name": tool_name
+                            "tool_call_id": tool_call_id
                         })
                         # Continue with next tool call if any
                         continue
@@ -719,7 +716,7 @@ class MCPClient:
                 tool_message = {
                     "role": "tool",
                     "content": tool_response,
-                    "tool_name": tool_name
+                    "tool_call_id": tool_call_id
                 }
 
                 messages.append(tool_message)
@@ -737,20 +734,18 @@ class MCPClient:
                     self._warn_vision_not_supported(len(tool_images), f"The tool '{tool_name}'")
 
 
-            # Get stream response from Ollama with the tool results
-            chat_params_followup = {
-                "model": model,
-                "messages": messages,
-                "stream": True,
-                "tools": available_tools,
-                "options": model_options
-            }
-
-            # Add thinking parameter if thinking mode is enabled and model supports it
-            if supports_thinking:
-                chat_params_followup["think"] = self.thinking_mode
-
-            stream = await self.ollama.chat(**chat_params_followup)
+            # Get stream response from LLM with the tool results
+            stream = await self.llm.acompletion(
+                model=model,
+                messages=apply_images(messages),
+                stream=True,
+                stream_options={"include_usage": True},
+                tools=available_tools or None,
+                **({
+                    "reasoning_effort": "high"
+                } if supports_thinking and self.thinking_mode else {}),
+                **self.model_config_manager.get_completion_kwargs(self.provider),
+            )
 
             # Process the streaming response with thinking mode support
             followup_response, pending_tool_calls, followup_metrics = await self.streaming_manager.process_streaming_response(
@@ -772,8 +767,8 @@ class MCPClient:
             })
 
             # Update actual token count from followup metrics if available
-            if followup_metrics and followup_metrics.get('eval_count'):
-                self.actual_token_count += followup_metrics['eval_count']
+            if followup_metrics and followup_metrics.get('completion_tokens'):
+                self.actual_token_count += followup_metrics['completion_tokens']
 
             if followup_response:
                 response_text = followup_response
@@ -1052,7 +1047,7 @@ class MCPClient:
                         border_style="red", expand=False
                     ))
 
-                except ollama.ResponseError as e:
+                except Exception as e:
                     # Extract error message without the traceback
                     error_msg = str(e)
                     if "does not support tools" in error_msg.lower():
@@ -1064,8 +1059,17 @@ class MCPClient:
                             title="Tools Not Supported",
                             border_style="red", expand=False
                         ))
+                    elif "401" in error_msg or "403" in error_msg or "unauthorized" in error_msg.lower():
+                        self.console.print(Panel(
+                            f"[bold red]Authentication Error:[/bold red] The [bold blue]{self.provider}[/bold blue] provider rejected the request.\n\n"
+                            + ("No API key is set. " if not self.api_key else "The API key may be invalid or lack access to this model. ")
+                            + "Set a valid key with [bold cyan]--api-key[/bold cyan] or [bold cyan]$OLLMCP_API_KEY[/bold cyan].\n\n"
+                            f"[dim]Provider response: {error_msg}[/dim]",
+                            title="Authentication Failed", border_style="red", expand=False
+                        ))
                     else:
-                        self.console.print(Panel(f"[bold red]Ollama Error:[/bold red] {error_msg}",
+                        self.console.print() # Add spacing before the panel
+                        self.console.print(Panel(f"[bold red]LLM Error:[/bold red] {error_msg}",
                                                  border_style="red", expand=False))
 
                     # If it's a "model not found" error, suggest how to fix it
@@ -1411,7 +1415,9 @@ class MCPClient:
         """Automatically load the default configuration if it exists."""
         if self.config_manager.config_exists("default"):
             # self.console.print("[cyan]Default configuration found, loading...[/cyan]")
-            self.default_configuration_status = self.load_configuration("default")
+            # Connection identity (host/model/apiKey) is already resolved in
+            # async_main before the client was built, so only apply shared settings.
+            self.default_configuration_status = self.load_configuration("default", apply_connection=False)
 
     def print_auto_load_default_config_status(self):
         """Print the status of the auto-load default configuration."""
@@ -1425,10 +1431,26 @@ class MCPClient:
         Args:
             config_name: Optional name for the config (defaults to 'default')
         """
-        # Build config data
-        config_data = {
-            "host": self.host,
+        # Start from the existing config so other providers' profiles are kept,
+        # then update this provider's connection profile and the shared settings.
+        if self.config_manager.config_exists(config_name):
+            config_data = self.config_manager.load_configuration(config_name)
+        else:
+            config_data = default_config()
+
+        # Don't write env-var-sourced keys to disk; keep any previously saved key.
+        existing_profile = (config_data.get("providers") or {}).get(self.provider, {})
+        config_data.setdefault("providers", {})
+        config_data["providers"][self.provider] = {
+            "host": self.host or "",
             "model": self.model_manager.get_current_model(),
+            "apiKey": (self.api_key or "") if self.persist_api_key else existing_profile.get("apiKey", ""),
+        }
+        # Remember the last saved provider as the default for plain `ollmcp`.
+        config_data["defaultProvider"] = self.provider
+
+        # Shared settings (apply across all providers)
+        config_data.update({
             "enabledTools": self.tool_manager.get_enabled_tools(),
             "contextSettings": {
                 "retainContext": self.retain_context
@@ -1452,16 +1474,20 @@ class MCPClient:
             "hilSettings": {
                 "enabled": self.hil_manager.is_enabled()
             }
-        }
+        })
 
         # Use the ConfigManager to save the configuration
         return self.config_manager.save_configuration(config_data, config_name)
 
-    def load_configuration(self, config_name=None):
+    def load_configuration(self, config_name=None, apply_connection=True):
         """Load tool configuration and model settings from a file
 
         Args:
             config_name: Optional name of the config to load (defaults to 'default')
+            apply_connection: When True, apply the active provider's saved
+                connection profile (host/model/apiKey). At startup this is set
+                to False because the connection identity is already resolved in
+                async_main (with CLI flags taking precedence over the profile).
 
         Returns:
             bool: True if loaded successfully, False otherwise
@@ -1472,16 +1498,23 @@ class MCPClient:
         if not config_data:
             return False
 
-        # Apply the loaded configuration
-        if "host" in config_data:
-            new_host = config_data["host"]
-            if new_host != self.host:
-                self.host = new_host
-                self.ollama = ollama.AsyncClient(host=new_host)
-                self.model_manager.ollama = self.ollama
-
-        if "model" in config_data:
-            self.model_manager.set_model(config_data["model"])
+        # Apply the active provider's saved connection profile. The provider
+        # itself is fixed for the session (chosen at startup), so we only update
+        # host/model/apiKey for self.provider.
+        if apply_connection:
+            profile = (config_data.get("providers") or {}).get(self.provider)
+            if profile:
+                new_host = profile.get("host") or self.host
+                new_key = profile.get("apiKey") or self.api_key
+                if new_host != self.host or new_key != self.api_key:
+                    self.host = new_host
+                    self.api_key = new_key
+                    self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+                    self.model_manager.llm = self.llm
+                    self.model_manager.api_base = new_host
+                    self.model_manager.api_key = self.api_key
+                if profile.get("model"):
+                    self.model_manager.set_model(profile["model"])
 
         # Load enabled tools if specified
         if "enabledTools" in config_data:
@@ -1554,13 +1587,19 @@ class MCPClient:
         # Enable all tools in the server connector
         self.server_connector.enable_all_tools()
 
-        # Reset host from the default configuration
-        if "host" in config_data:
-            new_host = config_data["host"]
-            if new_host != self.host:
-                self.host = new_host
-                self.ollama = ollama.AsyncClient(host=new_host)
-                self.model_manager.ollama = self.ollama
+        # Reset the active provider's connection profile to its defaults.
+        # The provider itself stays fixed for the session.
+        profile = (config_data.get("providers") or {}).get(self.provider) or default_provider_profile(self.provider)
+        self.api_key = profile.get("apiKey", "")
+        new_host = profile.get("host") or None
+        if new_host != self.host:
+            self.host = new_host
+            self.llm = AnyLLM.create(self.provider, api_key=self.api_key, api_base=new_host)
+            self.model_manager.llm = self.llm
+            self.model_manager.api_base = new_host
+            self.model_manager.api_key = self.api_key
+        if profile.get("model"):
+            self.model_manager.set_model(profile["model"])
 
         # Reset context settings from the default configuration
         if "contextSettings" in config_data:
@@ -1839,8 +1878,18 @@ def main(
     ),
     host: str = typer.Option(
         None, "--host", "-H",
-        help="Ollama host URL",
-        rich_help_panel="Ollama Configuration"
+        help="LLM host / API base URL. Defaults to Ollama's localhost:11434 for the ollama provider, or the provider's own default endpoint otherwise.",
+        rich_help_panel="LLM Configuration"
+    ),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", "-p",
+        help="LLM provider (e.g., ollama, openai, deepseek, openrouter). Defaults to your saved configuration's provider, or ollama.",
+        rich_help_panel="LLM Configuration"
+    ),
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", "-k",
+        help="API key for the LLM provider. Also read from $OLLMCP_API_KEY (works with any --provider; not written to config). Not needed for ollama.",
+        rich_help_panel="LLM Configuration",
     ),
 
     # General Options
@@ -1863,7 +1912,7 @@ def main(
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host))
+        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key))
     finally:
         try:
             # Ensure executor cleanup completes before closing loop
@@ -1872,19 +1921,66 @@ def main(
         finally:
             loop.close()
 
-async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host):
+async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key):
     """Asynchronous main function to run the MCP Client for Ollama"""
 
     console = Console()
 
-    # Create a temporary client to check if Ollama is running
-    initial_host = host if host is not None else DEFAULT_OLLAMA_HOST
-    client = MCPClient(model=model or DEFAULT_MODEL, host=initial_host)
+    # Resolve the provider and its saved connection profile before building the
+    # client, so the preflight check targets the right endpoint on the first try.
+    # `provider`/`model`/`host`/`api_key` are None unless the flag was actually
+    # passed, so CLI values cleanly take precedence over the saved profile
+    # (and `--provider` picks the provider; plain `ollmcp` resumes the last saved).
+    config_mgr = ConfigManager(console)
+    saved = config_mgr.load_configuration("default") if config_mgr.config_exists("default") else {}
+
+    effective_provider = provider or saved.get("defaultProvider") or DEFAULT_PROVIDER
+    if not validate_provider(effective_provider, console):
+        return
+
+    profile = (saved.get("providers") or {}).get(effective_provider) or default_provider_profile(effective_provider)
+
+    # Host: CLI flag > saved profile host > ollama local default / provider default.
+    if host is not None:
+        resolved_host = host
+    elif profile.get("host"):
+        resolved_host = profile["host"]
+    elif effective_provider == "ollama":
+        resolved_host = DEFAULT_OLLAMA_HOST
+    else:
+        resolved_host = None
+
+    # API key precedence: --api-key flag > OLLMCP_API_KEY env var > saved profile.
+    # Keys from the env var are never written back to the config file.
+    env_api_key = os.environ.get("OLLMCP_API_KEY")
+    if api_key:
+        resolved_api_key = api_key
+        persist_api_key = True
+    elif env_api_key:
+        resolved_api_key = env_api_key
+        persist_api_key = False
+    else:
+        resolved_api_key = profile.get("apiKey") or None
+        persist_api_key = True
+    resolved_model = model or profile.get("model") or DEFAULT_MODEL
+
+    try:
+        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key, persist_api_key=persist_api_key)
+    except MissingApiKeyError as e:
+        console.print(Panel(
+            f"[bold red]API key required:[/bold red] The [bold blue]{effective_provider}[/bold blue] provider needs an API key.\n\n"
+            f"Provide one with [bold cyan]--api-key[/bold cyan] / [bold cyan]-k[/bold cyan], "
+            f"or set [bold cyan]$OLLMCP_API_KEY[/bold cyan] or [bold cyan]${e.env_var_name}[/bold cyan].\n\n"
+            "[dim]Tip: if you pass a shell variable, quote it (e.g. [/dim][bold cyan]--api-key \"$MY_KEY\"[/bold cyan][dim]) "
+            "so an unset value isn't silently dropped.[/dim]",
+            title="Missing API Key", border_style="red", expand=False
+        ))
+        return
 
     # Show startup banner before server discovery messages.
     client.print_welcome_ascii()
 
-    if not await preflight_ollama(client, host):
+    if not await preflight_ollama(client):
         return
 
     # Registry is always the base layer — merge with any flag-provided sources
@@ -1918,18 +2014,14 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
                 return
     try:
         await client.connect_to_servers(mcp_server, mcp_server_url, config_path, claude_desktop, server_configs)
+        # Connection identity (provider/host/model/apiKey) was already resolved
+        # above; this only applies the shared settings from the saved config.
         client.auto_load_default_config()
 
-        if host != client.host and host is not None:
-            client.host = host
-            client.ollama = ollama.AsyncClient(host=host)
-            client.model_manager.ollama = client.ollama
-
-        # Resolve the model to use: --model flag > saved config > first available
-        # model, validated against what's actually installed (auto_load_default_config()
-        # above already applied any saved model to model_manager when a config existed).
-        # `model` is None unless --model was actually passed, so this is unambiguous
-        # (unlike comparing against the DEFAULT_MODEL sentinel).
+        # Resolve the model to use: --model flag > saved profile model > first
+        # available model, validated against what's actually installed. The model
+        # resolved before construction is already in model_manager as its current
+        # model, so use it as the saved candidate.
         saved_model = client.model_manager.get_current_model() if client.default_configuration_status else None
         client.model_resolution_status = await client.model_manager.resolve_initial_model(model, saved_model)
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -942,7 +942,8 @@ class MCPClient:
                     f"[bold yellow]New version available![/bold yellow]\n\n"
                     f"Current version: [cyan]{current_version}[/cyan]\n"
                     f"Latest version: [green]{latest_version}[/green]\n\n"
-                    f"Upgrade with: [bold white]pip install --upgrade mcp-client-for-ollama[/bold white]",
+                    f"Upgrade with: [bold white]uv tool install --upgrade ollmcp[/bold white]\n"
+                    f"Or if you prefer: [bold white]pip install --upgrade ollmcp[/bold white]",
                     title="Update Available", border_style="yellow", expand=False
                 ))
         except Exception:
@@ -1911,7 +1912,7 @@ def main(
         return
 
     if version:
-        typer.echo(f"mcp-client-for-ollama {__version__}")
+        typer.echo(f"ollmcp {__version__}")
         raise typer.Exit()
 
     # Run the async main function with proper cleanup

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -22,6 +22,7 @@ from prompt_toolkit.styles import Style
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
+from rich.prompt import Prompt
 from rich.text import Text
 import httpx
 from any_llm import AnyLLM
@@ -584,6 +585,8 @@ class MCPClient:
         enabled_tools = self.tool_manager.get_enabled_tool_objects()
 
         loop_count = 0
+        iteration_budget = self.loop_limit
+        loop_unlimited = False
         pending_tool_calls = tool_calls
 
         # Keep looping while the model requests tools and we have capacity
@@ -591,15 +594,22 @@ class MCPClient:
             if self.abort_current_query:
                 break
 
-            if loop_count >= self.loop_limit:
-                self.console.print()  # Add spacing before the panel
-                self.console.print(Panel(
-                    f"[yellow]Your current loop limit is set to [bold]{self.loop_limit}[/bold] and has been reached. Skipping additional tool calls.[/yellow]\n"
-                    f"You will probably want to increase this limit if your model requires more tool interactions to complete tasks.\n"
-                    f"You can change the loop limit with the [bold cyan]/loop-limit[/bold cyan] command.",
-                    title="[bold]Loop Limit Reached[/bold]", border_style="yellow", expand=False
-                ))
-                break
+            if not loop_unlimited and loop_count >= iteration_budget:
+                action, amount = await self._prompt_loop_limit_action(iteration_budget)
+                if action == "continue":
+                    iteration_budget += amount
+                elif action == "unlimited":
+                    loop_unlimited = True
+                elif action == "wrap":
+                    wrap_text = await self._wrap_up_final_answer(
+                        messages, model, pending_tool_calls, supports_thinking
+                    )
+                    if wrap_text:
+                        response_text = wrap_text
+                    break
+                elif action == "abort":
+                    self.abort_current_query = True
+                    raise AbortQueryException("Query aborted at loop limit")
 
             loop_count += 1
 
@@ -1362,6 +1372,120 @@ class MCPClient:
                 return
 
             self.console.print("[red]Invalid selection. Choose 1, 2, single, multiline, or q.[/red]")
+
+    async def _prompt_loop_limit_action(self, iteration_budget):
+        """Ask the user what to do when the agent loop limit is reached.
+
+        Returns (action, amount) where action is one of:
+          "continue"  — resume with iteration_budget increased by amount
+          "unlimited" — remove the cap for this query
+          "wrap"      — force a final tool-free answer
+          "abort"     — discard the turn
+        """
+        self.console.print()
+        self.console.print()
+        self.console.print(Panel(
+            f"[yellow]Loop limit of [bold]{iteration_budget}[/bold] reached after this batch.[/yellow]\n\n"
+            "[bold cyan]What would you like to do?[/bold cyan]\n"
+            f"  [green]c/continue[/green]  - Run another [bold]{self.loop_limit}[/bold] iterations (default)\n"
+            "  [cyan]n/number[/cyan]    - Choose how many more iterations to allow\n"
+            "  [magenta]u/unlimited[/magenta] - Remove the cap and run until the model stops\n"
+            "  [yellow]w/wrap[/yellow]      - Ask the model to summarise what it found so far\n"
+            "  [bold red]a/abort[/bold red]     - Discard this turn (nothing saved to history)",
+            title="[bold]Loop Limit Reached[/bold]", border_style="yellow", expand=False
+        ))
+
+        self.monitor_paused = True
+        if os.name != 'nt':
+            try:
+                await asyncio.wait_for(self.monitor_paused_ack.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+        try:
+            choice = Prompt.ask(
+                "[bold]Choice[/bold]",
+                choices=["c", "continue", "n", "number", "u", "unlimited", "w", "wrap", "a", "abort"],
+                default="c",
+                show_choices=False,
+            ).lower()
+        finally:
+            self.monitor_paused = False
+
+        if choice in ("n", "number"):
+            raw = await get_input_no_autocomplete("How many more iterations?")
+            try:
+                extra = int((raw or "").strip())
+                if extra < 1:
+                    raise ValueError
+            except ValueError:
+                self.console.print(f"[yellow]Invalid number — granting {self.loop_limit} more iterations.[/yellow]")
+                extra = self.loop_limit
+            return ("continue", extra)
+
+        if choice in ("u", "unlimited"):
+            self.console.print("[magenta]🤖 Running without iteration cap for the rest of this query.[/magenta]")
+            return ("unlimited", 0)
+
+        if choice in ("w", "wrap"):
+            self.console.print("[cyan]🤖 Asking the model to wrap up with what it has gathered...[/cyan]")
+            return ("wrap", 0)
+
+        if choice in ("a", "abort"):
+            self.console.print("[bold red]🛑 Aborting query...[/bold red]")
+            return ("abort", 0)
+
+        # c / continue
+        self.console.print(f"[green]🤖 Granting {self.loop_limit} more iterations.[/green]")
+        return ("continue", self.loop_limit)
+
+    async def _wrap_up_final_answer(self, messages, model, pending_tool_calls, supports_thinking):
+        """Force one final tool-free completion so gathered context is not lost.
+
+        At the point this is called the last assistant message contains unanswered
+        tool_calls. Providers reject a follow-up call while those are dangling, so
+        we append synthetic skipped-tool responses first, then request a plain text
+        answer with tools=None.
+        """
+        for tool in pending_tool_calls:
+            messages.append({
+                "role": "tool",
+                "content": "Tool call skipped — loop limit reached.",
+                "tool_call_id": tool["id"],
+            })
+
+        messages.append({
+            "role": "user",
+            "content": (
+                "Stop calling tools. Based on the information gathered so far, "
+                "give your best final answer now."
+            ),
+        })
+
+        stream = await self.llm.acompletion(
+            model=model,
+            messages=apply_images(messages),
+            stream=True,
+            stream_options={"include_usage": True},
+            tools=None,
+            **({
+                "reasoning_effort": "high"
+            } if supports_thinking and self.thinking_mode else {}),
+            **self.model_config_manager.get_completion_kwargs(self.provider),
+        )
+
+        wrap_text, _, wrap_metrics = await self.streaming_manager.process_streaming_response(
+            stream,
+            thinking_mode=self.thinking_mode,
+            show_thinking=self.show_thinking,
+            show_metrics=self.show_metrics,
+            answer_render_mode=self.answer_render_mode,
+            cancellation_check=lambda: self.abort_current_query,
+        )
+
+        if wrap_metrics and wrap_metrics.get("completion_tokens"):
+            self.actual_token_count += wrap_metrics["completion_tokens"]
+
+        return wrap_text
 
     async def set_loop_limit(self):
         """Configure the maximum number of follow-up tool loops per query."""

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -61,6 +61,7 @@ class MCPClient:
         "plain": "Plain",
         "markdown": "Markdown",
         "both": "Both",
+        "blocks": "Markdown (blocks)",
     }
 
     INPUT_MODE_LABELS = {
@@ -119,7 +120,7 @@ class MCPClient:
         self.show_tool_execution = True  # By default, show tool execution displays
         # Metrics display settings
         self.show_metrics = False  # By default, don't show metrics after each query
-        self.answer_render_mode = "markdown"  # Show answers in markdown format by default (options: plain, markdown, or both)
+        self.answer_render_mode = "both"  # Default to the safest mode (options: plain, markdown, both, blocks)
         self.input_mode = "single"  # Keep chat input single-line by default
         self.multiline_key_bindings = self._build_multiline_key_bindings()
         # Agent mode settings
@@ -1266,18 +1267,21 @@ class MCPClient:
             "1": ("plain", "Plain"),
             "2": ("markdown", "Markdown"),
             "3": ("both", "Both"),
+            "4": ("blocks", "Markdown (blocks)"),
             "plain": ("plain", "Plain"),
             "markdown": ("markdown", "Markdown"),
             "both": ("both", "Both"),
+            "blocks": ("blocks", "Markdown (blocks)"),
         }
 
         while True:
             self.console.print(Panel(
                 "\n"
-                "1. [bold]Plain[/bold] only\n"
-                "2. [bold]Markdown[/bold] only\n"
-                "3. [bold]Both[/bold] plain streaming and final markdown\n\n"
-                "[dim]Type 1, 2, 3, plain, markdown, both, or q to cancel.[/dim]",
+                "1. [bold]Plain only[/bold] [green](most stable)[/green]\n"
+                "2. [bold]Markdown only[/bold] [yellow](live; can flicker/duplicate lines with emojis or on resize)[/yellow]\n"
+                "3. [bold]Both[/bold] plain streaming and final markdown [green](more stable)[/green]\n"
+                "4. [bold]Markdown (blocks)[/bold] [cyan](stable; renders each block once it completes)[/cyan]\n\n"
+                "[dim]Type 1, 2, 3, 4, plain, markdown, both, blocks, or q to cancel.[/dim]",
                 title="[bold]📝 Answer Display Mode[/bold]",
                 border_style="cyan",
                 expand=False,
@@ -1301,11 +1305,13 @@ class MCPClient:
                     self.console.print("[cyan]Responses will stream once without the final markdown re-render.[/cyan]")
                 elif self.answer_render_mode == "markdown":
                     self.console.print("[cyan]Responses will render as markdown during streaming with throttled redraws.[/cyan]")
+                elif self.answer_render_mode == "blocks":
+                    self.console.print("[cyan]Responses will render as markdown one block at a time, append-only (no redraws).[/cyan]")
                 else:
                     self.console.print("[cyan]Responses will stream as plain text first, then re-render as markdown.[/cyan]")
                 return
 
-            self.console.print("[red]Invalid selection. Choose 1, 2, 3, plain, markdown, both, or q.[/red]")
+            self.console.print("[red]Invalid selection. Choose 1, 2, 3, 4, plain, markdown, both, blocks, or q.[/red]")
 
     async def select_input_mode(self):
         """Select how chat input should be entered."""
@@ -1562,7 +1568,7 @@ class MCPClient:
                 self.show_metrics = config_data["displaySettings"]["showMetrics"]
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     self.answer_render_mode = answer_render_mode
 
         if "inputSettings" in config_data:
@@ -1645,7 +1651,7 @@ class MCPClient:
                 self.show_metrics = False
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     self.answer_render_mode = answer_render_mode
                 else:
                     self.answer_render_mode = "both"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -32,7 +32,7 @@ from . import __version__
 from .config.manager import ConfigManager
 from .config.defaults import default_config, default_provider_profile
 from .utils.version import check_for_updates
-from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART
+from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART, REASONING_EFFORT_LEVELS, DEFAULT_REASONING_EFFORT
 from .utils.connection import preflight_ollama, validate_provider
 from .utils.images import apply_images
 from .server.connector import ServerConnector
@@ -117,6 +117,7 @@ class MCPClient:
         # Thinking mode settings
         self.thinking_mode = True  # By default, thinking mode is enabled for models that support it
         self.show_thinking = True   # By default, thinking text is visible after completion
+        self.reasoning_effort = DEFAULT_REASONING_EFFORT  # Effort level sent when thinking mode is on
         # Tool display settings
         self.show_tool_execution = True  # By default, show tool execution displays
         # Metrics display settings
@@ -306,7 +307,10 @@ class MCPClient:
 
     def display_current_model(self):
         """Display the currently selected model"""
-        self.model_manager.display_current_model()
+        self.model_manager.display_current_model(
+            thinking_mode=self.thinking_mode,
+            reasoning_effort=self.reasoning_effort,
+        )
 
     async def supports_thinking_mode(self) -> bool:
         """Check if the current model supports thinking mode by checking its capabilities
@@ -334,6 +338,21 @@ class MCPClient:
             return 'vision' in caps
         except Exception:
             return False
+
+    def _reasoning_effort_kwargs(self, supports_thinking: bool) -> dict:
+        """Return the reasoning_effort kwarg for acompletion, or {} when thinking is off/unsupported.
+
+        For Ollama, any-llm maps concrete levels to think="low"/"medium"/"high" and treats
+        "auto" as no explicit think override (model default). Since thinking_mode=True means
+        the user wants thinking, we substitute "high" for Ollama+auto to guarantee think is set.
+        Cloud providers receive the level as-is including "auto" (provider's own default effort).
+        """
+        if not (supports_thinking and self.thinking_mode):
+            return {}
+        effort = self.reasoning_effort
+        if self.provider == "ollama" and effort == "auto":
+            effort = "high"
+        return {"reasoning_effort": effort}
 
     async def select_model(self):
         """Let the user select an Ollama model from the available ones"""
@@ -549,9 +568,7 @@ class MCPClient:
             stream=True,
             stream_options={"include_usage": True},
             tools=available_tools or None,
-            **({
-                "reasoning_effort": "high"
-            } if supports_thinking and self.thinking_mode else {}),
+            **self._reasoning_effort_kwargs(supports_thinking),
             **self.model_config_manager.get_completion_kwargs(self.provider),
         )
 
@@ -752,9 +769,7 @@ class MCPClient:
                 stream=True,
                 stream_options={"include_usage": True},
                 tools=available_tools or None,
-                **({
-                    "reasoning_effort": "high"
-                } if supports_thinking and self.thinking_mode else {}),
+                **self._reasoning_effort_kwargs(supports_thinking),
                 **self.model_config_manager.get_completion_kwargs(self.provider),
             )
 
@@ -1111,6 +1126,7 @@ class MCPClient:
             "• Type [bold]/model-config[/bold] or [bold]/mc[/bold] to configure system prompt and model parameters\n"
             "• Type [bold]/thinking-mode[/bold] or [bold]/tm[/bold] to toggle thinking mode\n"
             "• Type [bold]/show-thinking[/bold] or [bold]/st[/bold] to toggle thinking text visibility\n"
+            "• Type [bold]/reasoning-effort[/bold] or [bold]/re[/bold] to set reasoning effort level (auto/minimal/low/medium/high/xhigh)\n"
             "• Type [bold]/show-metrics[/bold] or [bold]/sm[/bold] to toggle performance metrics display\n\n"
 
             "[bold cyan]Agent Mode:[/bold cyan] \n"
@@ -1241,6 +1257,54 @@ class MCPClient:
             self.console.print("[cyan]💭 The reasoning process will remain visible in the final response.[/cyan]")
         else:
             self.console.print("[cyan]🧹 The reasoning process will be hidden, showing only the final answer.[/cyan]")
+
+    async def select_reasoning_effort(self):
+        """Select reasoning effort level used when thinking mode is active."""
+        level_labels = {
+            "auto": "Auto (provider default)",
+            "minimal": "Minimal",
+            "low": "Low",
+            "medium": "Medium",
+            "high": "High",
+            "xhigh": "Extreme (xhigh)",
+        }
+        numbered = list(REASONING_EFFORT_LEVELS)  # auto, minimal, low, medium, high, xhigh
+        options_map = {str(i + 1): lvl for i, lvl in enumerate(numbered)}
+        for lvl in numbered:
+            options_map[lvl] = lvl
+
+        while True:
+            menu_lines = "\n".join(
+                f"{i + 1}. [bold]{level_labels[lvl]}[/bold] [dim]({lvl})[/dim]"
+                for i, lvl in enumerate(numbered)
+            )
+            self.console.print(Panel(
+                f"\n{menu_lines}\n\n"
+                "[dim]Applies when thinking mode is on and the model supports thinking\n"
+                "Level support depends on the provider and model.\n"
+                "Type a number, a level name, or q to cancel.[/dim]",
+                title="[bold]🤔 Reasoning Effort[/bold]",
+                border_style="magenta",
+                expand=False,
+            ))
+            self.console.print(f"Current level: [bold magenta]{level_labels.get(self.reasoning_effort, self.reasoning_effort)}[/bold magenta]")
+            if not self.thinking_mode:
+                self.console.print("[yellow]Note: thinking mode is currently off — this preference will apply once enabled.[/yellow]")
+
+            selection = await get_input_no_autocomplete("Select reasoning effort")
+            normalized = selection.strip().lower()
+
+            if normalized in {"q", "quit"}:
+                self.console.print("[yellow]Reasoning effort unchanged.[/yellow]")
+                return
+
+            if normalized in options_map:
+                self.reasoning_effort = options_map[normalized]
+                label = level_labels.get(self.reasoning_effort, self.reasoning_effort)
+                self.console.print(f"[green]Reasoning effort set to {label}![/green]")
+                return
+
+            self.console.print(f"[red]Invalid selection. Choose 1–{len(numbered)}, a level name, or q.[/red]")
 
     def toggle_show_tool_execution(self):
         """Toggle whether tool execution displays are shown"""
@@ -1467,9 +1531,7 @@ class MCPClient:
             stream=True,
             stream_options={"include_usage": True},
             tools=None,
-            **({
-                "reasoning_effort": "high"
-            } if supports_thinking and self.thinking_mode else {}),
+            **self._reasoning_effort_kwargs(supports_thinking),
             **self.model_config_manager.get_completion_kwargs(self.provider),
         )
 
@@ -1526,6 +1588,7 @@ class MCPClient:
         if self.thinking_mode:
             thinking_status = f"Thinking mode: [green]Enabled[/green]\n"
             thinking_status += f"Show thinking text: [{'green' if self.show_thinking else 'red'}]{'Visible' if self.show_thinking else 'Hidden'}[/{'green' if self.show_thinking else 'red'}]\n"
+            thinking_status += f"Reasoning effort: [cyan]{self.reasoning_effort}[/cyan]\n"
         else:
             thinking_status = f"Thinking mode: [red]Disabled[/red]\n"
 
@@ -1589,7 +1652,8 @@ class MCPClient:
             },
             "modelSettings": {
                 "thinkingMode": self.thinking_mode,
-                "showThinking": self.show_thinking
+                "showThinking": self.show_thinking,
+                "reasoningEffort": self.reasoning_effort
             },
             "agentSettings": {
                 "loopLimit": self.loop_limit
@@ -1672,6 +1736,10 @@ class MCPClient:
                 self.thinking_mode = config_data["modelSettings"]["thinkingMode"]
             if "showThinking" in config_data["modelSettings"]:
                 self.show_thinking = config_data["modelSettings"]["showThinking"]
+            if "reasoningEffort" in config_data["modelSettings"]:
+                effort = str(config_data["modelSettings"]["reasoningEffort"]).lower()
+                if effort in REASONING_EFFORT_LEVELS:
+                    self.reasoning_effort = effort
 
         if "agentSettings" in config_data:
             if "loopLimit" in config_data["agentSettings"]:
@@ -1750,6 +1818,11 @@ class MCPClient:
             else:
                 # Default show thinking to True if not specified
                 self.show_thinking = True
+            if "reasoningEffort" in config_data["modelSettings"]:
+                effort = str(config_data["modelSettings"]["reasoningEffort"]).lower()
+                self.reasoning_effort = effort if effort in REASONING_EFFORT_LEVELS else DEFAULT_REASONING_EFFORT
+            else:
+                self.reasoning_effort = DEFAULT_REASONING_EFFORT
 
         if "agentSettings" in config_data:
             if "loopLimit" in config_data["agentSettings"]:

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -963,6 +963,7 @@ class MCPClient:
 
         while True:
             try:
+                self.console.print()  # Add spacing before the prompt
                 # Use await to call the async method
                 query = await self.get_user_input()
 

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -4,7 +4,7 @@ This module provides default settings and paths used throughout the application.
 """
 
 import os
-from ..utils.constants import DEFAULT_MODEL, DEFAULT_CONFIG_FILE, DEFAULT_CONFIG_DIR, DEFAULT_OLLAMA_HOST
+from ..utils.constants import DEFAULT_MODEL, DEFAULT_CONFIG_FILE, DEFAULT_CONFIG_DIR, DEFAULT_OLLAMA_HOST, DEFAULT_REASONING_EFFORT
 
 def default_provider_profile(provider: str = "ollama") -> dict:
     """Get the default connection profile for a provider.
@@ -43,7 +43,8 @@ def default_config() -> dict:
         },
         "modelSettings": {
             "thinkingMode": True,
-            "showThinking": True
+            "showThinking": True,
+            "reasoningEffort": DEFAULT_REASONING_EFFORT
         },
         "agentSettings": {
             "loopLimit": 7

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -6,6 +6,25 @@ This module provides default settings and paths used throughout the application.
 import os
 from ..utils.constants import DEFAULT_MODEL, DEFAULT_CONFIG_FILE, DEFAULT_CONFIG_DIR, DEFAULT_OLLAMA_HOST
 
+def default_provider_profile(provider: str = "ollama") -> dict:
+    """Get the default connection profile for a provider.
+
+    Args:
+        provider: Provider name (e.g., "ollama", "openai")
+
+    Returns:
+        dict: Default per-provider connection identity (host, model, apiKey).
+              An empty host means "use the provider's own default endpoint";
+              for ollama we seed the local default. An empty model means
+              "resolve to the first available model at startup".
+    """
+    return {
+        "host": DEFAULT_OLLAMA_HOST if provider == "ollama" else "",
+        "model": DEFAULT_MODEL if provider == "ollama" else "",
+        "apiKey": "",
+    }
+
+
 def default_config() -> dict:
     """Get default configuration settings.
 
@@ -14,8 +33,10 @@ def default_config() -> dict:
     """
 
     return {
-        "host": DEFAULT_OLLAMA_HOST,
-        "model": DEFAULT_MODEL,
+        "defaultProvider": "ollama",
+        "providers": {
+            "ollama": default_provider_profile("ollama"),
+        },
         "enabledTools": {},  # Will be populated with available tools
         "contextSettings": {
             "retainContext": True

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -69,7 +69,7 @@ def default_config() -> dict:
         "displaySettings": {
             "showToolExecution": True,
             "showMetrics": False,
-            "answerRenderMode": "markdown"
+            "answerRenderMode": "both"
         },
         "inputSettings": {
             "inputMode": "single"

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -291,7 +291,7 @@ class ConfigManager:
                 validated["displaySettings"]["showMetrics"] = bool(config_data["displaySettings"]["showMetrics"])
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     validated["displaySettings"]["answerRenderMode"] = answer_render_mode
 
         if "inputSettings" in config_data and isinstance(config_data["inputSettings"], dict):

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -10,7 +10,7 @@ from typing import Dict, Any, Optional
 from rich.console import Console
 from rich.panel import Panel
 from ..utils.constants import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE
-from .defaults import default_config
+from .defaults import default_config, default_provider_profile
 
 class ConfigManager:
     """Manages configuration for the MCP Client for Ollama.
@@ -197,17 +197,35 @@ class ConfigManager:
         # Start with default configuration
         validated = default_config()
 
-        # Remove default host - only include if explicitly in config file
-        # This allows CLI arguments to take precedence when config file
-        # doesn't have a host field (e.g., older config files)
-        del validated["host"]
+        # Resolve per-provider connection profiles.
+        # New format: a "providers" map keyed by provider name plus a
+        # "defaultProvider". Legacy format: flat top-level host/model/provider/
+        # apiKey, which we migrate into a single provider profile so old config
+        # files keep working and are rewritten in the new shape on next save.
+        validated["providers"] = {}
+        if isinstance(config_data.get("providers"), dict):
+            default_provider = config_data.get("defaultProvider") or "ollama"
+            for name, profile in config_data["providers"].items():
+                if isinstance(profile, dict):
+                    validated["providers"][name] = {
+                        "host": profile.get("host", ""),
+                        "model": profile.get("model", ""),
+                        "apiKey": profile.get("apiKey", ""),
+                    }
+        elif any(k in config_data for k in ("host", "model", "provider", "apiKey")):
+            default_provider = config_data.get("provider") or "ollama"
+            validated["providers"][default_provider] = {
+                "host": config_data.get("host", ""),
+                "model": config_data.get("model", ""),
+                "apiKey": config_data.get("apiKey", ""),
+            }
+        else:
+            default_provider = "ollama"
 
-        # Apply values from the loaded configuration if they exist
-        if "host" in config_data:
-            validated["host"] = config_data["host"]
-
-        if "model" in config_data:
-            validated["model"] = config_data["model"]
+        # Ensure the default provider always has at least a seed profile.
+        if default_provider not in validated["providers"]:
+            validated["providers"][default_provider] = default_provider_profile(default_provider)
+        validated["defaultProvider"] = default_provider
 
         if "enabledTools" in config_data and isinstance(config_data["enabledTools"], dict):
             validated["enabledTools"] = config_data["enabledTools"]

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -9,7 +9,7 @@ import os
 from typing import Dict, Any, Optional
 from rich.console import Console
 from rich.panel import Panel
-from ..utils.constants import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE
+from ..utils.constants import DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE, REASONING_EFFORT_LEVELS
 from .defaults import default_config, default_provider_profile
 
 class ConfigManager:
@@ -151,6 +151,7 @@ class ConfigManager:
             "• Context retention enabled\n"
             "• Thinking mode enabled\n"
             "• Thinking text visible\n"
+            "• Reasoning effort reset to medium\n"
             "• Agent loop limit reset",
             title="Config Reset", border_style="green", expand=False
         ))
@@ -239,6 +240,10 @@ class ConfigManager:
                 validated["modelSettings"]["thinkingMode"] = bool(config_data["modelSettings"]["thinkingMode"])
             if "showThinking" in config_data["modelSettings"]:
                 validated["modelSettings"]["showThinking"] = bool(config_data["modelSettings"]["showThinking"])
+            if "reasoningEffort" in config_data["modelSettings"]:
+                effort = str(config_data["modelSettings"]["reasoningEffort"]).lower()
+                if effort in REASONING_EFFORT_LEVELS:
+                    validated["modelSettings"]["reasoningEffort"] = effort
 
         if "agentSettings" in config_data and isinstance(config_data["agentSettings"], dict):
             if "loopLimit" in config_data["agentSettings"]:

--- a/mcp_client_for_ollama/models/config_manager.py
+++ b/mcp_client_for_ollama/models/config_manager.py
@@ -210,6 +210,40 @@ class ModelConfigManager:
             options["num_batch"] = self.num_batch
         return options
 
+    def get_completion_kwargs(self, provider: str = "ollama") -> Dict[str, Any]:
+        """Get model options as kwargs for AnyLLM.acompletion().
+
+        For ollama: returns all 15 options using native names. They flow
+        through acompletion's **kwargs into the Ollama SDK's options dict.
+
+        For other providers: returns only the 7 standard OpenAI-compatible
+        options, remapping num_predict → max_tokens. Ollama-specific params
+        are omitted since they would cause errors on other SDKs.
+
+        Returns:
+            Dict containing only the configured options as keyword arguments
+        """
+        if provider == "ollama":
+            return self.get_ollama_options()
+
+        # Standard OpenAI-compatible options only
+        kwargs: Dict[str, Any] = {}
+        if self.temperature is not None:
+            kwargs["temperature"] = self.temperature
+        if self.top_p is not None:
+            kwargs["top_p"] = self.top_p
+        if self.num_predict is not None:
+            kwargs["max_tokens"] = self.num_predict
+        if self.stop is not None:
+            kwargs["stop"] = self.stop
+        if self.seed is not None:
+            kwargs["seed"] = self.seed
+        if self.presence_penalty is not None:
+            kwargs["presence_penalty"] = self.presence_penalty
+        if self.frequency_penalty is not None:
+            kwargs["frequency_penalty"] = self.frequency_penalty
+        return kwargs
+
     def get_system_prompt(self) -> str:
         """Get the current system prompt.
 

--- a/mcp_client_for_ollama/models/manager.py
+++ b/mcp_client_for_ollama/models/manager.py
@@ -162,10 +162,18 @@ class ModelManager:
         badges = [badge for cap, badge in badge_map if cap in capabilities]
         return " [dim]│[/dim] ".join(badges)
 
-    def display_current_model(self) -> None:
+    def display_current_model(self, thinking_mode: bool = False, reasoning_effort: str = "") -> None:
         """Display the currently selected model in the console."""
         capabilities = self._capabilities_cache.get(self.model, [])
         badges = self.format_capabilities_badges(capabilities)
+
+        # Annotate the Thinking badge with the current effort level when thinking is active
+        if thinking_mode and reasoning_effort and "thinking" in capabilities:
+            badges = badges.replace(
+                "[bold magenta]💭 Thinking[/bold magenta]",
+                f"[bold magenta]💭 Thinking ({reasoning_effort})[/bold magenta]",
+            )
+
         content = (
             f"[bold blue]Current model:[/bold blue] [bold green]{self.model}[/bold green]"
             f" [bold yellow]({self.provider})[/bold yellow]"

--- a/mcp_client_for_ollama/models/manager.py
+++ b/mcp_client_for_ollama/models/manager.py
@@ -3,7 +3,10 @@
 This module handles listing, selecting, and managing Ollama models.
 """
 import asyncio
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Tuple
+
+import httpx
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -18,45 +21,79 @@ class ModelManager:
     Ollama is running, and selecting models to use with the client.
     """
 
-    def __init__(self, console: Optional[Console] = None, default_model: str = DEFAULT_MODEL, ollama: Optional[Any] = None):
+    def __init__(self, console: Optional[Console] = None, default_model: str = DEFAULT_MODEL, llm: Optional[Any] = None, provider: str = "ollama", api_base: Optional[str] = None, api_key: Optional[str] = None):
         """Initialize the ModelManager.
 
         Args:
             console: Rich console for output (optional)
             default_model: Default model to use if none is specified
+            llm: AnyLLM instance for provider access
+            provider: Provider name (e.g. 'ollama', 'openai')
+            api_base: Provider base URL
+            api_key: Provider API key
         """
         self.console = console or Console()
         self.model = default_model
-        self.ollama = ollama
+        self.llm = llm
+        self.provider = provider
+        self.api_base = api_base
+        self.api_key = api_key
         self._capabilities_cache: Dict[str, List[str]] = {}
 
     async def check_ollama_running(self) -> bool:
-        """Check if Ollama is running by making a request to its API.
+        """Check if the LLM provider is reachable.
 
         Returns:
-            bool: True if Ollama is running, False otherwise
+            bool: True if the provider is reachable, False otherwise
         """
         try:
-            result = await self.ollama.list()
-            if result:
-                return True
+            await self._list_models()
+            return True
         except Exception:
             return False
 
     async def list_ollama_models(self) -> List[Dict[str, Any]]:
-        """Get a list of available Ollama models.
+        """Get a list of available models from the provider.
 
         Returns:
             List[Dict[str, Any]]: List of model objects each with name and other metadata
         """
         try:
-            result = await self.ollama.list()
-            if result:
-                models = result.get("models", [])
-                return models
+            return await self._list_models()
         except Exception as e:
-            self.console.print(f"[red]Error getting models from Ollama: {str(e)}[/red]")
+            self.console.print(f"[red]Error getting models: {str(e)}[/red]")
             return []
+
+    async def _list_models(self) -> List[Dict[str, Any]]:
+        """Fetch models from the provider, returning a list of dicts with 'name' etc."""
+        if self.provider == "ollama":
+            return await self._ollama_list_models()
+        return await self._generic_list_models()
+
+    async def _ollama_list_models(self) -> List[Dict[str, Any]]:
+        """Call ollama's native /api/tags for full model metadata."""
+        base = (self.api_base or "http://localhost:11434").rstrip("/")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{base}/api/tags")
+            resp.raise_for_status()
+            return resp.json().get("models", [])
+
+    async def _generic_list_models(self) -> List[Dict[str, Any]]:
+        """List models via any-llm for OpenAI-compatible providers."""
+        if self.llm is None:
+            return []
+        result = await self.llm.alist_models()
+        items = result.data if hasattr(result, "data") else result
+        models = []
+        for m in (items or []):
+            model_id = getattr(m, "id", str(m))
+            created = getattr(m, "created", None)
+            modified_at = (
+                datetime.fromtimestamp(created, tz=timezone.utc).isoformat()
+                if created else ""
+            )
+            models.append({"name": model_id, "model": model_id, "modified_at": modified_at, "size": 0, "digest": "", "details": {}})
+        return models
 
     def get_current_model(self) -> str:
         """Get the currently selected model.
@@ -86,12 +123,27 @@ class ModelManager:
         if model_name in self._capabilities_cache:
             return self._capabilities_cache[model_name]
         try:
-            model_info = await self.ollama.show(model_name)
-            caps = model_info.get('capabilities') or []
+            caps = await self._fetch_capabilities(model_name)
             self._capabilities_cache[model_name] = list(caps)
         except Exception:
             self._capabilities_cache[model_name] = []
         return self._capabilities_cache[model_name]
+
+    async def _fetch_capabilities(self, model_name: str) -> List[str]:
+        """Fetch raw capabilities for a model from the provider."""
+        if self.provider == "ollama":
+            return await self._ollama_fetch_capabilities(model_name)
+        # For non-ollama providers, assume all capabilities are available.
+        # The provider API will surface an error if a specific capability is unsupported.
+        return ["tools", "vision", "thinking"]
+
+    async def _ollama_fetch_capabilities(self, model_name: str) -> List[str]:
+        """Call ollama's /api/show endpoint for real capability data."""
+        base = (self.api_base or "http://localhost:11434").rstrip("/")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(f"{base}/api/show", json={"name": model_name})
+            resp.raise_for_status()
+            return resp.json().get("capabilities", [])
 
     def format_capabilities_badges(self, capabilities: List[str]) -> str:
         """Format model capabilities as colored emoji+word badges.
@@ -114,7 +166,10 @@ class ModelManager:
         """Display the currently selected model in the console."""
         capabilities = self._capabilities_cache.get(self.model, [])
         badges = self.format_capabilities_badges(capabilities)
-        content = f"[bold blue]Current model:[/bold blue] [bold green]{self.model}[/bold green]"
+        content = (
+            f"[bold blue]Current model:[/bold blue] [bold green]{self.model}[/bold green]"
+            f" [bold yellow]({self.provider})[/bold yellow]"
+        )
         if badges:
             content += f"\n[bold blue]Capabilities:[/bold blue] {badges}"
         self.console.print(Panel(content, border_style="blue", expand=False))
@@ -143,12 +198,20 @@ class ModelManager:
 
         # Format the date if available
         modified_at = model.get("modified_at", "Unknown")
-        if modified_at != "Unknown":
+        if modified_at and modified_at != "Unknown":
             try:
-                # Directly format the datetime object
-                modified_at = modified_at.strftime("%Y-%m-%d %H:%M:%S")
+                if hasattr(modified_at, "strftime"):
+                    # datetime object (e.g. from non-ollama providers)
+                    modified_at = modified_at.strftime("%Y-%m-%d %H:%M:%S")
+                elif isinstance(modified_at, str):
+                    # ISO string from ollama native API — parse then format
+                    from datetime import datetime
+                    dt = datetime.fromisoformat(modified_at)
+                    modified_at = dt.strftime("%Y-%m-%d %H:%M:%S")
             except Exception:
                 modified_at = "Unknown date"
+        else:
+            modified_at = "Unknown"
 
         return model_name, size_str, modified_at
 
@@ -345,7 +408,7 @@ class ModelManager:
                 "[bold yellow]No Ollama models found on this host.[/bold yellow]\n\n"
                 "Pull one in another terminal, for example:\n"
                 "[bold cyan]ollama pull qwen3:0.6b[/bold cyan]\n\n"
-                "Then restart ollmcp, or run [bold cyan]/model[/bold cyan] once a model is installed.",
+                "Then restart ollmcp, or run [bold cyan]/model[/bold cyan] once a model is available.",
                 title="No Models Available", border_style="yellow", expand=False
             ))
             self.console.print()
@@ -360,7 +423,7 @@ class ModelManager:
         else:
             requested, used = status
             self.console.print(Panel(
-                f"Requested model [bold yellow]{requested}[/bold yellow] is not installed — "
+                f"Requested model [bold yellow]{requested}[/bold yellow] is not available — "
                 f"using [bold green]{used}[/bold green] instead.\n\n"
                 f"Pull it with [bold cyan]ollama pull {requested}[/bold cyan] to use it, or:\n"
                 "• Switch models: [bold cyan]/model[/bold cyan] or [bold cyan]/m[/bold cyan]\n"

--- a/mcp_client_for_ollama/prompts/commands.py
+++ b/mcp_client_for_ollama/prompts/commands.py
@@ -52,6 +52,10 @@ async def run_slash_command(client: Any, command_name: str) -> bool:
         await client.set_loop_limit()
         return True
 
+    if command_name == 'reasoning-effort':
+        await client.select_reasoning_effort()
+        return True
+
     if command_name == 'show-tool-execution':
         client.toggle_show_tool_execution()
         return True

--- a/mcp_client_for_ollama/prompts/routing.py
+++ b/mcp_client_for_ollama/prompts/routing.py
@@ -24,6 +24,8 @@ SLASH_COMMAND_ALIASES = {
     "st": "show-thinking",
     "loop-limit": "loop-limit",
     "ll": "loop-limit",
+    "reasoning-effort": "reasoning-effort",
+    "re": "reasoning-effort",
     "show-tool-execution": "show-tool-execution",
     "ste": "show-tool-execution",
     "show-metrics": "show-metrics",

--- a/mcp_client_for_ollama/utils/connection.py
+++ b/mcp_client_for_ollama/utils/connection.py
@@ -1,10 +1,50 @@
-"""Utility to test connectivity"""
-from typing import Any, Optional
+"""Utility to test connectivity and provider validation"""
+from typing import Any
 
-import ollama
+from rich.console import Console
 from rich.panel import Panel
 import urllib.request
 import urllib.error
+
+from any_llm import AnyLLM
+from any_llm.exceptions import UnsupportedProviderError
+from any_llm.providers.openai.base import BaseOpenAIProvider
+
+from .constants import SUPPORTED_PROVIDERS
+
+
+def validate_provider(provider: str, console: Console) -> bool:
+    """Validate that a provider is known and supported by ollmcp.
+
+    Returns True if the provider is usable, False otherwise (after printing
+    a user-facing error panel).
+    """
+    try:
+        provider_class = AnyLLM.get_provider_class(provider)
+    except UnsupportedProviderError:
+        console.print() # newline for spacing
+        console.print(Panel(
+            f"[bold red]Unknown provider:[/bold red] [bold blue]{provider}[/bold blue] is not a valid provider name.\n\n"
+            f"Currently supported: {SUPPORTED_PROVIDERS}.\n\n"
+            f"[dim]More providers coming soon.[/dim]",
+            title="Unknown Provider", border_style="red", expand=False
+        ))
+        return False
+    except ImportError:
+        provider_class = None
+
+    if provider_class is None or (provider != "ollama" and not issubclass(provider_class, BaseOpenAIProvider)):
+        console.print() # newline for spacing
+        console.print(Panel(
+            f"[bold yellow]Provider not available yet:[/bold yellow] [bold blue]{provider}[/bold blue] isn't supported by ollmcp yet.\n\n"
+            f"Currently supported: {SUPPORTED_PROVIDERS}.\n\n"
+            f"[dim]More providers coming soon.[/dim]",
+            title="Provider Not Supported", border_style="yellow", expand=False
+        ))
+        return False
+
+    return True
+
 
 def check_url_connectivity(url):
     """
@@ -29,48 +69,48 @@ def check_url_connectivity(url):
         return False
 
 
-async def preflight_ollama(client: Any, cli_host: Optional[str] = None) -> bool:
-    """Resolve preflight host and check Ollama availability.
+async def preflight_ollama(client: Any) -> bool:
+    """Check that the client's configured LLM provider is reachable.
 
-    Host resolution order:
-    1) CLI host (`cli_host`) if provided
-    2) default saved config host (if present)
-    3) current client host
-
-    This function mutates `client.host`, `client.ollama`, and
-    `client.model_manager.ollama` when host resolution changes.
+    The provider, host, and API key are already resolved on the client before
+    this runs, so this only performs the reachability check and renders a
+    provider-appropriate error panel when it fails.
 
     Args:
-        client: MCPClient-like object with config/model manager members.
-        cli_host: Optional host provided from CLI args.
+        client: MCPClient-like object with a `model_manager` member.
 
     Returns:
-        bool: True when Ollama is reachable, otherwise False.
+        bool: True when the provider is reachable, otherwise False.
     """
-    preflight_host = cli_host if cli_host is not None else client.host
-
-    if cli_host is None and client.config_manager.config_exists("default"):
-        default_config = client.config_manager.load_configuration("default")
-        config_host = default_config.get("host")
-        if config_host:
-            preflight_host = config_host
-
-    if preflight_host != client.host:
-        client.host = preflight_host
-        client.ollama = ollama.AsyncClient(host=preflight_host)
-        client.model_manager.ollama = client.ollama
-
     is_running = await client.model_manager.check_ollama_running()
     if not is_running:
-        client.console.print(Panel(
-            "[bold red]Error: Ollama is not running![/bold red]\n\n"
-            f"[yellow]Ollama current configured host: {client.host}[/yellow]\n\n"
-            "This client requires Ollama to be running to process queries.\n\n"
-            "Please start Ollama by running the 'ollama serve' command in a terminal.\n\n"
-            "💡 [bold magenta]Tip:[/bold magenta] If you configured a different host in a saved default configuration you can\n\n"
-            "   1. Use --host flag to override the configured host for example: ollmcp --host http://localhost:11434\n"
-            "   2. Once done, you can save a new default configuration to avoid needing to specify it each time.",
-            title="Ollama Not Running", border_style="red", expand=False
-        ))
+        if client.provider == "ollama":
+            client.console.print(Panel(
+                "[bold red]Error: Cannot connect to Ollama![/bold red]\n\n"
+                f"[yellow]Configured host: {client.host}[/yellow]\n\n"
+                "Possible causes:\n"
+                "• Ollama is not running or unreachable\n"
+                "• Incorrect host/port configuration\n\n"
+                "Solutions:\n"
+                "• Start it with [bold cyan]ollama serve[/bold cyan]\n"
+                "• Use [bold cyan]--host[/bold cyan] to point at a different Ollama host\n"
+                "• Use [bold cyan]--provider[/bold cyan] and [bold cyan]--api-key[/bold cyan] for a remote provider",
+                title="Ollama Not Available", border_style="red", expand=False
+            ))
+        else:
+            host_line = f"[yellow]API base URL: {client.host}[/yellow]\n\n" if client.host else ""
+            client.console.print(Panel(
+                f"[bold red]Error: Cannot reach the {client.provider} provider![/bold red]\n\n"
+                f"{host_line}"
+                "Possible causes:\n"
+                "• Invalid or missing API key\n"
+                "• Network/connectivity issue\n"
+                "• Wrong API base URL\n\n"
+                "Solutions:\n"
+                "• Check your [bold cyan]--api-key[/bold cyan] / [bold cyan]$OLLMCP_API_KEY[/bold cyan]\n"
+                "• Use [bold cyan]--host[/bold cyan] to override the API base URL if needed\n"
+                "• Verify the provider name and that its package is installed",
+                title="LLM Provider Not Available", border_style="red", expand=False
+            ))
 
     return is_running

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -27,6 +27,16 @@ DEFAULT_MODEL = "qwen3:0.6b"
 # Default ollama lcoal url for API requests
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 
+# Default LLM provider
+DEFAULT_PROVIDER = "ollama"
+
+# Providers ollmcp currently supports: Ollama (native) plus OpenAI and any
+# OpenAI-compatible provider (they all use the bundled openai package).
+SUPPORTED_PROVIDERS = (
+    "ollama, openai, and OpenAI-compatible providers "
+    "(openrouter, deepseek, perplexity, etc.)"
+)
+
 # Default number of history entries to display when returning from menus
 DEFAULT_HISTORY_DISPLAY_LIMIT = 5
 

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -30,6 +30,11 @@ DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 # Default LLM provider
 DEFAULT_PROVIDER = "ollama"
 
+# Reasoning effort levels exposed to the user (excludes "none" which conflicts with thinking-mode
+# being the master on/off switch, and any-llm's internal "auto" handling on Ollama is special-cased)
+REASONING_EFFORT_LEVELS = ("auto", "minimal", "low", "medium", "high", "xhigh")
+DEFAULT_REASONING_EFFORT = "medium"
+
 # Providers ollmcp currently supports: Ollama (native) plus OpenAI and any
 # OpenAI-compatible provider (they all use the bundled openai package).
 SUPPORTED_PROVIDERS = (
@@ -81,6 +86,7 @@ INTERACTIVE_COMMANDS = {
     'load-config': 'Load saved configuration',
     'loop-limit': 'Set agent max loop limit',
     'model-config': 'Configure model parameters',
+    'reasoning-effort': 'Set reasoning effort level',
     'model': 'Select Ollama model',
     'input-mode': 'Switch chat input between single-line and multiline',
     'prompts': 'Browse available MCP prompts',

--- a/mcp_client_for_ollama/utils/images.py
+++ b/mcp_client_for_ollama/utils/images.py
@@ -1,0 +1,27 @@
+"""Image format conversion for LLM provider compatibility."""
+
+from typing import Any, Dict, List
+
+
+def apply_images(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert Ollama-style `images` fields to OpenAI content arrays.
+
+    All any-llm providers expect the OpenAI content-array format for images.
+    Providers that use a different native format (e.g. Ollama) convert
+    internally from this universal representation.
+    """
+    result = []
+    for msg in messages:
+        if msg.get("images") and msg.get("role") == "user":
+            content_parts = [{"type": "text", "text": msg.get("content", "")}]
+            for img in msg["images"]:
+                content_parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{img}"},
+                })
+            new_msg = {k: v for k, v in msg.items() if k not in ("images", "content")}
+            new_msg["content"] = content_parts
+            result.append(new_msg)
+        else:
+            result.append(msg)
+    return result

--- a/mcp_client_for_ollama/utils/input.py
+++ b/mcp_client_for_ollama/utils/input.py
@@ -1,50 +1,84 @@
 """
 Input utilities for the MCP client for Ollama.
 
-This module provides functions for getting user input without autocomplete.
+This module provides functions for getting user input without autocomplete
+and reading a single keypress in a cross-platform manner.
 """
+
+from __future__ import annotations
+
+import os
 import sys
-import tty
-import termios
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.styles import Style
+
 from .constants import DEFAULT_COMPLETION_STYLE
 
 
-def read_single_keypress() -> str:
-    """Read a single keypress without requiring Enter."""
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return ch
+if os.name == "nt":
+    import msvcrt
+
+    def read_single_keypress() -> str:
+        """
+        Read a single keypress without requiring Enter.
+
+        Uses the Windows console API via ``msvcrt``.
+        Function keys and arrow keys emit a two-byte sequence; those
+        prefixes are discarded so only meaningful key presses are returned.
+        """
+        while True:
+            ch = msvcrt.getwch()
+
+            # Function keys / arrow keys
+            if ch in ("\x00", "\xe0"):
+                msvcrt.getwch()
+                continue
+
+            # Normalize Ctrl+C behaviour
+            if ch == "\x03":
+                raise KeyboardInterrupt
+
+            return ch
+
+else:
+    import termios
+    import tty
+
+    def read_single_keypress() -> str:
+        """
+        Read a single keypress without requiring Enter.
+
+        Uses POSIX terminal raw mode.
+        """
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+
+        try:
+            tty.setraw(fd)
+            return sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
 
 async def get_input_no_autocomplete(prompt_text: str) -> str:
-    """Get user input without autocomplete (for file paths, config names, etc.)
+    """
+    Prompt the user without autocomplete.
 
-    This is useful for inputs where prompt/command autocomplete would be distracting
-    or inappropriate, such as file paths, config names, or prompt arguments.
+    Useful for file paths, configuration names and other free-form input.
 
     Args:
-        prompt_text: The prompt text to display (without the ❯ symbol)
+        prompt_text: Prompt displayed to the user.
 
     Returns:
-        str: User input or 'quit' if cancelled
+        The user's input, or ``"quit"`` if the prompt is cancelled.
     """
     try:
-        # Create a temporary session without completer
-        temp_session = PromptSession(
+        session = PromptSession(
             style=Style.from_dict(DEFAULT_COMPLETION_STYLE)
         )
-        user_input = await temp_session.prompt_async(
-            f"{prompt_text}❯ "
-        )
-        return user_input
-    except KeyboardInterrupt:
-        return "quit"
-    except EOFError:
+
+        return await session.prompt_async(f"{prompt_text}❯ ")
+
+    except (KeyboardInterrupt, EOFError):
         return "quit"

--- a/mcp_client_for_ollama/utils/metrics.py
+++ b/mcp_client_for_ollama/utils/metrics.py
@@ -1,87 +1,61 @@
 """
-Metrics display utilities for the MCP client for Ollama.
+Metrics display utilities for the MCP client.
 
-This module provides functions for extracting and displaying performance metrics from Ollama responses.
+This module provides functions for extracting and displaying token usage
+from streaming LLM responses.
 """
 from rich.panel import Panel
 
+
 def extract_metrics(chunk):
-    """Extract metrics from an Ollama response chunk
+    """Extract token usage from a streaming chunk.
 
     Args:
-        chunk: Response chunk from Ollama that may contain metrics
+        chunk: A ChatCompletionChunk that may carry a usage field.
 
     Returns:
-        dict: Dictionary containing extracted metrics, or None if no metrics available
+        dict: Token usage counts, or None if the chunk has no usage data.
     """
-    if not (hasattr(chunk, 'done') and chunk.done):
+    usage = getattr(chunk, "usage", None)
+    if usage is None:
         return None
-
     return {
-        'total_duration': getattr(chunk, 'total_duration', None),
-        'load_duration': getattr(chunk, 'load_duration', None),
-        'prompt_eval_count': getattr(chunk, 'prompt_eval_count', None),
-        'prompt_eval_duration': getattr(chunk, 'prompt_eval_duration', None),
-        'eval_count': getattr(chunk, 'eval_count', None),
-        'eval_duration': getattr(chunk, 'eval_duration', None)
+        "prompt_tokens": getattr(usage, "prompt_tokens", None),
+        "completion_tokens": getattr(usage, "completion_tokens", None),
+        "total_tokens": getattr(usage, "total_tokens", None),
     }
 
+
 def display_metrics(console, metrics):
-    """Display performance metrics in a formatted way
+    """Display token usage in a formatted panel.
 
     Args:
         console: Rich console for output
-        metrics: Dictionary containing metrics from Ollama response
+        metrics: Dictionary containing token usage from the response
     """
     if not metrics:
         return
 
-    # Convert nanoseconds to seconds for durations
-    def ns_to_seconds(ns_value):
-        return ns_value / 1_000_000_000 if ns_value else 0
+    prompt_tokens = metrics.get("prompt_tokens") or 0
+    completion_tokens = metrics.get("completion_tokens") or 0
+    total_tokens = metrics.get("total_tokens") or 0
 
-    total_duration = ns_to_seconds(metrics.get('total_duration'))
-    load_duration = ns_to_seconds(metrics.get('load_duration'))
-    prompt_eval_duration = ns_to_seconds(metrics.get('prompt_eval_duration'))
-    eval_duration = ns_to_seconds(metrics.get('eval_duration'))
+    if not any([prompt_tokens, completion_tokens, total_tokens]):
+        return
 
-    prompt_eval_count = metrics.get('prompt_eval_count', 0)
-    eval_count = metrics.get('eval_count', 0)
+    lines = []
+    if prompt_tokens:
+        lines.append(f"[cyan]prompt tokens:[/cyan]     {prompt_tokens}")
+    if completion_tokens:
+        lines.append(f"[cyan]completion tokens:[/cyan] {completion_tokens}")
+    if total_tokens:
+        lines.append(f"[cyan]total tokens:[/cyan]      {total_tokens}")
 
-    # Build metrics content
-    metrics_lines = []
-
-    # Display basic metrics
-    if total_duration > 0:
-        metrics_lines.append(f"[cyan]total duration:[/cyan]       {total_duration:.9f}s")
-    if load_duration > 0:
-        metrics_lines.append(f"[cyan]load duration:[/cyan]        {load_duration * 1000:.6f}ms")
-    if prompt_eval_count:
-        metrics_lines.append(f"[cyan]prompt eval count:[/cyan]    {prompt_eval_count} token(s)")
-    if prompt_eval_duration > 0:
-        metrics_lines.append(f"[cyan]prompt eval duration:[/cyan] {prompt_eval_duration * 1000:.6f}ms")
-    if eval_count:
-        metrics_lines.append(f"[cyan]eval count:[/cyan]           {eval_count} token(s)")
-    if eval_duration > 0:
-        metrics_lines.append(f"[cyan]eval duration:[/cyan]        {eval_duration:.9f}s")
-
-    # Calculate and display rates
-    if prompt_eval_count and prompt_eval_duration > 0:
-        prompt_eval_rate = prompt_eval_count / prompt_eval_duration
-        metrics_lines.append(f"[green]prompt eval rate:[/green]     {prompt_eval_rate:.2f} tokens/s")
-
-    if eval_count and eval_duration > 0:
-        eval_rate = eval_count / eval_duration
-        metrics_lines.append(f"[green]eval rate:[/green]            {eval_rate:.2f} tokens/s")
-
-    # Display metrics in a panel
-    if metrics_lines:
-        console.print()  # Add spacing before panel
-        metrics_content = "\n".join(metrics_lines)
-        console.print(Panel(
-            metrics_content,
-            title="📊 Performance Metrics",
-            border_style="violet",
-            expand=False
-        ))
-        console.print()  # Add spacing after panel
+    console.print()
+    console.print(Panel(
+        "\n".join(lines),
+        title="📊 Token Usage",
+        border_style="violet",
+        expand=False,
+    ))
+    console.print()

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -203,7 +203,7 @@ class StreamingManager:
         """Process a streaming response from Ollama with status spinner and content updates
 
         Args:
-            stream: Async iterator of response chunks
+            stream: Async iterator of ChatCompletionChunk objects
             print_response: Flag to control live updating of response text
             thinking_mode: Whether to handle thinking mode responses
             show_thinking: Whether to keep thinking text visible in final output
@@ -234,27 +234,47 @@ class StreamingManager:
             status = self.console.status("[cyan]working...", spinner="dots")
             status.start()
 
+            # Buffer for incremental tool call deltas
+            tool_call_buffers = {}
 
             try:
-                async for chunk in stream:
+                stream_iter = stream.__aiter__()
+                while True:
+                    try:
+                        chunk = await stream_iter.__anext__()
+                    except StopAsyncIteration:
+                        break
+                    except Exception as e:
+                        import logging
+                        logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
+                        continue
+
                     # Check for cancellation
                     if cancellation_check and cancellation_check():
                         self.console.print("\n[yellow]Generation aborted by user.[/yellow]")
                         return accumulated_text, tool_calls, metrics
 
-                    # Capture metrics when chunk is done
+                    # Capture metrics when chunk carries usage data
                     extracted_metrics = extract_metrics(chunk)
                     if extracted_metrics:
                         metrics = extracted_metrics
 
+                    if not getattr(chunk, "choices", None):
+                        continue
+
+                    choice = chunk.choices[0]
+                    delta = choice.delta
+
                     # Handle thinking content
-                    if (thinking_mode and hasattr(chunk, 'message') and
-                        hasattr(chunk.message, 'thinking') and chunk.message.thinking):
-                        # Stop spinner on first thinking chunk ONLY if show_thinking is True
+                    thinking = None
+                    reasoning = getattr(delta, "reasoning", None)
+                    if reasoning is not None:
+                        thinking = reasoning.content if hasattr(reasoning, "content") else (reasoning if isinstance(reasoning, str) else None)
+
+                    if thinking_mode and thinking:
                         if first_chunk and show_thinking:
                             status.stop()
                             first_chunk = False
-
                         if not thinking_content:
                             thinking_content = "🤔 **Thinking:**\n\n"
                             if not thinking_started and show_thinking:
@@ -262,45 +282,57 @@ class StreamingManager:
                                 self.console.print(Markdown("---"))
                                 self.console.print()
                                 thinking_started = True
-                        thinking_content += chunk.message.thinking
-                        # Print thinking content as plain text only if show_thinking is True
+                        thinking_content += thinking
                         if show_thinking:
-                            self.console.print(chunk.message.thinking, end="")
+                            self.console.print(thinking, end="")
 
                     # Handle regular content
-                    if (hasattr(chunk, 'message') and hasattr(chunk.message, 'content') and
-                        chunk.message.content):
-                        # Stop spinner on first content chunk (always)
+                    content = getattr(delta, "content", None) or ""
+                    if content:
                         if first_chunk:
                             status.stop()
                             first_chunk = False
-
-                        # Print separator and Answer label when transitioning from thinking to content
                         if not accumulated_text and stream_plain_text:
                             self._print_answer_transition_header(show_thinking, "plain")
-
-                        accumulated_text += chunk.message.content
-
-                        # Print only new content as plain text (will render full markdown at end)
+                        accumulated_text += content
                         if stream_plain_text:
-                            self.console.print(chunk.message.content, end="")
+                            self.console.print(content, end="")
                         elif render_mode == "markdown":
                             if progressive_renderer is None:
                                 self._print_answer_transition_header(show_thinking, "markdown")
                                 progressive_renderer = ProgressiveMarkdownRenderer(self.console)
                                 progressive_renderer.start()
-                            progressive_renderer.update(chunk.message.content)
+                            progressive_renderer.update(content)
 
-                    # Handle tool calls
-                    if (hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and
-                        chunk.message.tool_calls):
-                        # Stop spinner on first tool call chunk (always) - just in case no content arrives
+                    # Buffer incremental tool call deltas
+                    delta_tool_calls = getattr(delta, "tool_calls", None)
+                    if delta_tool_calls:
                         if first_chunk:
                             status.stop()
                             first_chunk = False
+                        for tc in delta_tool_calls:
+                            idx = tc.index if hasattr(tc, "index") else 0
+                            if idx not in tool_call_buffers:
+                                tool_call_buffers[idx] = {"id": "", "name": "", "arguments": ""}
+                            buf = tool_call_buffers[idx]
+                            if getattr(tc, "id", None):
+                                buf["id"] = tc.id
+                            if hasattr(tc, "function") and tc.function:
+                                if getattr(tc.function, "name", None):
+                                    buf["name"] += tc.function.name
+                                if getattr(tc.function, "arguments", None):
+                                    buf["arguments"] += tc.function.arguments
 
-                        for tool in chunk.message.tool_calls:
-                            tool_calls.append(tool)
+                    # On finish, emit completed tool calls
+                    if getattr(choice, "finish_reason", None) and tool_call_buffers:
+                        for idx, buf in sorted(tool_call_buffers.items()):
+                            tool_calls.append({
+                                "id": buf["id"] or f"call_{idx}",
+                                "type": "function",
+                                "function": {"name": buf["name"], "arguments": buf["arguments"]},
+                            })
+                        tool_call_buffers.clear()
+
             finally:
                 if progressive_renderer is not None:
                     progressive_renderer.finish()
@@ -315,28 +347,65 @@ class StreamingManager:
 
         else:
             # Silent processing without display
-            async for chunk in stream:
+            tool_call_buffers = {}
+            stream_iter = stream.__aiter__()
+            while True:
+                try:
+                    chunk = await stream_iter.__anext__()
+                except StopAsyncIteration:
+                    break
+                except Exception as e:
+                    import logging
+                    logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
+                    continue
+
                 # Check for cancellation
                 if cancellation_check and cancellation_check():
                     return accumulated_text, tool_calls, metrics
 
-                # Capture metrics when chunk is done
                 extracted_metrics = extract_metrics(chunk)
                 if extracted_metrics:
                     metrics = extracted_metrics
 
-                if (thinking_mode and hasattr(chunk, 'message') and
-                    hasattr(chunk.message, 'thinking') and chunk.message.thinking):
-                    thinking_content += chunk.message.thinking
+                if not getattr(chunk, "choices", None):
+                    continue
 
-                if (hasattr(chunk, 'message') and hasattr(chunk.message, 'content') and
-                    chunk.message.content):
-                    accumulated_text += chunk.message.content
+                choice = chunk.choices[0]
+                delta = choice.delta
 
-                if (hasattr(chunk, 'message') and hasattr(chunk.message, 'tool_calls') and
-                    chunk.message.tool_calls):
-                    for tool in chunk.message.tool_calls:
-                        tool_calls.append(tool)
+                reasoning = getattr(delta, "reasoning", None)
+                if thinking_mode and reasoning is not None:
+                    thinking = reasoning.content if hasattr(reasoning, "content") else (reasoning if isinstance(reasoning, str) else None)
+                    if thinking:
+                        thinking_content += thinking
+
+                content = getattr(delta, "content", None) or ""
+                if content:
+                    accumulated_text += content
+
+                delta_tool_calls = getattr(delta, "tool_calls", None)
+                if delta_tool_calls:
+                    for tc in delta_tool_calls:
+                        idx = tc.index if hasattr(tc, "index") else 0
+                        if idx not in tool_call_buffers:
+                            tool_call_buffers[idx] = {"id": "", "name": "", "arguments": ""}
+                        buf = tool_call_buffers[idx]
+                        if getattr(tc, "id", None):
+                            buf["id"] = tc.id
+                        if hasattr(tc, "function") and tc.function:
+                            if getattr(tc.function, "name", None):
+                                buf["name"] += tc.function.name
+                            if getattr(tc.function, "arguments", None):
+                                buf["arguments"] += tc.function.arguments
+
+                if getattr(choice, "finish_reason", None) and tool_call_buffers:
+                    for idx, buf in sorted(tool_call_buffers.items()):
+                        tool_calls.append({
+                            "id": buf["id"] or f"call_{idx}",
+                            "type": "function",
+                            "function": {"name": buf["name"], "arguments": buf["arguments"]},
+                        })
+                    tool_call_buffers.clear()
 
         # Display metrics if requested
         if show_metrics and metrics:

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -92,6 +92,11 @@ class ProgressiveMarkdownRenderer:
 
         commit_point = self._find_safe_commit_point(uncommitted)
         if commit_point is None:
+            # No paragraph boundary, but the live zone is taller than the
+            # threshold. Fall back to the last single-newline boundary so the
+            # zone stays bounded and rich.Live can still erase prior frames.
+            commit_point = self._find_fallback_commit_point(uncommitted)
+        if commit_point is None:
             return
 
         text_to_commit = uncommitted[:commit_point]
@@ -161,10 +166,88 @@ class ProgressiveMarkdownRenderer:
 
         return last_safe_break
 
+    def _find_fallback_commit_point(self, text):
+        """Find the last single-newline boundary not inside a fenced code block.
+
+        Used when content is taller than the viewport but has no paragraph
+        boundary to commit at. Commits up to the last newline, leaving only the
+        final (in-progress) line in the Live zone. Returns the index or None if
+        no safe point exists (e.g. inside a code fence or a single long line).
+        """
+        in_code_block = False
+        last_safe_break = None
+        pos = 0
+
+        lines = text.split("\n")
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+
+            pos += len(line) + 1  # Move past this line and its newline
+
+            # Safe to break after this line if we're outside a code block and
+            # there is a following line to keep in the Live zone.
+            if not in_code_block and i < len(lines) - 1 and pos < len(text):
+                last_safe_break = pos
+
+        return last_safe_break
+
+
+class BlockMarkdownRenderer(ProgressiveMarkdownRenderer):
+    """Append-only markdown renderer.
+
+    Prints each completed markdown block (paragraph/list/table/code fence) once
+    via console.print and never redraws it. Because nothing is ever erased, it
+    cannot exhibit the rich.Live cursor-miscount duplication that occurs with
+    wide glyphs (emoji) or terminal resizes.
+    """
+
+    def start(self):
+        """No live zone; just reset the refresh throttle."""
+        self._last_refresh = monotonic()
+
+    def update(self, new_chunk):
+        """Append a chunk and flush any completed blocks (throttled)."""
+        self.full_text += new_chunk
+        now = monotonic()
+        if now - self._last_refresh < self.REFRESH_INTERVAL:
+            return
+        self._last_refresh = now
+        self._commit_complete_blocks()
+
+    def finish(self):
+        """Flush whatever remains as a final markdown block."""
+        remaining = self.full_text[len(self.committed_text):]
+        if remaining:
+            self._print_markdown_preserving_trailing_newlines(remaining)
+            self.committed_text = self.full_text
+
+    def _commit_complete_blocks(self):
+        """Commit complete paragraphs; flush lines if a block grows too tall."""
+        uncommitted = self.full_text[len(self.committed_text):]
+        if not uncommitted:
+            return
+        commit_point = self._find_safe_commit_point(uncommitted)
+        if commit_point is None:
+            # No completed paragraph yet. If the in-progress block is already
+            # taller than the viewport, flush its completed lines so long prose
+            # keeps flowing; otherwise wait for more content.
+            terminal_size = shutil.get_terminal_size()
+            viewport_height = max(1, terminal_size.lines - 2)
+            threshold = int(viewport_height * self.VIEWPORT_COMMIT_THRESHOLD)
+            if self._estimate_height(uncommitted, terminal_size.columns) > threshold:
+                commit_point = self._find_fallback_commit_point(uncommitted)
+        if commit_point is None:
+            return
+        self._print_markdown_preserving_trailing_newlines(uncommitted[:commit_point])
+        self.committed_text += uncommitted[:commit_point]
+
+
 class StreamingManager:
     """Manages streaming responses for Ollama API calls"""
 
-    VALID_ANSWER_RENDER_MODES = {"plain", "markdown", "both"}
+    VALID_ANSWER_RENDER_MODES = {"plain", "markdown", "both", "blocks"}
 
     def __init__(self, console):
         """Initialize the streaming manager
@@ -297,10 +380,14 @@ class StreamingManager:
                         accumulated_text += content
                         if stream_plain_text:
                             self.console.print(content, end="")
-                        elif render_mode == "markdown":
+                        elif render_mode in {"markdown", "blocks"}:
                             if progressive_renderer is None:
                                 self._print_answer_transition_header(show_thinking, "markdown")
-                                progressive_renderer = ProgressiveMarkdownRenderer(self.console)
+                                renderer_cls = (
+                                    BlockMarkdownRenderer if render_mode == "blocks"
+                                    else ProgressiveMarkdownRenderer
+                                )
+                                progressive_renderer = renderer_cls(self.console)
                                 progressive_renderer.start()
                             progressive_renderer.update(content)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-client-for-ollama"
-version = "0.30.0"
+version = "0.31.0"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcp-client-for-ollama"
 version = "0.30.0"
 description = "MCP Client for Ollama - A client for connecting to Model Context Protocol servers using Ollama"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "MIT"
 authors = [
     {name = "Jonathan Löwenstern"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
+    "any-llm-sdk[ollama,openai] ~=1.18.0",
     "mcp>=1.25,<1.28",
-    "ollama~=0.6.0",
     "prompt-toolkit~=3.0.52",
     "rich>=14.2.0,<14.3",
     "typer~=0.21.0",

--- a/tests/test_api_key_persistence.py
+++ b/tests/test_api_key_persistence.py
@@ -1,0 +1,62 @@
+"""Tests for API key persistence in MCPClient.save_configuration().
+
+Keys supplied through the OLLMCP_API_KEY env var (persist_api_key=False) must
+never be written to the config file, while keys passed via --api-key
+(persist_api_key=True) are saved. A previously saved key is preserved when a
+non-persistable key is in use.
+"""
+
+import json
+
+from mcp_client_for_ollama.client import MCPClient
+from mcp_client_for_ollama.config import manager as config_manager
+
+
+def _saved_api_key(config_dir, provider="ollama"):
+    with open(config_dir / "config.json") as f:
+        return json.load(f)["providers"][provider]["apiKey"]
+
+
+def _make_client():
+    client = MCPClient()
+    client.model_manager.set_model("test-model")
+    return client
+
+
+def test_flag_key_is_persisted(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    client = _make_client()
+    client.api_key = "sk-flag"
+    client.persist_api_key = True
+
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == "sk-flag"
+
+
+def test_env_key_is_not_persisted(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    client = _make_client()
+    client.api_key = "sk-env"
+    client.persist_api_key = False
+
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == ""
+
+
+def test_env_key_preserves_previously_saved_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_manager, "DEFAULT_CONFIG_DIR", str(tmp_path))
+
+    # First run saves a key from the --api-key flag.
+    client = _make_client()
+    client.api_key = "sk-saved"
+    client.persist_api_key = True
+    client.save_configuration()
+
+    # A later run uses an env-var key, which must not overwrite the saved one.
+    client.api_key = "sk-env"
+    client.persist_api_key = False
+    client.save_configuration()
+
+    assert _saved_api_key(tmp_path) == "sk-saved"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -5,37 +5,82 @@ from mcp_client_for_ollama.config.defaults import default_config
 from rich.console import Console
 
 
-def test_validate_config_preserves_host():
-    """Test that _validate_config preserves the host field from loaded config."""
+def test_validate_config_preserves_providers_map():
+    """A new-format config keeps its per-provider profiles and defaultProvider."""
     mgr = ConfigManager(Console())
 
-    config_data = {
-        "host": "http://remote-server:11434",
-        "model": "test-model"
-    }
+    validated = mgr._validate_config({
+        "defaultProvider": "openai",
+        "providers": {
+            "ollama": {"host": "http://localhost:11434", "model": "qwen3:0.6b", "apiKey": ""},
+            "openai": {"host": "", "model": "gpt-4o", "apiKey": "sk-test"},
+        },
+    })
 
-    validated = mgr._validate_config(config_data)
+    assert validated["defaultProvider"] == "openai"
+    assert validated["providers"]["openai"] == {"host": "", "model": "gpt-4o", "apiKey": "sk-test"}
+    assert validated["providers"]["ollama"]["model"] == "qwen3:0.6b"
 
-    assert validated["host"] == "http://remote-server:11434"
 
-
-def test_validate_config_omits_host_when_missing():
-    """Test that _validate_config omits host when not in config file.
-
-    This allows CLI arguments to take precedence over defaults when
-    the config file doesn't have a host field (e.g., older config files).
-    """
+def test_validate_config_migrates_legacy_flat_config():
+    """A legacy flat config is migrated into a single provider profile."""
     mgr = ConfigManager(Console())
 
-    config_data = {
-        "model": "test-model"
+    validated = mgr._validate_config({
+        "host": "https://api.atlascloud.ai/v1",
+        "model": "deepseek",
+        "provider": "openai",
+        "apiKey": "sk-legacy",
+    })
+
+    assert validated["defaultProvider"] == "openai"
+    assert validated["providers"]["openai"] == {
+        "host": "https://api.atlascloud.ai/v1",
+        "model": "deepseek",
+        "apiKey": "sk-legacy",
     }
 
-    validated = mgr._validate_config(config_data)
 
-    # Host should NOT be in the validated config when not in original
-    # This allows CLI arguments to take precedence
-    assert "host" not in validated
+def test_validate_config_legacy_without_provider_defaults_to_ollama():
+    """A legacy config lacking a provider migrates under ollama."""
+    mgr = ConfigManager(Console())
+
+    validated = mgr._validate_config({"model": "test-model"})
+
+    assert validated["defaultProvider"] == "ollama"
+    assert validated["providers"]["ollama"]["model"] == "test-model"
+
+
+def test_validate_config_seeds_default_provider_when_absent():
+    """A config with neither providers nor connection fields still seeds ollama."""
+    mgr = ConfigManager(Console())
+
+    validated = mgr._validate_config({"displaySettings": {"answerRenderMode": "both"}})
+
+    assert validated["defaultProvider"] == "ollama"
+    assert "ollama" in validated["providers"]
+
+
+def test_save_load_round_trip_preserves_all_providers(monkeypatch, tmp_path):
+    """Saving and reloading keeps every provider profile and the default."""
+    import mcp_client_for_ollama.config.manager as manager_module
+
+    monkeypatch.setattr(manager_module, "DEFAULT_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(manager_module, "DEFAULT_CONFIG_FILE", "config.json")
+
+    mgr = ConfigManager(Console())
+    cfg = default_config()
+    cfg["providers"]["openai"] = {"host": "", "model": "gpt-4o", "apiKey": "sk-test"}
+    cfg["defaultProvider"] = "openai"
+
+    assert mgr.save_configuration(cfg, "default") is True
+
+    loaded = mgr.load_configuration("default")
+    assert loaded["defaultProvider"] == "openai"
+    assert loaded["providers"]["openai"]["model"] == "gpt-4o"
+    assert loaded["providers"]["openai"]["apiKey"] == "sk-test"
+    # The pre-existing ollama profile is not dropped.
+    assert "ollama" in loaded["providers"]
 
 
 def test_default_config_shows_thinking_text():

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -141,3 +141,32 @@ def test_validate_config_ignores_invalid_input_mode():
     })
 
     assert validated["inputSettings"]["inputMode"] == "single"
+
+
+def test_default_config_has_reasoning_effort():
+    """New configurations include reasoningEffort = 'medium'."""
+    config = default_config()
+
+    assert config["modelSettings"]["reasoningEffort"] == "medium"
+
+
+def test_validate_config_preserves_valid_reasoning_effort():
+    """A valid reasoning effort level survives configuration validation."""
+    mgr = ConfigManager(Console())
+
+    for level in ("auto", "minimal", "low", "medium", "high", "xhigh"):
+        validated = mgr._validate_config({
+            "modelSettings": {"reasoningEffort": level}
+        })
+        assert validated["modelSettings"]["reasoningEffort"] == level
+
+
+def test_validate_config_ignores_invalid_reasoning_effort():
+    """An invalid reasoning effort falls back to the default 'medium'."""
+    mgr = ConfigManager(Console())
+
+    validated = mgr._validate_config({
+        "modelSettings": {"reasoningEffort": "turbo-max-extreme"}
+    })
+
+    assert validated["modelSettings"]["reasoningEffort"] == "medium"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -94,7 +94,7 @@ def test_default_config_uses_both_answer_render_modes():
     """Test that new configurations keep the current dual answer display behavior."""
     config = default_config()
 
-    assert config["displaySettings"]["answerRenderMode"] == "markdown"
+    assert config["displaySettings"]["answerRenderMode"] == "both"
 
 
 def test_validate_config_preserves_answer_render_mode():

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -10,10 +10,10 @@ from mcp_client_for_ollama.models.manager import ModelManager
 
 
 def _make_manager(models):
-    """Build a ModelManager with a fake ollama client returning the given models."""
-    fake_ollama = AsyncMock()
-    fake_ollama.list = AsyncMock(return_value={"models": models})
-    return ModelManager(console=Console(), default_model="placeholder:1b", ollama=fake_ollama)
+    """Build a ModelManager whose provider reports the given installed models."""
+    mgr = ModelManager(console=Console(), default_model="placeholder:1b")
+    mgr._list_models = AsyncMock(return_value=models)
+    return mgr
 
 
 class TestResolveInitialModel(unittest.IsolatedAsyncioTestCase):
@@ -79,15 +79,15 @@ class TestResolveInitialModel(unittest.IsolatedAsyncioTestCase):
 
 
 class TestProcessQueryWithNoModel(unittest.IsolatedAsyncioTestCase):
-    async def test_returns_early_without_calling_ollama(self):
+    async def test_returns_early_without_calling_llm(self):
         client = MCPClient()
         client.model_manager.set_model("")
-        client.ollama.chat = AsyncMock(side_effect=AssertionError("ollama.chat should not be called"))
+        client.llm.acompletion = AsyncMock(side_effect=AssertionError("llm.acompletion should not be called"))
 
         response = await client.process_query("hi")
 
         self.assertEqual(response, "")
-        client.ollama.chat.assert_not_called()
+        client.llm.acompletion.assert_not_called()
 
 
 class TestPrintResolutionStatus(unittest.TestCase):

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -1,0 +1,60 @@
+"""Tests for _reasoning_effort_kwargs and related reasoning effort behavior."""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class _ReasoningEffortClient:
+    """Minimal stand-in with just the attributes _reasoning_effort_kwargs reads."""
+
+    def __init__(self, provider, thinking_mode, reasoning_effort):
+        self.provider = provider
+        self.thinking_mode = thinking_mode
+        self.reasoning_effort = reasoning_effort
+
+    def _reasoning_effort_kwargs(self, supports_thinking: bool) -> dict:
+        if not (supports_thinking and self.thinking_mode):
+            return {}
+        effort = self.reasoning_effort
+        if self.provider == "ollama" and effort == "auto":
+            effort = "high"
+        return {"reasoning_effort": effort}
+
+
+class TestReasoningEffortKwargs(unittest.TestCase):
+
+    def test_returns_empty_when_thinking_mode_off(self):
+        client = _ReasoningEffortClient("ollama", thinking_mode=False, reasoning_effort="high")
+        self.assertEqual(client._reasoning_effort_kwargs(supports_thinking=True), {})
+
+    def test_returns_empty_when_model_does_not_support_thinking(self):
+        client = _ReasoningEffortClient("ollama", thinking_mode=True, reasoning_effort="high")
+        self.assertEqual(client._reasoning_effort_kwargs(supports_thinking=False), {})
+
+    def test_returns_configured_level_for_cloud_provider(self):
+        for level in ("minimal", "low", "medium", "high", "xhigh"):
+            client = _ReasoningEffortClient("openai", thinking_mode=True, reasoning_effort=level)
+            result = client._reasoning_effort_kwargs(supports_thinking=True)
+            self.assertEqual(result, {"reasoning_effort": level}, f"failed for level={level}")
+
+    def test_auto_is_forwarded_to_cloud_provider(self):
+        client = _ReasoningEffortClient("openai", thinking_mode=True, reasoning_effort="auto")
+        result = client._reasoning_effort_kwargs(supports_thinking=True)
+        self.assertEqual(result, {"reasoning_effort": "auto"})
+
+    def test_auto_is_substituted_for_ollama(self):
+        """Ollama+auto would silently disable thinking; helper substitutes a concrete level."""
+        client = _ReasoningEffortClient("ollama", thinking_mode=True, reasoning_effort="auto")
+        result = client._reasoning_effort_kwargs(supports_thinking=True)
+        self.assertIn("reasoning_effort", result)
+        self.assertNotEqual(result["reasoning_effort"], "auto",
+                            "auto must be substituted for Ollama so any-llm sets think=True")
+
+    def test_concrete_level_forwarded_for_ollama(self):
+        client = _ReasoningEffortClient("ollama", thinking_mode=True, reasoning_effort="high")
+        result = client._reasoning_effort_kwargs(supports_thinking=True)
+        self.assertEqual(result, {"reasoning_effort": "high"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slash_command_execution.py
+++ b/tests/test_slash_command_execution.py
@@ -20,6 +20,7 @@ class DummyClient:
         self.toggle_context_retention = MagicMock()
         self.toggle_thinking_mode = AsyncMock()
         self.toggle_show_thinking = AsyncMock()
+        self.select_reasoning_effort = AsyncMock()
         self.set_loop_limit = AsyncMock()
         self.toggle_show_tool_execution = MagicMock()
         self.toggle_show_metrics = MagicMock()
@@ -123,6 +124,14 @@ class TestSlashCommandExecution(unittest.IsolatedAsyncioTestCase):
                     self.assertFalse(result)
                 else:
                     self.assertTrue(result)
+
+    async def test_run_reasoning_effort_command_awaits_selection(self):
+        client = DummyClient()
+
+        result = await run_slash_command(client, "reasoning-effort")
+
+        self.assertTrue(result)
+        client.select_reasoning_effort.assert_awaited_once_with()
 
     async def test_unknown_command_raises_assertion(self):
         client = DummyClient()

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -1,10 +1,15 @@
 """Tests for streaming answer rendering modes."""
 
+import os
 import unittest
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
-from mcp_client_for_ollama.utils.streaming import ProgressiveMarkdownRenderer, StreamingManager
+from mcp_client_for_ollama.utils.streaming import (
+    BlockMarkdownRenderer,
+    ProgressiveMarkdownRenderer,
+    StreamingManager,
+)
 
 
 @dataclass
@@ -73,6 +78,9 @@ class TestableProgressiveMarkdownRenderer(ProgressiveMarkdownRenderer):
 
     def estimate_height(self, text, terminal_width):
         return self._estimate_height(text, terminal_width)
+
+    def find_fallback_commit_point(self, text):
+        return self._find_fallback_commit_point(text)
 
 
 class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
@@ -167,6 +175,34 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         # The last update should clear the live zone
         self.assertTrue(any(refresh for _, refresh in live.updates))
 
+    async def test_blocks_mode_uses_append_only_renderer(self):
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.Live",
+            FakeLive,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, _, _ = await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="hello "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="**world**"))]),
+                ),
+                answer_render_mode="blocks",
+            )
+
+        printed = [call.args[0] for call in self.console.print.call_args_list if call.args]
+        self.assertEqual(response_text, "hello **world**")
+        # Markdown header, not the plain one.
+        self.assertNotIn("MD::📝 **Answer:**", printed)
+        self.assertEqual(printed.count("MD::📝 **Answer (Markdown):**"), 1)
+        # Content rendered as markdown via console.print, append-only.
+        self.assertIn("MD::hello **world**", printed)
+        # Block mode never creates a Live zone.
+        self.assertEqual(FakeLive.instances, [])
+
     async def test_visible_thinking_gets_blank_line_before_answer_header(self):
         manager = StreamingManager(self.console)
 
@@ -217,6 +253,111 @@ class TestProgressiveMarkdownRenderer(unittest.TestCase):
     def test_estimate_height_wraps_when_exceeding_width(self):
         estimated_height = self.renderer.estimate_height("abcde", terminal_width=4)
         self.assertEqual(estimated_height, 2)
+
+    def test_fallback_commit_point_uses_last_newline_outside_code_fence(self):
+        point = self.renderer.find_fallback_commit_point("alpha\nbeta\ngamma")
+        # Commits up to the last newline, leaving "gamma" in the live zone.
+        self.assertEqual(point, len("alpha\nbeta\n"))
+
+    def test_fallback_commit_point_skips_inside_code_fence(self):
+        self.assertIsNone(
+            self.renderer.find_fallback_commit_point("```\ncode line\nmore code\n")
+        )
+
+    def test_fallback_commit_point_none_without_newline(self):
+        self.assertIsNone(
+            self.renderer.find_fallback_commit_point("one very long single line")
+        )
+
+    def test_fallback_commit_bounds_live_zone_without_paragraph_breaks(self):
+        renderer = TestableProgressiveMarkdownRenderer(self.console)
+        fake_size = os.terminal_size((80, 10))  # columns=80, lines=10 -> viewport 8
+        times = iter(float(i) for i in range(100))
+        with patch(
+            "mcp_client_for_ollama.utils.streaming.Markdown",
+            side_effect=lambda text: f"MD::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Live", FakeLive
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Text",
+            side_effect=lambda text: f"TEXT::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.shutil.get_terminal_size",
+            return_value=fake_size,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.monotonic",
+            side_effect=lambda *a, **k: next(times),
+        ):
+            renderer.start()
+            for i in range(20):
+                renderer.update(f"line number {i}\n")  # single '\n', never '\n\n'
+
+        # A commit must have occurred even though no paragraph boundary exists.
+        self.assertNotEqual(renderer.committed_text, "")
+        # The remaining live content must stay below the viewport so rich can erase it.
+        uncommitted = renderer.full_text[len(renderer.committed_text):]
+        viewport = max(1, fake_size.lines - 2)
+        self.assertLess(renderer.estimate_height(uncommitted, fake_size.columns), viewport)
+
+
+class TestBlockMarkdownRenderer(unittest.TestCase):
+    """Validate the append-only (block) markdown renderer."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        FakeLive.instances.clear()
+
+    def _drive(self, renderer, chunks, fake_size=os.terminal_size((80, 24))):
+        times = iter(float(i) for i in range(1000))
+        with patch(
+            "mcp_client_for_ollama.utils.streaming.Markdown",
+            side_effect=lambda text: f"MD::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Live", FakeLive
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.shutil.get_terminal_size",
+            return_value=fake_size,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.monotonic",
+            side_effect=lambda *a, **k: next(times),
+        ):
+            renderer.start()
+            for chunk in chunks:
+                renderer.update(chunk)
+            renderer.finish()
+
+    def test_commits_complete_paragraph_without_live(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        self._drive(renderer, ["hello **world**\n\n"])
+
+        printed = [c.args[0] for c in self.console.print.call_args_list if c.args]
+        self.assertIn("MD::hello **world**", printed)
+        # Append-only: it must never create a Live zone.
+        self.assertEqual(FakeLive.instances, [])
+        self.assertEqual(renderer.committed_text, renderer.full_text)
+
+    def test_finish_flushes_remaining_incomplete_block(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        # No paragraph break and short enough to stay buffered until finish().
+        self._drive(renderer, ["just a short answer"])
+
+        printed = [c.args[0] for c in self.console.print.call_args_list if c.args]
+        self.assertIn("MD::just a short answer", printed)
+        self.assertEqual(FakeLive.instances, [])
+
+    def test_long_block_flushes_lines_without_paragraph_breaks(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        # viewport 8, threshold int(8*0.6)=4 -> long single-newline prose flushes.
+        self._drive(
+            renderer,
+            [f"line number {i}\n" for i in range(20)],
+            fake_size=os.terminal_size((80, 10)),
+        )
+
+        # Everything ends up committed (append-only) and no Live was ever used.
+        self.assertEqual(renderer.committed_text, renderer.full_text)
+        self.assertEqual(FakeLive.instances, [])
+        self.assertNotEqual(renderer.committed_text, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -8,19 +8,28 @@ from mcp_client_for_ollama.utils.streaming import ProgressiveMarkdownRenderer, S
 
 
 @dataclass
-class DummyMessage:
-    """Minimal message double for streaming tests."""
+class DummyDelta:
+    """Minimal delta double for streaming tests."""
 
     content: str = ""
-    thinking: str = ""
+    reasoning: str = None
     tool_calls: list = None
+
+
+@dataclass
+class DummyChoice:
+    """Minimal choice double for streaming tests."""
+
+    delta: DummyDelta
+    finish_reason: str = None
 
 
 @dataclass
 class DummyChunk:
     """Minimal chunk double for streaming tests."""
 
-    message: DummyMessage
+    choices: list
+    usage: object = None
 
 
 async def _stream_chunks(*chunks):
@@ -83,7 +92,7 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
             return_value=None,
         ):
             response_text, tool_calls, metrics = await manager.process_streaming_response(
-                _stream_chunks(DummyChunk(DummyMessage(content="hello **world**"))),
+                _stream_chunks(DummyChunk(choices=[DummyChoice(DummyDelta(content="hello **world**"))])),
                 answer_render_mode="plain",
             )
 
@@ -104,7 +113,7 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
             return_value=None,
         ):
             response_text, _, _ = await manager.process_streaming_response(
-                _stream_chunks(DummyChunk(DummyMessage(content="hello **world**"))),
+                _stream_chunks(DummyChunk(choices=[DummyChoice(DummyDelta(content="hello **world**"))])),
                 answer_render_mode="both",
             )
 
@@ -133,8 +142,8 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         ):
             response_text, _, _ = await manager.process_streaming_response(
                 _stream_chunks(
-                    DummyChunk(DummyMessage(content="hello ")),
-                    DummyChunk(DummyMessage(content="**world**")),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="hello "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="**world**"))]),
                 ),
                 answer_render_mode="markdown",
             )
@@ -167,8 +176,8 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         ):
             response_text, _, _ = await manager.process_streaming_response(
                 _stream_chunks(
-                    DummyChunk(DummyMessage(thinking="planning")),
-                    DummyChunk(DummyMessage(content="answer")),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="planning"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="answer"))]),
                 ),
                 thinking_mode=True,
                 show_thinking=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
+requires-python = ">=3.11"
 
 [[package]]
 name = "annotated-doc"
@@ -25,11 +21,52 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.112.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/dd/808c144d4a883fcfd12fe0d7689b1d86bbbea6666c1cc957ad19f1017c22/anthropic-0.112.0.tar.gz", hash = "sha256:e180cd91aa5b9b32e4007fe69892ab128d8a86b9f90825103b1903fbc977d0af", size = 937460, upload-time = "2026-06-24T18:45:56.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/26/ea71185027956325be1903d4fcaf7461d5ef40ca8f0e64f992e24ea9db0e/anthropic-0.112.0-py3-none-any.whl", hash = "sha256:bcc6268612c716dbb77133dd60fc41d26016d1b81dee9a52314d210193638751", size = 931954, upload-time = "2026-06-24T18:45:58.205Z" },
+]
+
+[[package]]
+name = "any-llm-sdk"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "openresponses-types" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/9c/8a1b3f014f3ae1db1ca193466ae8b54f49580b0500bd4f25a640b893d5fb/any_llm_sdk-1.18.0.tar.gz", hash = "sha256:9136b094da01a4fd1a6370610bfc03f7d640a4ba72a1f53299044e55ddd74a00", size = 154567, upload-time = "2026-06-22T08:29:10.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/4e/3cb7c7594354105cfa2afedff929a6cc0409a449a9719a5b5c63553201e8/any_llm_sdk-1.18.0-py3-none-any.whl", hash = "sha256:d36d67dada917d31027efb6cc4233e52c5f40b8dfbd8df35f7c4cf9d508b05fb", size = 203446, upload-time = "2026-06-22T08:29:09.436Z" },
+]
+
+[package.optional-dependencies]
+ollama = [
+    { name = "ollama" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -65,18 +102,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
-    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
-    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
-    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
-    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
-    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
     { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
     { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
     { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
@@ -165,7 +190,6 @@ version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -217,15 +241,21 @@ wheels = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
+name = "distro"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -293,6 +323,96 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -300,8 +420,7 @@ dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -362,8 +481,8 @@ name = "mcp-client-for-ollama"
 version = "0.30.0"
 source = { editable = "." }
 dependencies = [
+    { name = "any-llm-sdk", extra = ["ollama"] },
     { name = "mcp" },
-    { name = "ollama" },
     { name = "prompt-toolkit" },
     { name = "rich" },
     { name = "typer" },
@@ -376,8 +495,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "any-llm-sdk", extras = ["ollama", "openai"], specifier = "~=1.18.0" },
     { name = "mcp", specifier = ">=1.25,<1.28" },
-    { name = "ollama", specifier = "~=0.6.0" },
     { name = "prompt-toolkit", specifier = "~=3.0.52" },
     { name = "rich", specifier = ">=14.2.0,<14.3" },
     { name = "typer", specifier = "~=0.21.0" },
@@ -406,6 +525,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+]
+
+[[package]]
+name = "openresponses-types"
+version = "2.3.0.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254, upload-time = "2026-01-22T20:02:03.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/5f/e16dad89ed24f586da5b01b9b206d3adbf21fe1af8e4dc55d5b93158fde6/openresponses_types-2.3.0.post1-py3-none-any.whl", hash = "sha256:88f6abcef9cad839203abff420dd080978bf6eb33cc06ddc5d78da4ccdba7613", size = 13847, upload-time = "2026-01-22T20:02:02.582Z" },
 ]
 
 [[package]]
@@ -471,20 +621,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
-    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
-    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
     { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
     { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
     { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
@@ -605,9 +741,6 @@ wheels = [
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
@@ -624,12 +757,10 @@ version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -659,9 +790,6 @@ name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
     { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
     { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
@@ -685,8 +813,7 @@ version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
@@ -709,136 +836,8 @@ wheels = [
 
 [[package]]
 name = "rpds-py"
-version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
-    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
-    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
-    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
-    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
-    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
-    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
-    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
-    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
-    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
-    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
-    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
-    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
-    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
-    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
-    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
-    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
-    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
-    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
-    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
-    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
-    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
-    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
-    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
-    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
-    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
-    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
-    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
-    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
-]
-
-[[package]]
-name = "rpds-py"
 version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
@@ -982,6 +981,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1008,57 +1016,15 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.4.1"
+name = "tqdm"
+version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
-    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
-    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
-    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
-    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
-    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
-    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
-    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
-    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
-    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
-    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
-    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
-    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
 ]
 
 [[package]]
@@ -1104,7 +1070,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "mcp-client-for-ollama"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk", extra = ["ollama"] },


### PR DESCRIPTION
## Release v0.31.0 — Multiple LLM providers via any-llm 🌍

> ⚠️ **Work in progress.** This is the rollup PR for the `v0.31.0` release. It collects the changes below into a single release into `main`.

The headline of this release is that `ollmcp` is no longer Ollama-only. The client now talks to multiple LLM providers through the [any-llm](https://github.com/mozilla-ai/any-llm) SDK, while keeping **Ollama as the default** and the full TUI experience unchanged.

### ✨ Highlights

- **🌍 Multiple LLM providers** — Use Ollama (default) or any OpenAI-compatible provider (OpenAI, OpenRouter, DeepSeek, Perplexity, etc.). Select one with `--provider/-p`, point it at an endpoint with `--host/-H`, and authenticate with `--api-key/-k` or the provider-agnostic `$OLLMCP_API_KEY` env var.
- **🗂️ Per-provider profiles** — Model, host, and API key are remembered **per provider**, so switching never reuses another provider's settings. A `defaultProvider` is tracked so plain `ollmcp` resumes wherever you left off. Legacy single-provider configs are migrated automatically.
- **🔑 Safer API-key handling** — Clear precedence (`--api-key` → `$OLLMCP_API_KEY` → saved config → provider-native env var). Only keys passed with `--api-key` are written to disk; env-var keys are never persisted. Missing-key and 401 auth errors are now handled gracefully.
- **🖼️ Provider-agnostic vision & metrics** — Images are converted to the OpenAI content-array format so vision works across providers, and token-usage metrics replace Ollama-specific ones.
- **📝 New "Markdown (blocks)" answer display mode** — An append-only renderer that prints each completed markdown block once, fixing the duplicated-lines / flicker issue in the live "Markdown only" mode (especially with wide glyphs/emojis or terminal resizes). The default display mode is now the safer **"both"**.
- **💪 Reasoning effort levels** — New `/reasoning-effort` (`/re`) command to control how much reasoning effort a model applies when thinking mode is on: `auto`, `minimal`, `low`, `medium` (default), `high`, or `xhigh`. Some providers/models may ignore the setting.
- **🔁 Interactive agent loop-limit choices** — When the agent loop limit is reached, the client now presents an interactive prompt instead of silently stopping. You can continue with more iterations, go unlimited, ask the model to wrap up with a final answer, or abort the turn entirely.
- **🪟 Windows support** — Fixed a startup crash on Windows caused by unconditional POSIX-only `tty`/`termios` imports. Windows now uses `msvcrt` for keyboard input; Linux/macOS behavior is unchanged. A dedicated Windows smoke-test CI job now verifies CLI startup.

### 📦 Included changes

| PR | Summary |
| --- | --- |
| #246 | feat(any-llm): refactor MCP client to support multiple LLM providers |
| #248 | fix(build): require Python **>=3.11** for any-llm-sdk compatibility |
| #249 | chore(client): add spacing before the user input prompt |
| #250 | docs: add troubleshooting section and update installation instructions (recommend `uv`) |
| #251 | feat(streaming): add append-only "Markdown (blocks)" answer display mode |
| #252 | fix: update upgrade instructions and command name in output |
| #244 | fix: Windows crash caused by unconditional tty/termios imports |
| #256 | feat: enhance agent mode with interactive choices when loop limit is reached |
| #257 | chore(ci): update release process to use release drafts + add Windows smoke-test workflow |
| #258 | fix(ci): correct Windows smoke-test package installation and command execution |
| #259 | feat: add reasoning effort levels and `/reasoning-effort` command |
| #260 | docs: refine README table of contents and enhance MCP sections |
| #261 | chore(ci): bump dependency-review and checkout GitHub actions |
| #262 | chore(release): bump version to 0.31.0 |

### ⚠️ Breaking change

- **Minimum Python is now 3.11** (was 3.10). `any-llm-sdk` only publishes wheels for Python >=3.11. This applies to both the `mcp-client-for-ollama` and `ollmcp` packages, the CI/publish workflows, and the docs.

### 📌 Notes & current limitations

- **Non-Ollama providers are experimental** and still being stabilized — not everything may work yet.
- **OpenAI-compatible only for now.** Providers any-llm exposes that are *not* OpenAI-compatible (e.g. `anthropic`, `gemini`, `mistral`, `groq`, `cohere`) are not supported yet.
- **Capability detection limitation:** real per-model capabilities (`tools`, `vision`, `thinking`) are only read from Ollama. For every other provider all three are assumed available, so a model may be shown as supporting a capability it doesn't actually have (the provider's API will error when you try to use it).

### ✅ Testing

- New tests for API-key persistence and config migration.
- Expanded streaming-manager tests, including unit + integration coverage for the new block renderer.
- New tests for reasoning-effort levels and slash-command execution.
- Updated model-manager and config-manager tests for the multi-provider flow.
