### PR TITLE
fix(tests): add pytest importlib import mode to fix collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ include = ["mcp_client_for_ollama*"]
 dev = [
     "pytest~=9.1.0",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"


### PR DESCRIPTION
Fixes #288.

`tests/` and `cli-package/tests/` are both packages named `tests`, so under pytest's default `prepend` mode one shadows the other in `sys.modules` and bare `uv run pytest` fails collection. `--import-mode=importlib` loads test files by path instead of by module name, so they can't collide. It goes in `addopts` because pytest has no ini key for the import mode.

Bare `pytest` now passes (242), along with the explicit-path and CI-style `cd tests && pytest` invocations. CI picks up the root config automatically, so no workflow change.