### PR TITLE
fix(server): keep connections alive when a capability query is cancelled

### DIFF
--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -133,6 +133,11 @@ class ServerConnector:
         server_name = server["name"]
         self.console.print(f"[cyan]Connecting to server: {server_name}[/cyan]")
 
+        # Tracks whether the MCP handshake completed, so a cancellation raised
+        # later (while querying capabilities) is not reported as the server
+        # failing to answer initialize.
+        initialized = False
+
         try:
             server_type = server.get("type", "script")
             session = None
@@ -200,6 +205,7 @@ class ServerConnector:
 
                 # Initialize the session and capture capabilities
                 init_result = await session.initialize()
+                initialized = True
 
                 # Success — transfer connection contexts to the main exit_stack.
                 # local_stack is now empty; its __aexit__ becomes a no-op.
@@ -230,6 +236,8 @@ class ServerConnector:
                         )
                         server_tools.append(tool_copy)
                         self.enabled_tools[qualified_name] = True
+                except asyncio.CancelledError:
+                    self.console.print(f"[yellow]Warning: Listing tools from {server_name} was cancelled; continuing without them[/yellow]")
                 except Exception as e:
                     self.console.print(f"[yellow]Warning: Failed to list tools from {server_name}: {str(e)}[/yellow]")
             else:
@@ -246,6 +254,8 @@ class ServerConnector:
                     server_prompts = prompts_response.prompts if hasattr(prompts_response, 'prompts') else []
                     if server_prompts:
                         self.prompts_by_server[server_name] = server_prompts
+                except asyncio.CancelledError:
+                    self.console.print(f"[yellow]Warning: Listing prompts from {server_name} was cancelled; continuing without them[/yellow]")
                 except Exception as e:
                     self.console.print(f"[yellow]Warning: Failed to list prompts from {server_name}: {str(e)}[/yellow]")
             else:
@@ -260,6 +270,8 @@ class ServerConnector:
                     server_resources = resources_response.resources if hasattr(resources_response, 'resources') else []
                     if server_resources:
                         self.resources_by_server[server_name] = server_resources
+                except asyncio.CancelledError:
+                    self.console.print(f"[yellow]Warning: Listing resources from {server_name} was cancelled; continuing without them[/yellow]")
                 except Exception as e:
                     self.console.print(f"[yellow]Warning: Failed to list resources from {server_name}: {str(e)}[/yellow]")
                 try:
@@ -267,6 +279,8 @@ class ServerConnector:
                     server_templates = templates_response.resourceTemplates if hasattr(templates_response, 'resourceTemplates') else []
                     if server_templates:
                         self.templates_by_server[server_name] = server_templates
+                except asyncio.CancelledError:
+                    self.console.print(f"[yellow]Warning: Listing resource templates from {server_name} was cancelled; continuing without them[/yellow]")
                 except Exception as e:
                     self.console.print(f"[yellow]Warning: Failed to list resource templates from {server_name}: {str(e)}[/yellow]")
                 summary_parts = []
@@ -287,19 +301,29 @@ class ServerConnector:
             return True
 
         except asyncio.CancelledError:
-            self.console.print(
-                f"[red]Error connecting to {server_name}: Server did not respond to MCP "
-                f"initialization. Verify the URL serves an MCP endpoint, not a regular web "
-                f"page or other service.[/red]"
-            )
+            self._discard_server_state(server_name)
+            if initialized:
+                self.console.print(
+                    f"[red]Error connecting to {server_name}: Connection dropped after a "
+                    f"successful MCP initialization.[/red]"
+                )
+            else:
+                self.console.print(
+                    f"[red]Error connecting to {server_name}: Server did not respond to MCP "
+                    f"initialization. Verify the URL serves an MCP endpoint, not a regular web "
+                    f"page or other service.[/red]"
+                )
             return False
         except FileNotFoundError as e:
+            self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: File not found - {str(e)}[/red]")
             return False
         except PermissionError:
+            self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: Permission denied[/red]")
             return False
         except Exception as e:
+            self._discard_server_state(server_name)
             sub_exceptions = getattr(e, 'exceptions', None)
             if sub_exceptions:
                 for sub in sub_exceptions:
@@ -493,6 +517,27 @@ class ServerConnector:
             headers["mcp-protocol-version"] = MCP_PROTOCOL_VERSION
 
         return headers
+
+    def _discard_server_state(self, server_name: str) -> None:
+        """Drop any state a failed connection attempt already registered.
+
+        Capabilities are queried after the session is stored, so a failure
+        partway through can leave a server registered as connected. Tools are
+        matched by their qualified "<server>.<tool>" prefix to also cover a
+        tools loop that only partially completed.
+
+        Args:
+            server_name: Name of the server whose partial state to remove
+        """
+        prefix = f"{server_name}."
+        self.sessions.pop(server_name, None)
+        self.session_ids.pop(server_name, None)
+        self.prompts_by_server.pop(server_name, None)
+        self.resources_by_server.pop(server_name, None)
+        self.templates_by_server.pop(server_name, None)
+        self.available_tools[:] = [t for t in self.available_tools if not t.name.startswith(prefix)]
+        for qualified_name in [n for n in self.enabled_tools if n.startswith(prefix)]:
+            del self.enabled_tools[qualified_name]
 
     async def disconnect_all_servers(self):
         """Disconnect from all servers and reset state"""

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,8 +1,10 @@
 """Test server connector functionality."""
 
+import asyncio
 import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
+from rich.console import Console
 from mcp_client_for_ollama.server.connector import ServerConnector
 from mcp_client_for_ollama.utils.constants import MCP_PROTOCOL_VERSION
 from contextlib import AsyncExitStack
@@ -230,6 +232,9 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
 
             # Mock the session and initialization
             mock_session = AsyncMock()
+            # __aenter__ yields this mock; falsy __aexit__ so it can't swallow assertions.
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = False
             mock_init_result = MagicMock()
             mock_init_result.capabilities = MagicMock()
             mock_init_result.capabilities.tools = None  # No tools capability
@@ -242,7 +247,7 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
                  patch.object(connector, '_create_script_params', return_value=MagicMock()):
 
                 mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
-                mock_stdio.return_value.__aexit__ = AsyncMock()
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 # Connect to server
                 result = await connector._connect_to_server(server)
@@ -267,6 +272,9 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
 
             # Mock the session and initialization
             mock_session = AsyncMock()
+            # __aenter__ yields this mock; falsy __aexit__ so it can't swallow assertions.
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = False
             mock_init_result = MagicMock()
             mock_init_result.capabilities = MagicMock()
             mock_init_result.capabilities.tools = MagicMock()  # Has tools
@@ -284,7 +292,7 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
                  patch.object(connector, '_create_script_params', return_value=MagicMock()):
 
                 mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
-                mock_stdio.return_value.__aexit__ = AsyncMock()
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 # Connect to server
                 result = await connector._connect_to_server(server)
@@ -308,6 +316,9 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
 
             # Mock the session and initialization
             mock_session = AsyncMock()
+            # __aenter__ yields this mock; falsy __aexit__ so it can't swallow assertions.
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = False
             mock_init_result = MagicMock()
             mock_init_result.capabilities = MagicMock()
             mock_init_result.capabilities.tools = MagicMock()  # Has tools
@@ -342,7 +353,7 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
                 mock_tool_class.return_value = mock_tool
 
                 mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
-                mock_stdio.return_value.__aexit__ = AsyncMock()
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 # Connect to server
                 result = await connector._connect_to_server(server)
@@ -410,3 +421,122 @@ class TestStreamableHttpNotPrefiltered(unittest.IsolatedAsyncioTestCase):
             assert len(attempted) == 1, "the HTTP server must not be skipped"
             assert attempted[0]["type"] == "streamable_http"
             assert attempted[0]["url"] == "https://mcp.unreachable.invalid/api/v1/connect"
+
+
+HANDSHAKE_ERROR = "did not respond to MCP initialization"
+
+
+class TestPostInitCancellation(unittest.IsolatedAsyncioTestCase):
+    """A cancellation raised after the handshake must not be reported as the
+    server failing to answer initialize, and must not abort the connection (#274)."""
+
+    def _mock_session(self, *, tools=True, prompts=False, resources=True):
+        """Build a session mock whose capabilities match a server's advertisement."""
+        mock_session = AsyncMock()
+        mock_session.__aenter__.return_value = mock_session
+        mock_session.__aexit__.return_value = False
+
+        mock_init_result = MagicMock()
+        mock_init_result.capabilities = MagicMock()
+        mock_init_result.capabilities.tools = MagicMock() if tools else None
+        mock_init_result.capabilities.prompts = MagicMock() if prompts else None
+        mock_init_result.capabilities.resources = MagicMock() if resources else None
+        mock_session.initialize.return_value = mock_init_result
+
+        mock_tool = MagicMock()
+        mock_tool.name = "spawn_actor"
+        mock_tool.description = "Spawn an actor"
+        mock_tool.inputSchema = {}
+        mock_tool.outputSchema = None
+        mock_tools_response = MagicMock()
+        mock_tools_response.tools = [mock_tool]
+        mock_session.list_tools.return_value = mock_tools_response
+
+        return mock_session
+
+    async def _connect(self, connector, mock_session):
+        """Run a stdio connection against the given session mock."""
+        server = {"name": "unreal-mcp", "type": "script", "path": "/fake/path.py"}
+        with patch('mcp_client_for_ollama.server.connector.stdio_client') as mock_stdio, \
+             patch('mcp_client_for_ollama.server.connector.ClientSession', return_value=mock_session), \
+             patch.object(connector, '_create_script_params', return_value=MagicMock()):
+
+            mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+            mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            return await connector._connect_to_server(server)
+
+    async def test_cancelled_resources_listing_keeps_the_connection(self):
+        """A server that advertises resources but drops the stream on
+        resources/list still connects, keeping the tools it already returned."""
+        # Wide console so rich does not wrap the message being asserted on.
+        console = Console(record=True, width=200)
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack, console=console)
+            mock_session = self._mock_session()
+            mock_session.list_resources.side_effect = asyncio.CancelledError()
+
+            result = await self._connect(connector, mock_session)
+
+        output = console.export_text()
+        assert result is True, "one broken capability query must not fail the connection"
+        assert "unreal-mcp" in connector.sessions
+        assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
+        assert HANDSHAKE_ERROR not in output, "initialize succeeded; do not blame the URL"
+
+    async def test_cancellation_during_initialize_reports_handshake_failure(self):
+        """The original message is still used when initialize itself is cancelled."""
+        console = Console(record=True, width=200)
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack, console=console)
+            mock_session = self._mock_session()
+            mock_session.initialize.side_effect = asyncio.CancelledError()
+
+            result = await self._connect(connector, mock_session)
+
+        assert result is False
+        assert HANDSHAKE_ERROR in console.export_text()
+        assert connector.sessions == {}
+
+    async def test_cancellation_after_initialize_is_not_reported_as_handshake_failure(self):
+        """A cancellation once the handshake is done gets its own message."""
+        console = Console(record=True, width=200)
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack, console=console)
+            mock_session = self._mock_session()
+
+            # Cancel while handing the transport over to the long-lived exit stack,
+            # i.e. after initialize() has already returned.
+            with patch.object(connector.exit_stack, 'enter_async_context',
+                              side_effect=asyncio.CancelledError()):
+                result = await self._connect(connector, mock_session)
+
+        output = console.export_text()
+        assert result is False
+        assert HANDSHAKE_ERROR not in output
+        assert "after a successful MCP initialization" in output
+
+    async def test_failed_connection_discards_partial_state(self):
+        """State registered before the failure must not survive it, otherwise the
+        client keeps offering tools for a server it reported as unreachable."""
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack)
+            mock_session = self._mock_session()
+
+            # A malformed resources payload: truthy, but len() raises when the
+            # summary line is built, after tools were already registered.
+            class MalformedResources:
+                def __bool__(self):
+                    return True
+
+            mock_resources_response = MagicMock()
+            mock_resources_response.resources = MalformedResources()
+            mock_session.list_resources.return_value = mock_resources_response
+
+            result = await self._connect(connector, mock_session)
+
+        assert result is False
+        assert connector.sessions == {}
+        assert connector.available_tools == []
+        assert connector.enabled_tools == {}
+        assert connector.resources_by_server == {}

--- a/tests/test_connector_e2e.py
+++ b/tests/test_connector_e2e.py
@@ -1,0 +1,183 @@
+"""End-to-end tests for ServerConnector against a real Streamable HTTP server.
+
+Everything else in the connector suite mocks ClientSession away. These tests
+run the real MCP SDK over a real socket, which is what exposed #274: a server
+that drops the stream on resources/list makes the pending request fail *after*
+a successful handshake, and that used to be reported as the server never
+answering initialize.
+
+The server runs in-process on an ephemeral port, so nothing here depends on a
+fixed port being free. Assertions target the observable outcome (does the
+connection survive, are the tools usable) rather than the exception type the
+SDK happens to raise, so they stay valid across mcp releases.
+"""
+
+import contextlib
+import json
+import socket
+import threading
+import unittest
+from contextlib import AsyncExitStack
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from rich.console import Console
+
+from mcp_client_for_ollama.server.connector import ServerConnector
+
+HANDSHAKE_ERROR = "did not respond to MCP initialization"
+
+TOOL = {
+    "name": "spawn_actor",
+    "description": "Spawn an actor in the level",
+    "inputSchema": {"type": "object", "properties": {}},
+}
+
+
+class _MCPTestServer(ThreadingHTTPServer):
+    """HTTP server whose resources/list behavior is switched per test."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+    mode = "healthy"  # or "drop_on_resources"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal Streamable HTTP MCP server.
+
+    Advertises tools and resources but not prompts, mirroring the server in
+    the #274 report.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        pass  # keep pytest output clean
+
+    def _send_json(self, payload, extra_headers=None):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (extra_headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(self, status):
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _result(self, msg_id, result, extra_headers=None):
+        self._send_json({"jsonrpc": "2.0", "id": msg_id, "result": result}, extra_headers)
+
+    def do_POST(self):
+        raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            self._send_empty(400)
+            return
+
+        method, msg_id = msg.get("method"), msg.get("id")
+
+        # Notifications carry no id and get an empty 202.
+        if msg_id is None:
+            self._send_empty(202)
+            return
+
+        if method == "initialize":
+            self._result(msg_id, {
+                # Echo the client's version so this stays valid as the SDK moves on.
+                "protocolVersion": msg["params"]["protocolVersion"],
+                "capabilities": {"tools": {}, "resources": {}},
+                "serverInfo": {"name": "fake-unreal-mcp", "version": "1.0.0"},
+            }, extra_headers={"mcp-session-id": "fake-unreal-session"})
+
+        elif method == "tools/list":
+            self._result(msg_id, {"tools": [TOOL]})
+
+        elif method == "resources/list":
+            if self.server.mode == "drop_on_resources":
+                # The #274 trigger: advertise resources, then die when asked.
+                with contextlib.suppress(OSError):
+                    self.connection.shutdown(socket.SHUT_RDWR)
+                self.connection.close()
+                self.close_connection = True
+                return
+            self._result(msg_id, {"resources": [
+                {"uri": "file:///level.umap", "name": "level.umap"},
+            ]})
+
+        elif method == "resources/templates/list":
+            self._result(msg_id, {"resourceTemplates": []})
+
+        else:
+            self._send_json({
+                "jsonrpc": "2.0", "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            })
+
+    def do_GET(self):
+        self._send_empty(405)  # no server->client SSE stream in this fake
+
+    def do_DELETE(self):
+        self._send_empty(200)
+
+
+class TestConnectorAgainstRealServer(unittest.IsolatedAsyncioTestCase):
+    """Real socket, real MCP SDK, real ServerConnector."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = _MCPTestServer(("127.0.0.1", 0), _Handler)
+        cls.url = f"http://127.0.0.1:{cls.server.server_address[1]}/mcp"
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    async def _connect(self, mode):
+        """Connect to the fake server in the given mode; returns (ok, connector, output)."""
+        type(self).server.mode = mode
+        console = Console(record=True, width=200)
+        stack = AsyncExitStack()
+        connector = ServerConnector(stack, console=console)
+        try:
+            ok = await connector._connect_to_server({
+                "name": "unreal-mcp", "type": "streamable_http", "url": self.url,
+            })
+        finally:
+            # In drop mode the server hard-resets the socket, so unwinding the
+            # transport raises on its way out. That teardown noise is not what
+            # these tests are about.
+            with contextlib.suppress(BaseException):
+                await stack.aclose()
+        return ok, connector, console.export_text()
+
+    async def test_healthy_server_connects_with_tools_and_resources(self):
+        """Sanity check on the fake server: a well-behaved one connects fully."""
+        ok, connector, _ = await self._connect("healthy")
+
+        assert ok is True
+        assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
+        assert "unreal-mcp" in connector.resources_by_server
+
+    async def test_stream_dropped_on_resources_keeps_the_connection(self):
+        """#274: losing the stream on resources/list must not undo a working
+        connection, nor be blamed on the URL."""
+        ok, connector, output = await self._connect("drop_on_resources")
+
+        assert ok is True, "a broken resources/list must not fail the connection"
+        assert "unreal-mcp" in connector.sessions
+        assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
+        assert connector.enabled_tools == {"unreal-mcp.spawn_actor": True}
+        assert HANDSHAKE_ERROR not in output, "initialize succeeded; do not blame the URL"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -256,6 +256,9 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
             server = {"name": "test-server", "type": "script", "path": "/tmp/test_server.py"}
 
             mock_session = AsyncMock()
+            # __aenter__ yields this mock; falsy __aexit__ so it can't swallow assertions.
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = False
             mock_init_result = MagicMock()
             mock_init_result.capabilities = MagicMock()
             mock_init_result.capabilities.tools = None
@@ -285,7 +288,7 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
                  patch.object(connector, '_create_script_params', return_value=MagicMock()):
 
                 mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
-                mock_stdio.return_value.__aexit__ = AsyncMock()
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 result = await connector._connect_to_server(server)
 
@@ -305,6 +308,9 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
             server = {"name": "test-server", "type": "script", "path": "/tmp/test_server.py"}
 
             mock_session = AsyncMock()
+            # __aenter__ yields this mock; falsy __aexit__ so it can't swallow assertions.
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = False
             mock_init_result = MagicMock()
             mock_init_result.capabilities = MagicMock()
             mock_init_result.capabilities.tools = None
@@ -318,7 +324,7 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
                  patch.object(connector, '_create_script_params', return_value=MagicMock()):
 
                 mock_stdio.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
-                mock_stdio.return_value.__aexit__ = AsyncMock()
+                mock_stdio.return_value.__aexit__ = AsyncMock(return_value=False)
 
                 result = await connector._connect_to_server(server)
 


### PR DESCRIPTION
Fixes #274.

A server that had **successfully** completed the MCP handshake was still reported as `Server did not respond to MCP initialization. Verify the URL serves an MCP endpoint`, sending the user to debug a URL that was already working.

Their log proves initialization worked: `Server unreal-mcp does not support prompts capability` is printed *after* both `initialize()` and `tools/list`. What actually got cancelled was `resources/list`.

## Root cause

`_connect_to_server` wrapped its whole body in one `except asyncio.CancelledError` whose message assumes the cancellation came from `initialize()`. It doesn't have to: `CancelledError` inherits from `BaseException`, so it slips past the `except Exception` guarding each capability query and lands in that handler.

A failed attempt also left state behind. The session is registered, and its tools pushed into `available_tools` / `enabled_tools`, *before* capabilities are queried, and no handler undid that.

## How

- Only blame the URL when the handshake actually failed; a later cancellation gets its own message.
- Catch `CancelledError` per capability query, so one broken call no longer aborts a working connection.
- Add `_discard_server_state()`, called from every failure path.

## Verification

`tests/test_connector_e2e.py` runs the real MCP SDK over a real socket: an in-process Streamable HTTP server on an ephemeral port that advertises `tools` + `resources` (not `prompts`), returns a tool, then drops the stream on `resources/list`.

The drop test **fails on `main`** with the exact reported error; the healthy-server test passes on both, so a failure points at the connector rather than at the fake server.

**Before (`main`)** — the reported error, plus the leak visible in the same run:

```
Error connecting to unreal-mcp: Server did not respond to MCP initialization...

_connect_to_server()    : False
sessions registered     : ['unreal-mcp']
tools offered to model  : ['unreal-mcp.spawn_actor']
state leak after failure: YES
```

**After:**

```
Warning: Listing resources from unreal-mcp was cancelled; continuing without them
Successfully connected to unreal-mcp with 1 tool(s)

_connect_to_server()    : True
state leak after failure: no
```

The per-query catch is what rescues the connection; the `initialized` flag and `_discard_server_state()` are correctness guarantees around it, covered by unit tests.

## The capability tests could not fail

Worth calling out, because it explains how this shipped. `TestCapabilityHandling` and `TestResourceCapability` mocked `ClientSession` as a bare `AsyncMock` without wiring `__aenter__`, so the connector never used the configured mock. And `__aexit__` was also a bare `AsyncMock`, which returns a **truthy** value — meaning *"exception suppressed"*. Every `AssertionError` raised inside `async with AsyncExitStack()` was swallowed on the way out, so `assert False` passed.

Both files now yield the configured mock and return `False` from `__aexit__`.

6 regression tests added in total (**4 fail on `main`**). Full suite: **227 passed**, e2e included, ~1s.
