### PR TITLE
fix(security): strip terminal control chars from tool responses

### DIFF
--- a/mcp_client_for_ollama/utils/hil_manager.py
+++ b/mcp_client_for_ollama/utils/hil_manager.py
@@ -4,18 +4,11 @@ This module manages HIL confirmations for tool calls, allowing users to review,
 approve, or skip tool executions before they are performed.
 """
 
-import re
-
 from rich.prompt import Prompt
 from rich.console import Console
 from rich.markup import escape
 
-
-# Control characters that could corrupt or spoof the confirmation display
-# (raw ANSI escapes, carriage returns, backspaces, C1 controls, ...). Tab and
-# newline are kept: they render harmlessly and newlines are needed for readable
-# multi-line values.
-_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+from .sanitize import strip_control_chars
 
 
 def _sanitize_for_display(value) -> str:
@@ -28,7 +21,7 @@ def _sanitize_for_display(value) -> str:
     and newline) and escape Rich markup. The value is otherwise shown in full,
     never truncated, so nothing is hidden at the moment the user approves.
     """
-    return escape(_CONTROL_CHARS.sub("", str(value)))
+    return escape(strip_control_chars(str(value)))
 
 
 class AbortQueryException(Exception):

--- a/mcp_client_for_ollama/utils/sanitize.py
+++ b/mcp_client_for_ollama/utils/sanitize.py
@@ -1,0 +1,29 @@
+"""Sanitization helpers for displaying untrusted text in the terminal.
+
+Tool arguments and tool responses can echo content supplied by a malicious MCP
+server. Anything shown in the terminal must not be able to emit raw ANSI escape
+sequences or other control characters, which could spoof the display or hide
+part of the content from the user (e.g. cursor moves, screen clears, or the
+"conceal" SGR code).
+"""
+
+import re
+
+# Control characters that could corrupt or spoof a terminal (raw ANSI escapes,
+# carriage returns, backspaces, C1 controls, DEL, ...). ESC (0x1b) lives in
+# 0x0b-0x1f, so it is stripped here. Tab (0x09) and newline (0x0a) are kept:
+# they render harmlessly and newline is needed for readable multi-line values.
+#
+# Note: Rich's own ``strip_control_codes`` is NOT sufficient — it leaves ESC
+# untouched, so it would not neutralize ANSI escape sequences.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def strip_control_chars(text: str) -> str:
+    """Remove terminal control characters (keeping tab and newline).
+
+    This neutralizes ANSI escape sequences and other control characters so an
+    untrusted string can't spoof the terminal or hide part of its content when
+    printed. The text is otherwise left intact, never truncated.
+    """
+    return _CONTROL_CHARS.sub("", text)

--- a/mcp_client_for_ollama/utils/tool_display.py
+++ b/mcp_client_for_ollama/utils/tool_display.py
@@ -12,6 +12,8 @@ from rich.text import Text
 from typing import Any
 from rich.markdown import Markdown
 
+from .sanitize import strip_control_chars
+
 
 class ToolDisplayManager:
     """Manages the display of tool calls and responses"""
@@ -79,6 +81,14 @@ class ToolDisplayManager:
         """
         if not show:
             return
+
+        # The response comes straight from the (untrusted) MCP server. Strip
+        # control characters so it can't emit raw ANSI escapes that spoof the
+        # terminal or hide part of what the tool actually returned. This panel
+        # is shown regardless of the HIL setting, so it must be safe even when
+        # confirmations are disabled. The JSON path below is unaffected: valid
+        # JSON has no raw control bytes.
+        tool_response = strip_control_chars(tool_response)
 
         args_display = self._format_json(tool_args)
 

--- a/mcp_client_for_ollama/utils/tool_display.py
+++ b/mcp_client_for_ollama/utils/tool_display.py
@@ -37,8 +37,10 @@ class ToolDisplayManager:
             parsed_data = json.loads(str(data))
             formatted_json = json.dumps(parsed_data, indent=2)
 
-        # Use Rich Syntax with Monokai theme for JSON
-        return Syntax(formatted_json, "json", theme="monokai", line_numbers=False)
+        # Use Rich Syntax with Monokai theme for JSON. word_wrap=True so long
+        # single-line values wrap instead of being cropped at the panel width,
+        # which would silently hide part of an argument or response.
+        return Syntax(formatted_json, "json", theme="monokai", line_numbers=False, word_wrap=True)
 
     def display_tool_execution(self, tool_name: str, tool_args: Any, show: bool = True) -> None:
         """Display the tool execution panel with arguments

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,93 @@
+"""Tests for terminal-output sanitization.
+
+Covers the shared ``strip_control_chars`` primitive and its use in the tool
+response panel, which is shown regardless of the HIL setting and renders
+content coming straight from the (untrusted) MCP server.
+"""
+
+import io
+import re
+import unittest
+
+from rich.console import Console
+
+from mcp_client_for_ollama.utils.sanitize import strip_control_chars
+from mcp_client_for_ollama.utils.tool_display import ToolDisplayManager
+
+
+class TestStripControlChars(unittest.TestCase):
+    def test_strips_ansi_escape_sequences(self):
+        # ESC (0x1b) must be removed so the sequence renders as inert text.
+        evil = "Hello\x1b[2J\x1b[31mred\x1b[8mhidden"
+        assert strip_control_chars(evil) == "Hello[2J[31mred[8mhidden"
+        assert "\x1b" not in strip_control_chars(evil)
+
+    def test_strips_c1_and_del_and_other_controls(self):
+        assert strip_control_chars("a\x07\x08\x0d\x7f\x9bb") == "ab"
+
+    def test_keeps_tab_and_newline(self):
+        assert strip_control_chars("a\tb\nc") == "a\tb\nc"
+
+    def test_leaves_plain_text_untouched(self):
+        text = "normal text with [brackets] and 日本語"
+        assert strip_control_chars(text) == text
+
+
+class TestToolResponseSanitization(unittest.TestCase):
+    def _render_response(self, tool_response):
+        """Render display_tool_response into a captured terminal buffer."""
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, width=80,
+                          color_system="standard")
+        ToolDisplayManager(console).display_tool_response(
+            "evil_tool", {"q": "x"}, tool_response, show=True)
+        return buf.getvalue()
+
+    def test_plain_text_response_cannot_inject_ansi(self):
+        # Non-JSON, few markdown patterns -> plain Text branch.
+        out = self._render_response("done\x1b[2J\x1b[8m secret\x1b[0m")
+        assert "\x1b[2J" not in out
+        assert "\x1b[8m" not in out
+        assert "[2J" in out  # neutralized escape shows as literal text
+
+    def test_markdown_response_cannot_inject_ansi(self):
+        # Enough markdown patterns (>7) -> Markdown branch.
+        payload = ("# Title\n- **a**\n- *b*\n- `c`\n> quote\n"
+                   "[l](u) more\x1b[2J\x1b[8mhidden")
+        out = self._render_response(payload)
+        assert "\x1b[2J" not in out
+        assert "\x1b[8m" not in out
+
+    def test_json_response_content_still_shown(self):
+        # The JSON path is unaffected by stripping (valid JSON has no raw
+        # control bytes); its content must still render.
+        out = self._render_response('{"result": "ok_marker"}')
+        assert "ok_marker" in out
+
+
+class TestNoWidthTruncation(unittest.TestCase):
+    """Long JSON values must wrap, not be cropped off the panel (word_wrap)."""
+
+    def _visible(self, fn_name, *args, width=100):
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=True, width=width,
+                          color_system="standard")
+        getattr(ToolDisplayManager(console), fn_name)(*args)
+        # Strip SGR codes so we compare the visible characters only.
+        return re.sub(r"\x1b\[[0-9;:]*m", "", buf.getvalue())
+
+    def test_long_argument_value_not_cropped(self):
+        long_value = "START_" + "A" * 140 + "_END"
+        out = self._visible("display_tool_execution", "shell",
+                            {"command": long_value})
+        assert "_END" in out
+
+    def test_long_json_response_value_not_cropped(self):
+        long_value = "START_" + "A" * 140 + "_END"
+        out = self._visible("display_tool_response", "shell", {"q": "x"},
+                            '{"stdout": "%s"}' % long_value)
+        assert "_END" in out
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extract the control-character stripping logic from hil_manager into a shared utils/sanitize.strip_control_chars helper and apply it to the tool response panel in tool_display. Tool responses come straight from the (untrusted) MCP server and are shown regardless of the HIL setting, so raw ANSI escape sequences could otherwise spoof the terminal or hide part of the returned content.

Add tests covering the sanitizer primitive and the tool response rendering paths (plain text, markdown, JSON) plus width-truncation.