### PR TITLE
fix(server): dedupe server entries and disambiguate colliding names

### DIFF
--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -16,7 +16,7 @@ from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
-from .discovery import process_server_paths, process_server_urls, parse_server_configs, parse_server_config_mapping, load_claude_desktop_servers
+from .discovery import process_server_paths, process_server_urls, parse_server_configs, parse_server_config_mapping, load_claude_desktop_servers, deduplicate_servers
 from ..utils.constants import MCP_PROTOCOL_VERSION
 
 class ServerConnector:
@@ -99,6 +99,13 @@ class ServerConnector:
             for server in desktop_servers:
                 self.console.print(f"[cyan]Found Claude Desktop server: {server['name']}[/cyan]")
             all_servers.extend(desktop_servers)
+
+        # The sources above are independent, so the same endpoint can arrive
+        # twice and distinct endpoints can arrive with the same name. Resolve
+        # both before connecting, or the second connection overwrites the first.
+        all_servers, notices = deduplicate_servers(all_servers)
+        for notice in notices:
+            self.console.print(f"[yellow]{notice}[/yellow]")
 
         if not all_servers:
             self.console.print(Panel(

--- a/mcp_client_for_ollama/server/discovery.py
+++ b/mcp_client_for_ollama/server/discovery.py
@@ -6,8 +6,8 @@ like Claude's configuration files.
 
 import os
 import json
-from typing import Dict, List, Any
-from urllib.parse import urlparse
+from typing import Dict, List, Any, Tuple
+from urllib.parse import urlparse, urlunparse
 from ..utils.constants import DEFAULT_CLAUDE_CONFIG
 
 def process_server_paths(server_paths) -> List[Dict[str, Any]]:
@@ -159,6 +159,98 @@ def parse_server_configs(config_path: str) -> List[Dict[str, Any]]:
     except Exception:
         # Return empty list on error
         return []
+
+def _server_target(server: Dict[str, Any]) -> tuple:
+    """Identify the endpoint a server entry points at.
+
+    Two entries with the same target are one server reached from two sources
+    (e.g. the registry and a ``-u`` flag), not two servers. The transport is
+    part of the target, so the same URL served over SSE and Streamable HTTP
+    stays two distinct entries.
+    """
+    server_type = server.get("type", "script")
+
+    url = server.get("url")
+    if url:
+        parsed = urlparse(url)
+        # Case in scheme/host is not meaningful, a trailing slash is not either,
+        # and the fragment never reaches the server.
+        normalized = urlunparse((
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            parsed.params,
+            parsed.query,
+            "",
+        ))
+        return (server_type, normalized)
+
+    path = server.get("path")
+    if path:
+        return ("script", os.path.abspath(path))
+
+    config = server.get("config") or {}
+    command = config.get("command")
+    if command:
+        return ("stdio", command, tuple(config.get("args") or []))
+
+    return ("name", server.get("name"))
+
+
+def deduplicate_servers(servers: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Collapse duplicate entries and make the remaining names unique.
+
+    Server entries arrive from five independent sources, so the same endpoint
+    can appear more than once, and names derived from a URL's netloc can
+    collide for endpoints that differ only by path. Both cases used to end with
+    one connection silently overwriting another in ``ServerConnector.sessions``
+    while the overwritten server's tools stayed advertised to the model.
+
+    Args:
+        servers: Server configurations, in source precedence order
+
+    Returns:
+        Tuple of (servers, notices) where notices are human-readable messages
+        about what was dropped or renamed
+    """
+    notices = []
+
+    # Same endpoint from two sources: keep the first, which is the entry from
+    # the more explicit source (a registry name beats a name derived from a URL).
+    unique = []
+    seen: Dict[tuple, str] = {}
+    for server in servers:
+        target = _server_target(server)
+        if target in seen:
+            notices.append(
+                f"Skipping duplicate entry '{server.get('name')}': "
+                f"same server as '{seen[target]}'"
+            )
+            continue
+        seen[target] = server.get("name")
+        unique.append(server)
+
+    # Distinct endpoints that resolved to the same name: disambiguate instead
+    # of letting the later one overwrite the earlier one.
+    result = []
+    used = set()
+    for server in unique:
+        name = server.get("name")
+        if name in used:
+            suffix = 2
+            while f"{name}-{suffix}" in used:
+                suffix += 1
+            new_name = f"{name}-{suffix}"
+            notices.append(
+                f"Renaming '{name}' to '{new_name}': another server already uses that name"
+            )
+            server = {**server, "name": new_name}
+            name = new_name
+        used.add(name)
+        result.append(server)
+
+    return result, notices
+
 
 def load_claude_desktop_servers() -> List[Dict[str, Any]]:
     """Load server configurations from Claude Desktop's config file.

--- a/mcp_client_for_ollama/server/discovery.py
+++ b/mcp_client_for_ollama/server/discovery.py
@@ -160,15 +160,30 @@ def parse_server_configs(config_path: str) -> List[Dict[str, Any]]:
         # Return empty list on error
         return []
 
+def _header_fingerprint(server: Dict[str, Any], config: Dict[str, Any]) -> tuple:
+    """Summarize the headers an HTTP entry connects with.
+
+    Mirrors ``ServerConnector._get_headers_from_server``: headers on the entry
+    win over headers in its config, and names are compared lowercased, since
+    that is how they are sent.
+    """
+    headers = server.get("headers") or config.get("headers") or {}
+    return tuple(sorted((name.lower(), value) for name, value in headers.items()))
+
+
 def _server_target(server: Dict[str, Any]) -> tuple:
-    """Identify the endpoint a server entry points at.
+    """Identify the endpoint a server entry points at, and as whom.
 
     Two entries with the same target are one server reached from two sources
     (e.g. the registry and a ``-u`` flag), not two servers. The transport is
     part of the target, so the same URL served over SSE and Streamable HTTP
-    stays two distinct entries.
+    stays two distinct entries. So are entries that differ only by credentials:
+    one URL with two ``Authorization`` headers is two tenants, and one command
+    with two ``env`` blocks is two accounts. Those configurations work today
+    because their names differ, and collapsing them would break them.
     """
     server_type = server.get("type", "script")
+    config = server.get("config") or {}
 
     url = server.get("url")
     if url:
@@ -183,16 +198,21 @@ def _server_target(server: Dict[str, Any]) -> tuple:
             parsed.query,
             "",
         ))
-        return (server_type, normalized)
+        return (server_type, normalized, _header_fingerprint(server, config))
 
     path = server.get("path")
     if path:
+        # A script server is launched with env=None, so the path is the whole target.
         return ("script", os.path.abspath(path))
 
-    config = server.get("config") or {}
     command = config.get("command")
     if command:
-        return ("stdio", command, tuple(config.get("args") or []))
+        return (
+            "stdio",
+            command,
+            tuple(config.get("args") or []),
+            tuple(sorted((config.get("env") or {}).items())),
+        )
 
     return ("name", server.get("name"))
 
@@ -231,7 +251,10 @@ def deduplicate_servers(servers: List[Dict[str, Any]]) -> Tuple[List[Dict[str, A
         unique.append(server)
 
     # Distinct endpoints that resolved to the same name: disambiguate instead
-    # of letting the later one overwrite the earlier one.
+    # of letting the later one overwrite the earlier one. Which entry keeps the
+    # bare name depends on source order, so the "-2" suffix can move between
+    # runs, and enabledTools is persisted by qualified name. That selection is
+    # already lost today, when one of the two servers disappears entirely.
     result = []
     used = set()
     for server in unique:

--- a/mcp_client_for_ollama/server/discovery.py
+++ b/mcp_client_for_ollama/server/discovery.py
@@ -160,6 +160,17 @@ def parse_server_configs(config_path: str) -> List[Dict[str, Any]]:
         # Return empty list on error
         return []
 
+def _stable(value: Any) -> str:
+    """Render a config value as a hashable, order-stable string.
+
+    Target tuples become dict keys, so every part of one has to be hashable —
+    but ``args``, ``env`` and ``headers`` come from hand-written JSON, which
+    permits lists and objects there. The key only has to be stable, not
+    readable, so anything JSON cannot serialize falls back to its repr.
+    """
+    return json.dumps(value, sort_keys=True, default=repr)
+
+
 def _header_fingerprint(server: Dict[str, Any], config: Dict[str, Any]) -> tuple:
     """Summarize the headers an HTTP entry connects with.
 
@@ -168,7 +179,7 @@ def _header_fingerprint(server: Dict[str, Any], config: Dict[str, Any]) -> tuple
     that is how they are sent.
     """
     headers = server.get("headers") or config.get("headers") or {}
-    return tuple(sorted((name.lower(), value) for name, value in headers.items()))
+    return tuple(sorted((name.lower(), _stable(value)) for name, value in headers.items()))
 
 
 def _server_target(server: Dict[str, Any]) -> tuple:
@@ -210,8 +221,11 @@ def _server_target(server: Dict[str, Any]) -> tuple:
         return (
             "stdio",
             command,
-            tuple(config.get("args") or []),
-            tuple(sorted((config.get("env") or {}).items())),
+            tuple(_stable(arg) for arg in config.get("args") or []),
+            tuple(sorted(
+                (name, _stable(value))
+                for name, value in (config.get("env") or {}).items()
+            )),
         )
 
     return ("name", server.get("name"))

--- a/tests/test_connector_server_dedup.py
+++ b/tests/test_connector_server_dedup.py
@@ -1,0 +1,187 @@
+"""Repro: two server entries that resolve to the same name silently collide.
+
+`connect_to_servers` concatenates its five sources (registry mapping, scripts,
+`-u` URLs, config file, Claude Desktop) into one list with no deduplication,
+and `_connect_to_server` stores each result with a bare
+`self.sessions[server_name] = ...`. When two entries share a name the second
+overwrites the first, while the first server's tools stay behind in
+`available_tools` pointing at a session that no longer exists.
+
+Two ways this happens in practice:
+
+1. The same server reached from the registry *and* from `-u` (issue #274:
+   `unreal-mcp` and `127_0_0_1_8000` are one server, connected twice).
+2. Two different servers on one host:port, because `process_server_urls`
+   derives the name from `netloc` alone and ignores the path.
+
+Same in-process-real-server approach as test_connector_e2e.py.
+"""
+
+import contextlib
+import json
+import threading
+import unittest
+from contextlib import AsyncExitStack
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from rich.console import Console
+
+from mcp_client_for_ollama.server.connector import ServerConnector
+
+
+def _tool(name):
+    return {"name": name, "description": name, "inputSchema": {"type": "object", "properties": {}}}
+
+
+# Path -> tool exposed there. Both live on one host:port, which is the point.
+TOOLS_BY_PATH = {"/alpha": _tool("alpha_tool"), "/beta": _tool("beta_tool")}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal Streamable HTTP MCP server whose tool list depends on the path."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        pass  # keep pytest output clean
+
+    def _send_json(self, payload, extra_headers=None):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (extra_headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(self, status):
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _result(self, msg_id, result, extra_headers=None):
+        self._send_json({"jsonrpc": "2.0", "id": msg_id, "result": result}, extra_headers)
+
+    def do_POST(self):
+        raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            self._send_empty(400)
+            return
+
+        method, msg_id = msg.get("method"), msg.get("id")
+        if msg_id is None:
+            self._send_empty(202)  # notification
+            return
+
+        path = self.path.split("?")[0]
+
+        if method == "initialize":
+            self._result(msg_id, {
+                "protocolVersion": msg["params"]["protocolVersion"],
+                "capabilities": {"tools": {}},  # tools only: no resources/prompts round trips
+                "serverInfo": {"name": f"fake{path}", "version": "1.0.0"},
+            }, extra_headers={"mcp-session-id": f"session{path}"})
+
+        elif method == "tools/list":
+            self._result(msg_id, {"tools": [TOOLS_BY_PATH.get(path, _tool("default_tool"))]})
+
+        else:
+            self._send_json({
+                "jsonrpc": "2.0", "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            })
+
+    def do_GET(self):
+        self._send_empty(405)
+
+    def do_DELETE(self):
+        self._send_empty(200)
+
+
+class TestServerEntryDeduplication(unittest.IsolatedAsyncioTestCase):
+    """Real socket, real MCP SDK, real ServerConnector."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        cls.server.daemon_threads = True
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    def url(self, path):
+        return f"http://127.0.0.1:{self.port}{path}"
+
+    async def _connect(self, **kwargs):
+        console = Console(record=True, width=200)
+        stack = AsyncExitStack()
+        connector = ServerConnector(stack, console=console)
+        try:
+            await connector.connect_to_servers(**kwargs)
+            # Snapshot before teardown; the connector is unusable after aclose().
+            return {
+                "sessions": dict(connector.sessions),
+                "tool_names": [t.name for t in connector.available_tools],
+                "enabled": dict(connector.enabled_tools),
+                "output": console.export_text(),
+            }
+        finally:
+            with contextlib.suppress(BaseException):
+                await stack.aclose()
+
+    async def test_same_server_from_registry_and_url_flag_connects_once(self):
+        """#274: `ollmcp -u <url>` for a server already in the registry.
+
+        The registry entry and the `-u` entry are the same endpoint, so this
+        must produce one connection and one copy of each tool -- not two.
+        """
+        url = self.url("/alpha")
+        result = await self._connect(
+            server_configs={"unreal-mcp": {"type": "streamable_http", "url": url}},
+            server_urls=[url],
+        )
+
+        assert len(result["sessions"]) == 1, (
+            "one endpoint reached from two sources must yield one session, got "
+            f"{sorted(result['sessions'])}"
+        )
+        assert len(result["tool_names"]) == len(set(result["tool_names"])), (
+            f"the same tool is offered to the model twice: {result['tool_names']}"
+        )
+
+    async def test_two_servers_on_one_host_port_keep_separate_sessions(self):
+        """Names come from netloc only, so different paths collide.
+
+        The second connection overwrites the first in `sessions`, but the first
+        server's tools remain in `available_tools`, so they now resolve to a
+        session that does not own them.
+        """
+        result = await self._connect(server_urls=[self.url("/alpha"), self.url("/beta")])
+
+        assert len(result["sessions"]) == 2, (
+            "two distinct servers must not share one session slot, got "
+            f"{sorted(result['sessions'])}"
+        )
+
+        # Every advertised tool must be owned by the session it is namespaced to.
+        for name in result["tool_names"]:
+            server_name = name.rsplit(".", 1)[0]
+            owned = [t.name for t in result["sessions"].get(server_name, {}).get("tools", [])]
+            assert name in owned, (
+                f"tool {name!r} is offered to the model but session "
+                f"{server_name!r} does not own it (owns {owned}) -- calling it "
+                "routes to the wrong server"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -286,6 +286,50 @@ def test_deduplicate_servers_ignores_header_name_casing():
     assert [s["name"] for s in result] == ["a"]
 
 
+def test_deduplicate_servers_handles_list_valued_env():
+    """Config JSON permits arrays in env, and the target tuple is a dict key.
+
+    Before the values were serialized, one entry like this raised
+    ``TypeError: unhashable type: 'list'`` out of ``deduplicate_servers`` —
+    which runs before the per-server ``try/except`` in ``_connect_to_server``,
+    so a single malformed entry took down every server instead of just its own.
+    """
+    servers = [
+        {"type": "config", "name": "a", "config": {
+            "command": "npx", "args": ["-y", "srv"], "env": {"OPTS": ["--a", "--b"]},
+        }},
+        {"type": "config", "name": "b", "config": {
+            "command": "npx", "args": ["-y", "srv"], "env": {"OPTS": ["--a", "--c"]},
+        }},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    # Different lists are different targets; equal lists still collapse.
+    assert [s["name"] for s in result] == ["a", "b"]
+    assert notices == []
+
+    duplicate = [servers[0], {"type": "config", "name": "a-copy", "config": {
+        "command": "npx", "args": ["-y", "srv"], "env": {"OPTS": ["--a", "--b"]},
+    }}]
+    result, _ = deduplicate_servers(duplicate)
+
+    assert [s["name"] for s in result] == ["a"]
+
+
+def test_deduplicate_servers_handles_list_valued_headers_and_args():
+    """The same applies to header values and to args."""
+    url = "https://mcp.example.com/mcp"
+    servers = [
+        {"type": "streamable_http", "name": "a", "url": url, "headers": {"X-Scope": ["read", "write"]}},
+        {"type": "streamable_http", "name": "b", "url": url, "headers": {"X-Scope": ["read"]}},
+        {"type": "config", "name": "c", "config": {"command": "npx", "args": [{"flag": "-y"}]}},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["a", "b", "c"]
+    assert notices == []
+
+
 def test_deduplicate_servers_passes_through_distinct_servers():
     """Unrelated servers are returned untouched, in order."""
     servers = process_server_urls([

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -1,6 +1,6 @@
 """Test server discovery functionality."""
 
-from mcp_client_for_ollama.server.discovery import process_server_urls, parse_server_config_mapping
+from mcp_client_for_ollama.server.discovery import process_server_urls, parse_server_config_mapping, deduplicate_servers
 
 
 def test_process_server_urls():
@@ -158,3 +158,82 @@ def test_parse_server_config_mapping_stdio_and_disabled():
     assert len(result) == 1
     assert result[0]["name"] == "fs"
     assert result[0]["type"] == "config"
+
+
+def test_deduplicate_servers_keeps_registry_entry_over_url_flag():
+    """A registry entry and a `-u` flag for one endpoint are one server.
+
+    The registry entry wins because it carries the name the user chose.
+    """
+    url = "http://127.0.0.1:8000/mcp"
+    servers = [
+        {"type": "streamable_http", "name": "unreal-mcp", "url": url, "config": {"url": url}},
+        {"type": "streamable_http", "name": "127_0_0_1_8000", "url": url},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["unreal-mcp"]
+    assert any("duplicate" in n for n in notices)
+
+
+def test_deduplicate_servers_normalizes_url_before_comparing():
+    """Trailing slash and host casing do not make a second server."""
+    servers = [
+        {"type": "streamable_http", "name": "a", "url": "http://LocalHost:8000/mcp/"},
+        {"type": "streamable_http", "name": "b", "url": "http://localhost:8000/mcp"},
+    ]
+    result, _ = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["a"]
+
+
+def test_deduplicate_servers_keeps_same_url_on_different_transports():
+    """SSE and Streamable HTTP on one URL are genuinely two entries."""
+    servers = [
+        {"type": "sse", "name": "x", "url": "http://localhost:8000/mcp"},
+        {"type": "streamable_http", "name": "y", "url": "http://localhost:8000/mcp"},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    assert len(result) == 2
+    assert notices == []
+
+
+def test_deduplicate_servers_renames_colliding_names():
+    """Two endpoints that differ only by path must not share a name.
+
+    `process_server_urls` derives the name from netloc alone, so these collide.
+    """
+    servers = process_server_urls([
+        "http://localhost:8000/alpha",
+        "http://localhost:8000/beta",
+    ])
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["localhost_8000", "localhost_8000-2"]
+    assert result[0]["url"].endswith("/alpha")
+    assert result[1]["url"].endswith("/beta")
+    assert any("Renaming" in n for n in notices)
+
+
+def test_deduplicate_servers_dedupes_stdio_by_command():
+    """The same STDIO command from two scopes is one server."""
+    servers = [
+        {"type": "config", "name": "fs", "config": {"command": "npx", "args": ["-y", "fs", "."]}},
+        {"type": "config", "name": "fs-copy", "config": {"command": "npx", "args": ["-y", "fs", "."]}},
+    ]
+    result, _ = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["fs"]
+
+
+def test_deduplicate_servers_passes_through_distinct_servers():
+    """Unrelated servers are returned untouched, in order."""
+    servers = process_server_urls([
+        "http://localhost:8000/mcp",
+        "http://localhost:9000/mcp",
+    ])
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["localhost_8000", "localhost_9000"]
+    assert notices == []

--- a/tests/test_server_discovery.py
+++ b/tests/test_server_discovery.py
@@ -227,6 +227,65 @@ def test_deduplicate_servers_dedupes_stdio_by_command():
     assert [s["name"] for s in result] == ["fs"]
 
 
+def test_deduplicate_servers_keeps_stdio_entries_with_different_env():
+    """One command run with two credential sets is two servers.
+
+    Both entries connect today, because their names differ; collapsing them
+    would silently drop an account.
+    """
+    servers = [
+        {"type": "config", "name": "github-work", "config": {
+            "command": "npx", "args": ["-y", "server-github"],
+            "env": {"GITHUB_TOKEN": "work-token"},
+        }},
+        {"type": "config", "name": "github-personal", "config": {
+            "command": "npx", "args": ["-y", "server-github"],
+            "env": {"GITHUB_TOKEN": "personal-token"},
+        }},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["github-work", "github-personal"]
+    assert notices == []
+
+
+def test_deduplicate_servers_dedupes_stdio_with_identical_env():
+    """The same command with the same env is still one server."""
+    env = {"GITHUB_TOKEN": "token"}
+    servers = [
+        {"type": "config", "name": "github", "config": {"command": "npx", "args": ["-y", "server-github"], "env": env}},
+        {"type": "config", "name": "github-copy", "config": {"command": "npx", "args": ["-y", "server-github"], "env": dict(env)}},
+    ]
+    result, _ = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["github"]
+
+
+def test_deduplicate_servers_keeps_http_entries_with_different_headers():
+    """Two tenants on one URL differ only by Authorization."""
+    url = "https://mcp.example.com/mcp"
+    servers = [
+        {"type": "streamable_http", "name": "tenant-a", "url": url, "headers": {"Authorization": "Bearer a"}},
+        {"type": "streamable_http", "name": "tenant-b", "url": url, "headers": {"Authorization": "Bearer b"}},
+    ]
+    result, notices = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["tenant-a", "tenant-b"]
+    assert notices == []
+
+
+def test_deduplicate_servers_ignores_header_name_casing():
+    """Header names are compared as they are sent: lowercased."""
+    url = "https://mcp.example.com/mcp"
+    servers = [
+        {"type": "streamable_http", "name": "a", "url": url, "headers": {"Authorization": "Bearer x"}},
+        {"type": "streamable_http", "name": "b", "url": url, "config": {"headers": {"authorization": "Bearer x"}}},
+    ]
+    result, _ = deduplicate_servers(servers)
+
+    assert [s["name"] for s in result] == ["a"]
+
+
 def test_deduplicate_servers_passes_through_distinct_servers():
     """Unrelated servers are returned untouched, in order."""
     servers = process_server_urls([


### PR DESCRIPTION
Fixes #283.

## Problem

`connect_to_servers` concatenates its five sources (registry mapping, scripts, `-u` URLs, config file, Claude Desktop) into one list with no deduplication, and `_connect_to_server` stores each result with a bare `self.sessions[server_name] = ...`. When two entries share a name the second overwrites the first, while the first server's tools stay in `available_tools` and `enabled_tools` — still advertised to the model, but now resolving to a session that does not own them.

Two ways this is reachable:

1. **The same endpoint from the registry and from `-u`** — the duplicate visible in the #274 log (`unreal-mcp` and `127_0_0_1_8000` are one server).
2. **Two servers on one host:port** — `process_server_urls` derives the name from `netloc` alone and ignores the path.

## Fix

`deduplicate_servers()` in `discovery.py`, called from `connect_to_servers` before connecting:

- **Collapse duplicates** by target: transport + normalized URL, script path, or stdio command+args. The first entry wins, which is the one from the more explicit source, so a registry name beats a name derived from a URL.
- **Disambiguate what still collides**: a distinct endpoint whose name is taken gets a `-2` suffix instead of overwriting.
- Both paths print what happened rather than losing a server silently.

URL normalization only ignores what the server cannot see: scheme/host casing, a trailing slash, and the fragment. Transport is part of the target key, so the same URL over SSE and Streamable HTTP stays two entries.

## Before / after

Registry + `-u`, same URL:

```
before   sessions: ['unreal-mcp', '127_0_0_1_61439']
         tools:    ['unreal-mcp.alpha_tool', '127_0_0_1_61439.alpha_tool']
after    Skipping duplicate entry '127_0_0_1_61439': same server as 'unreal-mcp'
         sessions: ['unreal-mcp']
         tools:    ['unreal-mcp.alpha_tool']
```

Two servers on one host:port:

```
before   sessions: ['127_0_0_1_61439']                       <- /alpha lost
         tools:    ['...alpha_tool', '...beta_tool']         <- alpha_tool orphaned
after    Renaming '127_0_0_1_61439' to '127_0_0_1_61439-2': another server already uses that name
         sessions: ['127_0_0_1_61439', '127_0_0_1_61439-2']
         tools:    ['127_0_0_1_61439.alpha_tool', '127_0_0_1_61439-2.beta_tool']
```

## Tests

- `tests/test_connector_server_dedup.py` — both scenarios end to end against a real in-process Streamable HTTP server, in the style of `test_connector_e2e.py`. Both fail on `main` and pass here.
- `tests/test_server_discovery.py` — six unit tests for `deduplicate_servers`: registry beats `-u`, URL normalization, SSE vs Streamable HTTP on one URL stays two entries, name suffixing, stdio dedup by command, and untouched pass-through.

`python -m pytest tests/` → **235 passed** (227 on `main` before this change). Python 3.14, `mcp` from the pinned range.

## Open question

I went with a numeric suffix for collisions rather than folding the URL path into the derived name, since renaming affects keys stored in `enabled_tools`. Suffixing only kicks in for a case that was previously broken anyway, so no name that works today changes. Happy to switch to path-based names if you prefer that shape.
