### PR TITLE
feat: enhance security measures in HIL manager and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
   - [Ollama Cloud Models](#ollama-cloud-models)
 - [Where Can I Find More MCP Servers?](#where-can-i-find-more-mcp-servers)
 - [Related Projects](#related-projects)
+- [Security](#security)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
 
@@ -1205,6 +1206,10 @@ This repository contains reference implementations for the Model Context Protoco
 
 - **[Ollama MCP Bridge](https://github.com/jonigl/ollama-mcp-bridge)** - A Python API layer that sits in front of Ollama, automatically adding tools from multiple MCP servers to every chat request. This project provides a transparent proxy solution that pre-loads all MCP servers at startup and seamlessly integrates their tools into the Ollama API.
 - **[MCP Server with Streamable HTTP Example](https://github.com/jonigl/mcp-server-with-streamable-http-example)** - An example MCP server demonstrating the usage of the streamable HTTP protocol.
+
+## Security
+
+MCP servers you connect are trusted by you, and their tool/resource responses are treated as untrusted content that reaches the model. See [SECURITY.md](SECURITY.md) for the trust model, how indirect prompt injection is handled, and how to report a vulnerability.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,10 +15,55 @@ Do **not** open a public issue. Instead:
    * **Your assessment of the potential impact**
    * **Any possible mitigations**
 
+## Trust model
+
+`ollmcp` connects a language model to one or more MCP servers and lets the model
+call their tools and read their resources. It is important to understand where
+the trust boundaries are:
+
+* **MCP servers you connect are trusted by you.** A server runs as a local
+  process or a remote endpoint you explicitly added (`ollmcp mcp add ...`). Only
+  connect servers you trust, the same way you would only run software you trust.
+* **Tool and resource responses are treated as untrusted content.** Whatever a
+  server returns is passed into the model's context so the model can use it. A
+  malicious or compromised server can embed instructions inside its responses
+  (this is known as **indirect prompt injection**) in an attempt to make the
+  model call other tools you did not intend.
+
+This is an inherent property of the MCP / tool-use paradigm, not a bug specific
+to this client: for a tool to be useful, its output must reach the model, and
+there is no reliable way to distinguish "data" from "instructions" in free-form
+text. The right defense is **not** to connect untrusted servers, combined with
+the defense-in-depth measures below.
+
+## How this client helps you stay in control
+
+* **Human-in-the-Loop (HIL) confirmation is enabled by default.** Before any
+  tool runs, you are shown the tool name and its **full arguments** (values are
+  never truncated, terminal control characters are stripped, and Rich markup is
+  escaped) so you can review exactly what would execute before approving.
+* **You choose which tools are enabled** per server, and can disable any tool.
+* **Agent Mode is bounded** by a configurable iteration limit.
+
+Because tool responses are untrusted, keep HIL enabled when you use servers that
+can take consequential actions (filesystem writes, shell execution, network
+requests, browser automation), and read the arguments before confirming.
+
 ## Security recommendations
 
 * Keep the client up to date
-* Run with only the necessary permissions
-* Be careful about the MCP servers you use
+* Only connect MCP servers you trust, and keep HIL enabled for powerful tools
+* Run with only the necessary permissions (least privilege)
+* Review tool arguments in the confirmation prompt before approving
+
+## Acknowledgments
+
+Thanks to the people who have responsibly reported security issues or suggested
+hardening improvements to this project:
+
+* [@fortress07](https://github.com/fortress07) — reported that the
+  Human-in-the-Loop confirmation truncated tool arguments, which led to the
+  confirmation display being hardened to show arguments in full and to strip
+  terminal control characters.
 
 Thank you for helping keep this project secure.

--- a/mcp_client_for_ollama/utils/hil_manager.py
+++ b/mcp_client_for_ollama/utils/hil_manager.py
@@ -4,8 +4,31 @@ This module manages HIL confirmations for tool calls, allowing users to review,
 approve, or skip tool executions before they are performed.
 """
 
+import re
+
 from rich.prompt import Prompt
 from rich.console import Console
+from rich.markup import escape
+
+
+# Control characters that could corrupt or spoof the confirmation display
+# (raw ANSI escapes, carriage returns, backspaces, C1 controls, ...). Tab and
+# newline are kept: they render harmlessly and newlines are needed for readable
+# multi-line values.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def _sanitize_for_display(value) -> str:
+    """Make an arbitrary tool-argument value safe to print in the prompt.
+
+    Tool arguments come from the model and may echo content supplied by a
+    malicious MCP server. When we show them for approval, two things must not
+    happen: control characters must not corrupt or spoof the terminal, and Rich
+    markup must not be interpreted. So we strip control characters (keeping tab
+    and newline) and escape Rich markup. The value is otherwise shown in full,
+    never truncated, so nothing is hidden at the moment the user approves.
+    """
+    return escape(_CONTROL_CHARS.sub("", str(value)))
 
 
 class AbortQueryException(Exception):
@@ -97,11 +120,20 @@ class HumanInTheLoopManager:
         if tool_args:
             self.console.print("[cyan]Arguments:[/cyan]")
             for key, value in tool_args.items():
-                # Truncate long values for display
-                display_value = str(value)
-                if len(display_value) > 50:
-                    display_value = display_value[:47] + "..."
-                self.console.print(f"  • {key}: {display_value}")
+                # Show the full value so nothing is hidden from the user during
+                # confirmation. Truncating here could conceal part of a payload
+                # (e.g. an injected command or key) that the user needs to see
+                # before approving. _sanitize_for_display strips control
+                # characters and escapes Rich markup so a malicious value can't
+                # spoof the terminal or hide part of its content.
+                safe_key = _sanitize_for_display(key)
+                display_value = _sanitize_for_display(value)
+                if "\n" in display_value:
+                    # Indent multi-line values so they stay visually grouped
+                    indented = display_value.replace("\n", "\n      ")
+                    self.console.print(f"  • [bold]{safe_key}[/bold]:\n      {indented}")
+                else:
+                    self.console.print(f"  • [bold]{safe_key}[/bold]: {display_value}")
         else:
             self.console.print("[cyan]Arguments:[/cyan] [dim]None[/dim]")
 


### PR DESCRIPTION
## Summary

Hardens the Human-in-the-Loop (HIL) tool-confirmation display and documents the
project's security trust model.

Previously the HIL prompt truncated tool arguments at 50 characters, so part of
a payload could be hidden at the exact moment the user decides whether to
approve a tool call. This PR:

- **Shows tool arguments in full** — no more truncation.
- **Sanitizes argument values for display** — strips terminal control characters
  (raw ANSI escapes, carriage returns, backspaces, C1 controls) and escapes Rich
  markup, so a value returned by an MCP server can't spoof or corrupt the
  confirmation output.
- **Documents the trust model** and indirect prompt injection in `SECURITY.md`
  (linked from the README): MCP servers you connect are trusted by you; their
  tool/resource responses are treated as untrusted content that reaches the
  model.

## Credit

Thanks to @fortress07 for the report that surfaced the argument-truncation
weakness in the HIL confirmation, which led to this hardening. 🙏

## Testing

- New display-safety checks pass (arguments not truncated, markup neutralized, no
  control byte reaches the terminal, legitimate content — tabs, newlines, unicode
  — preserved).
- Existing HIL tests (`tests/test_hil_session.py`) pass.