### PR TITLE
fix(display): keep thinking output separated from the tool panel

### DIFF
--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -466,8 +466,14 @@ class StreamingManager:
                     progressive_renderer.finish()
                 status.stop()
 
-            # Print newline at end
+            # Print newline at end. Thinking (and plain answer text) is streamed
+            # with end="", leaving the cursor mid-line. Close that dangling line
+            # so whatever follows (a tool panel, metrics, or the next turn) isn't
+            # glued to it. The thinking-only case (no answer text) matters for
+            # turns that go straight from thinking to tool calls.
             if accumulated_text and stream_plain_text:
+                self.console.print()
+            elif show_thinking and thinking_content and not accumulated_text:
                 self.console.print()
             # Render final markdown content properly (for "both" mode where progressive_renderer wasn't used)
             if accumulated_text and render_markdown and progressive_renderer is None:

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -3,6 +3,7 @@
 import os
 import unittest
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from mcp_client_for_ollama.utils.streaming import (
@@ -243,6 +244,44 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(calls[thinking_index + 1].args, ())
         self.assertEqual(calls[thinking_index + 2].args, ())
         self.assertEqual(calls[thinking_index + 3].args, ("MD::📝 **Answer:**",))
+
+    async def test_thinking_only_turn_closes_dangling_line(self):
+        # Thinking streamed with end="" then a tool call, with no answer text.
+        # The thinking line must be closed with a bare print() so a following
+        # tool-execution panel (or metrics) isn't glued to the last line.
+        tool_call = SimpleNamespace(
+            index=0, id="call_1",
+            function=SimpleNamespace(name="srv.tool", arguments="{}"),
+        )
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, tool_calls, _ = await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="planning"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(tool_calls=[tool_call]),
+                                                    finish_reason="tool_calls")]),
+                ),
+                thinking_mode=True,
+                show_thinking=True,
+                answer_render_mode="plain",
+            )
+
+        calls = self.console.print.call_args_list
+
+        self.assertEqual(response_text, "")
+        self.assertEqual(len(tool_calls), 1)
+        # No answer header on a tool-only turn.
+        self.assertFalse(any(call.args and "📝" in str(call.args[0]) for call in calls))
+        # Thinking was streamed without a trailing newline, and the last thing
+        # printed is a bare print() that closes the dangling line.
+        thinking_call = next(c for c in calls if c.args and c.args[0] == "planning")
+        self.assertEqual(thinking_call.kwargs.get("end"), "")
+        self.assertEqual(calls[-1].args, ())
+        self.assertEqual(calls[-1].kwargs, {})
 
 
 class TestBlockMarkdownRendererHelpers(unittest.TestCase):


### PR DESCRIPTION
When a turn goes straight from thinking to tool calls with no answer text, the streamed thinking (printed with end="") left the cursor mid-line and the end-of-stream newline was skipped (it was guarded by accumulated_text). The following tool-execution panel (or metrics) was then glued to the last thinking line. Close the thinking line in that case so the existing single-blank-line separator produces one clean gap.