### PR TITLE
Add Parallel Search MCP CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,13 @@ ollmcp mcp add --help
 
 ```bash
 ollmcp mcp add --transport http github https://api.githubcopilot.com/mcp/ --header "Authorization: Bearer $YOUR_GITHUB_PAT"
+ollmcp mcp add --transport http parallel-search https://search.parallel.ai/mcp
 ollmcp mcp add --transport stdio playwright npx @playwright/mcp@latest
 ollmcp mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /allowed-dir1 ~/allowed-dir2 # stdio transport by default
 ollmcp mcp add --env API_KEY=YOUR_KEY --transport sse my-sse-server http://localhost:8000/sse
 ```
 
+Parallel Search does not require an API key. When enabled, selected search queries and requested URLs are sent to Parallel.
 
 ### mcp add options
 


### PR DESCRIPTION
## Why

Adds an optional web search and URL-fetching MCP server to the existing CLI examples. The endpoint does not require an account or API key.

## Changes

- Add the native `ollmcp mcp add` command for Parallel Search MCP.
- Note that selected search queries and requested URLs are sent to Parallel.
- Preserve the existing server examples, configuration scopes, and defaults.

## Validation

- `git diff --check`: passed.
- README-only patch and exact-content assertions: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.