### PR TITLE
feat(streaming): add append-only "Markdown (blocks)" answer display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ MCP Client for Ollama (ollmcp) is a modern, interactive terminal application (TU
 - 🌍 **Multiple LLM Providers**: Use Ollama (default) or OpenAI-compatible providers (OpenAI, OpenRouter, DeepSeek, etc.), with connection settings remembered per provider
 - 🎨 **Rich Terminal Interface**: Interactive console UI with modern styling
 - 🌊 **Streaming Responses**: View model outputs in real-time as they're generated
-- 📝 **Answer Display Modes**: Switch between Plain, Markdown, or Both response views while streaming
+- 📝 **Answer Display Modes**: Switch between Plain, Markdown, Both, or Markdown (blocks) response views while streaming
 - 🛠️ **Tool Management**: Enable/disable specific tools or entire servers during chat sessions
 - 🧑‍💻 **Human-in-the-Loop (HIL)**: Review and approve tool executions before they run for enhanced control and safety
 - 🎮 **Advanced Model Configuration**: Fine-tune 15+ model parameters including context window size, temperature, sampling, repetition control, and more
@@ -305,7 +305,7 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 > [!WARNING]
 > **Non-Ollama providers are experimental.** Support for providers other than Ollama was added recently and is still being stabilized, not everything may work correctly yet.
 
-ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` — both work for **any** selected provider — or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
+ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-llm](https://github.com/mozilla-ai/any-llm) exposes. Select one with `--provider`. Provide the key with `--api-key` or `$OLLMCP_API_KEY` (both work for **any** selected provider) or via the provider's own environment variable shown below. `$OLLMCP_API_KEY` and the provider-native env vars are never written to disk; only a key passed with `--api-key` is saved to the config.
 
 | Provider (`--provider`) | API key env var |
 |---|---|
@@ -346,7 +346,7 @@ ollmcp works with **Ollama** plus any **OpenAI-compatible** provider that [any-l
 For the selected provider, ollmcp resolves the API key in this order, from **highest** to **lowest** precedence:
 
 1. The `--api-key` / `-k` flag.
-2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic — applies to whichever provider you selected with `--provider`).
+2. The `$OLLMCP_API_KEY` environment variable (provider-agnostic, applies to whichever provider you selected with `--provider`).
 3. The per-provider key saved in `~/.config/ollmcp/config.json` (present only if it was once passed via `--api-key`).
 4. The provider's own native environment variable, detected by [any-llm](https://github.com/mozilla-ai/any-llm) (e.g. `OPENAI_API_KEY`, `OPENROUTER_API_KEY`).
 
@@ -473,7 +473,7 @@ During chat, use these commands:
 | `/loop-limit`    | `/ll`            | Set maximum iterative tool-loop iterations (Agent Mode). Default: 7 |
 | `/model`         | `/m`             | List and select a different Ollama model            |
 | `/model-config`  | `/mc`            | Configure advanced model parameters and system prompt |
-| `/display-mode`  | `/dm`            | Choose Plain, Markdown, or Both answer display modes |
+| `/display-mode`  | `/dm`            | Choose Plain, Markdown, Both, or Markdown (blocks) answer display modes |
 | `/input-mode`    | `/im`            | Choose Single-line or Multiline chat input mode     |
 | `/prompts`       | `/pr`            | Browse and view all available MCP prompts             |
 | `/server:prompt_name`   | `/prompt_name`      | Invoke a prompt (qualified is recommended) |
@@ -495,16 +495,18 @@ During chat, use these commands:
 The `display-mode` (`dm`) command lets you choose how model answers are shown while they stream:
 
 - **Plain**: Streams the response once as plain text with no final markdown re-render
-- **Markdown**: Renders the response as markdown during streaming with throttled redraws
-- **Both**: Streams plain text first, then renders the completed response again as markdown
+- **Markdown**: Renders the response as markdown during streaming with throttled redraws (live; can flicker or duplicate lines with emojis or when you resize the terminal)
+- **Both** (default): Streams plain text first, then renders the completed response again as markdown
+- ✨**NEW** **Markdown (blocks)**: Renders the response as markdown one block at a time, append-only each paragraph/list/table/code block prints once when it completes and is never redrawn, so it cannot duplicate lines
 
 Use `/display-mode` or `/dm` during chat to open the interactive picker.
 
 **Why you might switch modes:**
 
 - **Plain** is the least noisy option if you want minimal redraw or flicker
-- **Markdown** is useful when formatting matters more than raw token-by-token output
+- **Markdown** shows live markdown formatting, but its in-place redraws can flicker or duplicate lines with emojis/resizes
 - **Both** gives you fast streaming feedback plus a clean final markdown rendering
+- **Markdown (blocks)** is the most stable way to see formatted markdown while streaming, at the cost of block-by-block (rather than token-by-token) updates
 
 > [!TIP]
 > Your selected display mode is saved with `save-config` and restored with `load-config`, so you can keep different viewing preferences for different workflows.
@@ -961,7 +963,7 @@ Connection settings are stored **per provider**, so switching providers never re
 The configuration also records a `defaultProvider`. When you run `ollmcp` with no `--provider` flag, it loads that provider's profile; a fresh install starts on `ollama`. Each time you `/save-config`, the provider you're currently using *becomes the new default*, so running plain `ollmcp` resumes wherever you left off. Pass `--provider <name>` at any time to switch to (and load) a different provider's profile, and `--model` / `--host` / `--api-key` override the saved values for that run.
 
 > [!NOTE]
-> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk — use one of those if you don't want your key persisted.
+> Only a key passed with `--api-key` is stored, in plain text, in `~/.config/ollmcp/config.json`. Keys provided through the `$OLLMCP_API_KEY` environment variable or a provider's native environment variable (for example `OPENROUTER_API_KEY`) are **never** written to disk, use one of those if you don't want your key persisted.
 
 The following settings are **shared** across all providers:
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -61,6 +61,7 @@ class MCPClient:
         "plain": "Plain",
         "markdown": "Markdown",
         "both": "Both",
+        "blocks": "Markdown (blocks)",
     }
 
     INPUT_MODE_LABELS = {
@@ -119,7 +120,7 @@ class MCPClient:
         self.show_tool_execution = True  # By default, show tool execution displays
         # Metrics display settings
         self.show_metrics = False  # By default, don't show metrics after each query
-        self.answer_render_mode = "markdown"  # Show answers in markdown format by default (options: plain, markdown, or both)
+        self.answer_render_mode = "both"  # Default to the safest mode (options: plain, markdown, both, blocks)
         self.input_mode = "single"  # Keep chat input single-line by default
         self.multiline_key_bindings = self._build_multiline_key_bindings()
         # Agent mode settings
@@ -1266,18 +1267,21 @@ class MCPClient:
             "1": ("plain", "Plain"),
             "2": ("markdown", "Markdown"),
             "3": ("both", "Both"),
+            "4": ("blocks", "Markdown (blocks)"),
             "plain": ("plain", "Plain"),
             "markdown": ("markdown", "Markdown"),
             "both": ("both", "Both"),
+            "blocks": ("blocks", "Markdown (blocks)"),
         }
 
         while True:
             self.console.print(Panel(
                 "\n"
-                "1. [bold]Plain[/bold] only\n"
-                "2. [bold]Markdown[/bold] only\n"
-                "3. [bold]Both[/bold] plain streaming and final markdown\n\n"
-                "[dim]Type 1, 2, 3, plain, markdown, both, or q to cancel.[/dim]",
+                "1. [bold]Plain only[/bold] [green](most stable)[/green]\n"
+                "2. [bold]Markdown only[/bold] [yellow](live; can flicker/duplicate lines with emojis or on resize)[/yellow]\n"
+                "3. [bold]Both[/bold] plain streaming and final markdown [green](more stable)[/green]\n"
+                "4. [bold]Markdown (blocks)[/bold] [cyan](stable; renders each block once it completes)[/cyan]\n\n"
+                "[dim]Type 1, 2, 3, 4, plain, markdown, both, blocks, or q to cancel.[/dim]",
                 title="[bold]📝 Answer Display Mode[/bold]",
                 border_style="cyan",
                 expand=False,
@@ -1301,11 +1305,13 @@ class MCPClient:
                     self.console.print("[cyan]Responses will stream once without the final markdown re-render.[/cyan]")
                 elif self.answer_render_mode == "markdown":
                     self.console.print("[cyan]Responses will render as markdown during streaming with throttled redraws.[/cyan]")
+                elif self.answer_render_mode == "blocks":
+                    self.console.print("[cyan]Responses will render as markdown one block at a time, append-only (no redraws).[/cyan]")
                 else:
                     self.console.print("[cyan]Responses will stream as plain text first, then re-render as markdown.[/cyan]")
                 return
 
-            self.console.print("[red]Invalid selection. Choose 1, 2, 3, plain, markdown, both, or q.[/red]")
+            self.console.print("[red]Invalid selection. Choose 1, 2, 3, 4, plain, markdown, both, blocks, or q.[/red]")
 
     async def select_input_mode(self):
         """Select how chat input should be entered."""
@@ -1562,7 +1568,7 @@ class MCPClient:
                 self.show_metrics = config_data["displaySettings"]["showMetrics"]
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     self.answer_render_mode = answer_render_mode
 
         if "inputSettings" in config_data:
@@ -1645,7 +1651,7 @@ class MCPClient:
                 self.show_metrics = False
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     self.answer_render_mode = answer_render_mode
                 else:
                     self.answer_render_mode = "both"

--- a/mcp_client_for_ollama/config/defaults.py
+++ b/mcp_client_for_ollama/config/defaults.py
@@ -69,7 +69,7 @@ def default_config() -> dict:
         "displaySettings": {
             "showToolExecution": True,
             "showMetrics": False,
-            "answerRenderMode": "markdown"
+            "answerRenderMode": "both"
         },
         "inputSettings": {
             "inputMode": "single"

--- a/mcp_client_for_ollama/config/manager.py
+++ b/mcp_client_for_ollama/config/manager.py
@@ -291,7 +291,7 @@ class ConfigManager:
                 validated["displaySettings"]["showMetrics"] = bool(config_data["displaySettings"]["showMetrics"])
             if "answerRenderMode" in config_data["displaySettings"]:
                 answer_render_mode = str(config_data["displaySettings"]["answerRenderMode"]).lower()
-                if answer_render_mode in {"plain", "markdown", "both"}:
+                if answer_render_mode in {"plain", "markdown", "both", "blocks"}:
                     validated["displaySettings"]["answerRenderMode"] = answer_render_mode
 
         if "inputSettings" in config_data and isinstance(config_data["inputSettings"], dict):

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -92,6 +92,11 @@ class ProgressiveMarkdownRenderer:
 
         commit_point = self._find_safe_commit_point(uncommitted)
         if commit_point is None:
+            # No paragraph boundary, but the live zone is taller than the
+            # threshold. Fall back to the last single-newline boundary so the
+            # zone stays bounded and rich.Live can still erase prior frames.
+            commit_point = self._find_fallback_commit_point(uncommitted)
+        if commit_point is None:
             return
 
         text_to_commit = uncommitted[:commit_point]
@@ -161,10 +166,88 @@ class ProgressiveMarkdownRenderer:
 
         return last_safe_break
 
+    def _find_fallback_commit_point(self, text):
+        """Find the last single-newline boundary not inside a fenced code block.
+
+        Used when content is taller than the viewport but has no paragraph
+        boundary to commit at. Commits up to the last newline, leaving only the
+        final (in-progress) line in the Live zone. Returns the index or None if
+        no safe point exists (e.g. inside a code fence or a single long line).
+        """
+        in_code_block = False
+        last_safe_break = None
+        pos = 0
+
+        lines = text.split("\n")
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+
+            pos += len(line) + 1  # Move past this line and its newline
+
+            # Safe to break after this line if we're outside a code block and
+            # there is a following line to keep in the Live zone.
+            if not in_code_block and i < len(lines) - 1 and pos < len(text):
+                last_safe_break = pos
+
+        return last_safe_break
+
+
+class BlockMarkdownRenderer(ProgressiveMarkdownRenderer):
+    """Append-only markdown renderer.
+
+    Prints each completed markdown block (paragraph/list/table/code fence) once
+    via console.print and never redraws it. Because nothing is ever erased, it
+    cannot exhibit the rich.Live cursor-miscount duplication that occurs with
+    wide glyphs (emoji) or terminal resizes.
+    """
+
+    def start(self):
+        """No live zone; just reset the refresh throttle."""
+        self._last_refresh = monotonic()
+
+    def update(self, new_chunk):
+        """Append a chunk and flush any completed blocks (throttled)."""
+        self.full_text += new_chunk
+        now = monotonic()
+        if now - self._last_refresh < self.REFRESH_INTERVAL:
+            return
+        self._last_refresh = now
+        self._commit_complete_blocks()
+
+    def finish(self):
+        """Flush whatever remains as a final markdown block."""
+        remaining = self.full_text[len(self.committed_text):]
+        if remaining:
+            self._print_markdown_preserving_trailing_newlines(remaining)
+            self.committed_text = self.full_text
+
+    def _commit_complete_blocks(self):
+        """Commit complete paragraphs; flush lines if a block grows too tall."""
+        uncommitted = self.full_text[len(self.committed_text):]
+        if not uncommitted:
+            return
+        commit_point = self._find_safe_commit_point(uncommitted)
+        if commit_point is None:
+            # No completed paragraph yet. If the in-progress block is already
+            # taller than the viewport, flush its completed lines so long prose
+            # keeps flowing; otherwise wait for more content.
+            terminal_size = shutil.get_terminal_size()
+            viewport_height = max(1, terminal_size.lines - 2)
+            threshold = int(viewport_height * self.VIEWPORT_COMMIT_THRESHOLD)
+            if self._estimate_height(uncommitted, terminal_size.columns) > threshold:
+                commit_point = self._find_fallback_commit_point(uncommitted)
+        if commit_point is None:
+            return
+        self._print_markdown_preserving_trailing_newlines(uncommitted[:commit_point])
+        self.committed_text += uncommitted[:commit_point]
+
+
 class StreamingManager:
     """Manages streaming responses for Ollama API calls"""
 
-    VALID_ANSWER_RENDER_MODES = {"plain", "markdown", "both"}
+    VALID_ANSWER_RENDER_MODES = {"plain", "markdown", "both", "blocks"}
 
     def __init__(self, console):
         """Initialize the streaming manager
@@ -297,10 +380,14 @@ class StreamingManager:
                         accumulated_text += content
                         if stream_plain_text:
                             self.console.print(content, end="")
-                        elif render_mode == "markdown":
+                        elif render_mode in {"markdown", "blocks"}:
                             if progressive_renderer is None:
                                 self._print_answer_transition_header(show_thinking, "markdown")
-                                progressive_renderer = ProgressiveMarkdownRenderer(self.console)
+                                renderer_cls = (
+                                    BlockMarkdownRenderer if render_mode == "blocks"
+                                    else ProgressiveMarkdownRenderer
+                                )
+                                progressive_renderer = renderer_cls(self.console)
                                 progressive_renderer.start()
                             progressive_renderer.update(content)
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -94,7 +94,7 @@ def test_default_config_uses_both_answer_render_modes():
     """Test that new configurations keep the current dual answer display behavior."""
     config = default_config()
 
-    assert config["displaySettings"]["answerRenderMode"] == "markdown"
+    assert config["displaySettings"]["answerRenderMode"] == "both"
 
 
 def test_validate_config_preserves_answer_render_mode():

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -1,10 +1,15 @@
 """Tests for streaming answer rendering modes."""
 
+import os
 import unittest
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
-from mcp_client_for_ollama.utils.streaming import ProgressiveMarkdownRenderer, StreamingManager
+from mcp_client_for_ollama.utils.streaming import (
+    BlockMarkdownRenderer,
+    ProgressiveMarkdownRenderer,
+    StreamingManager,
+)
 
 
 @dataclass
@@ -73,6 +78,9 @@ class TestableProgressiveMarkdownRenderer(ProgressiveMarkdownRenderer):
 
     def estimate_height(self, text, terminal_width):
         return self._estimate_height(text, terminal_width)
+
+    def find_fallback_commit_point(self, text):
+        return self._find_fallback_commit_point(text)
 
 
 class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
@@ -167,6 +175,34 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         # The last update should clear the live zone
         self.assertTrue(any(refresh for _, refresh in live.updates))
 
+    async def test_blocks_mode_uses_append_only_renderer(self):
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.Live",
+            FakeLive,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, _, _ = await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="hello "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="**world**"))]),
+                ),
+                answer_render_mode="blocks",
+            )
+
+        printed = [call.args[0] for call in self.console.print.call_args_list if call.args]
+        self.assertEqual(response_text, "hello **world**")
+        # Markdown header, not the plain one.
+        self.assertNotIn("MD::📝 **Answer:**", printed)
+        self.assertEqual(printed.count("MD::📝 **Answer (Markdown):**"), 1)
+        # Content rendered as markdown via console.print, append-only.
+        self.assertIn("MD::hello **world**", printed)
+        # Block mode never creates a Live zone.
+        self.assertEqual(FakeLive.instances, [])
+
     async def test_visible_thinking_gets_blank_line_before_answer_header(self):
         manager = StreamingManager(self.console)
 
@@ -217,6 +253,111 @@ class TestProgressiveMarkdownRenderer(unittest.TestCase):
     def test_estimate_height_wraps_when_exceeding_width(self):
         estimated_height = self.renderer.estimate_height("abcde", terminal_width=4)
         self.assertEqual(estimated_height, 2)
+
+    def test_fallback_commit_point_uses_last_newline_outside_code_fence(self):
+        point = self.renderer.find_fallback_commit_point("alpha\nbeta\ngamma")
+        # Commits up to the last newline, leaving "gamma" in the live zone.
+        self.assertEqual(point, len("alpha\nbeta\n"))
+
+    def test_fallback_commit_point_skips_inside_code_fence(self):
+        self.assertIsNone(
+            self.renderer.find_fallback_commit_point("```\ncode line\nmore code\n")
+        )
+
+    def test_fallback_commit_point_none_without_newline(self):
+        self.assertIsNone(
+            self.renderer.find_fallback_commit_point("one very long single line")
+        )
+
+    def test_fallback_commit_bounds_live_zone_without_paragraph_breaks(self):
+        renderer = TestableProgressiveMarkdownRenderer(self.console)
+        fake_size = os.terminal_size((80, 10))  # columns=80, lines=10 -> viewport 8
+        times = iter(float(i) for i in range(100))
+        with patch(
+            "mcp_client_for_ollama.utils.streaming.Markdown",
+            side_effect=lambda text: f"MD::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Live", FakeLive
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Text",
+            side_effect=lambda text: f"TEXT::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.shutil.get_terminal_size",
+            return_value=fake_size,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.monotonic",
+            side_effect=lambda *a, **k: next(times),
+        ):
+            renderer.start()
+            for i in range(20):
+                renderer.update(f"line number {i}\n")  # single '\n', never '\n\n'
+
+        # A commit must have occurred even though no paragraph boundary exists.
+        self.assertNotEqual(renderer.committed_text, "")
+        # The remaining live content must stay below the viewport so rich can erase it.
+        uncommitted = renderer.full_text[len(renderer.committed_text):]
+        viewport = max(1, fake_size.lines - 2)
+        self.assertLess(renderer.estimate_height(uncommitted, fake_size.columns), viewport)
+
+
+class TestBlockMarkdownRenderer(unittest.TestCase):
+    """Validate the append-only (block) markdown renderer."""
+
+    def setUp(self):
+        self.console = MagicMock()
+        FakeLive.instances.clear()
+
+    def _drive(self, renderer, chunks, fake_size=os.terminal_size((80, 24))):
+        times = iter(float(i) for i in range(1000))
+        with patch(
+            "mcp_client_for_ollama.utils.streaming.Markdown",
+            side_effect=lambda text: f"MD::{text}",
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.Live", FakeLive
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.shutil.get_terminal_size",
+            return_value=fake_size,
+        ), patch(
+            "mcp_client_for_ollama.utils.streaming.monotonic",
+            side_effect=lambda *a, **k: next(times),
+        ):
+            renderer.start()
+            for chunk in chunks:
+                renderer.update(chunk)
+            renderer.finish()
+
+    def test_commits_complete_paragraph_without_live(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        self._drive(renderer, ["hello **world**\n\n"])
+
+        printed = [c.args[0] for c in self.console.print.call_args_list if c.args]
+        self.assertIn("MD::hello **world**", printed)
+        # Append-only: it must never create a Live zone.
+        self.assertEqual(FakeLive.instances, [])
+        self.assertEqual(renderer.committed_text, renderer.full_text)
+
+    def test_finish_flushes_remaining_incomplete_block(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        # No paragraph break and short enough to stay buffered until finish().
+        self._drive(renderer, ["just a short answer"])
+
+        printed = [c.args[0] for c in self.console.print.call_args_list if c.args]
+        self.assertIn("MD::just a short answer", printed)
+        self.assertEqual(FakeLive.instances, [])
+
+    def test_long_block_flushes_lines_without_paragraph_breaks(self):
+        renderer = BlockMarkdownRenderer(self.console)
+        # viewport 8, threshold int(8*0.6)=4 -> long single-newline prose flushes.
+        self._drive(
+            renderer,
+            [f"line number {i}\n" for i in range(20)],
+            fake_size=os.terminal_size((80, 10)),
+        )
+
+        # Everything ends up committed (append-only) and no Live was ever used.
+        self.assertEqual(renderer.committed_text, renderer.full_text)
+        self.assertEqual(FakeLive.instances, [])
+        self.assertNotEqual(renderer.committed_text, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The live "Markdown only" mode duplicates lines while streaming, especially with emojis/wide glyphs or when the terminal is resized. Root cause: rich.Live erases its previous frame by moving the cursor up by the number of rows it *thinks* it rendered; with ambiguous-width glyphs or a resize that count diverges from what the terminal actually drew, so stale rows are left behind and accumulate on each refresh.

Add BlockMarkdownRenderer, an append-only renderer that prints each completed markdown block once via console.print and never redraws it, so it cannot exhibit the cursor-miscount duplication. Long prose without blank lines still flows by flushing completed lines once a block grows past the viewport.

Expose it as a new answer display mode ("blocks", labeled "Markdown (blocks)") alongside the existing modes, annotate "Markdown only" as live/may-flicker in the picker and README, and switch the default to the safer "both".

- streaming.py: BlockMarkdownRenderer (reuses base helpers) + render-mode wiring
- client.py: label, default, /dm picker option, config validators
- config: default -> "both", validation accepts "blocks"
- README: document the new mode and the new default
- tests: unit + integration coverage for the block renderer