### PR TITLE
feat(server): route MCP server output to per-session log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ wheels/
 
 # Virtual environments
 .venv
+
+# MacOS
+.DS_Store
+
+# IDE
+.vscode
+.claude

--- a/README.es.md
+++ b/README.es.md
@@ -325,6 +325,13 @@ El ámbito `project` escribe un archivo `.mcp.json` estándar en la raíz de tu 
 - `--install-completion`: Instalar los scripts de autocompletado de shell para el cliente
 - `--show-completion`: Mostrar las opciones de autocompletado de shell disponibles
 
+#### Logs de los servidores MCP:
+
+Lo que reportan los servidores MCP siempre se escribe en `~/.config/ollmcp/logs/<sesión>/<servidor>.log`, un directorio por ejecución, conservando los últimos 5. Estas opciones solo deciden qué además se muestra en vivo en pantalla:
+
+- `--debug`: Muestra la salida de los servidores a medida que llega: el stderr de los servidores stdio y sus notificaciones de log MCP.
+- `--log-level` NIVEL: Muestra las notificaciones de log MCP de ese nivel o superior (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`), y le pide a los servidores que solo envíen esas. No aplica al stderr; para eso usá `--debug`. Si lo pasás junto con `--debug`, gana este nivel.
+
 ### Proveedores de inferencia soportados
 
 > [!WARNING]

--- a/README.es.md
+++ b/README.es.md
@@ -327,10 +327,22 @@ El ámbito `project` escribe un archivo `.mcp.json` estándar en la raíz de tu 
 
 #### Logs de los servidores MCP:
 
-Lo que reportan los servidores MCP siempre se escribe en `~/.config/ollmcp/logs/<sesión>/<servidor>.log`, un directorio por ejecución, conservando los últimos 5. Estas opciones solo deciden qué además se muestra en vivo en pantalla:
+Todo lo que reporta un servidor MCP se escribe en `~/.config/ollmcp/logs/<sesión>/<servidor>.log`, un directorio por ejecución, conservando los últimos 5. **Nada de lo que imprime un servidor llega a la pantalla salvo que lo pidas** — si no, dibujaría encima de la respuesta que se está transmitiendo.
 
-- `--debug`: Muestra la salida de los servidores a medida que llega: el stderr de los servidores stdio y sus notificaciones de log MCP.
-- `--log-level` NIVEL: Muestra las notificaciones de log MCP de ese nivel o superior (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`), y le pide a los servidores que solo envíen esas. No aplica al stderr; para eso usá `--debug`. Si lo pasás junto con `--debug`, gana este nivel.
+Los servidores reportan por dos canales: su **stderr** (solo los servidores stdio, porque uno remoto corre en otro lado) y las **notificaciones de log MCP** (cualquier servidor). **Las dos opciones solo cambian lo que ves en pantalla — el archivo recibe todo igual:**
+
+| | se escribe en el archivo | se muestra en pantalla |
+|---|---|---|
+| *(sin opciones)* | todo lo que manda el servidor | nada del servidor |
+| `--debug` | todo lo que manda el servidor | todo eso, a medida que llega |
+| `--log-level NIVEL` | todo lo que manda el servidor | solo las notificaciones de ese nivel o superior |
+| `--debug --log-level NIVEL` | todo lo que manda el servidor | stderr completo + notificaciones de ese nivel o superior |
+
+NIVEL es uno de `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.
+
+Sin opciones no se pide ningún nivel: decide el servidor qué emite, y todo queda registrado. `--log-level` filtra lo que ves, y además se le envía al servidor (`logging/setLevel`) cuando este anuncia la capability de logging — ahí el servidor puede dejar de emitir los niveles más bajos, que entonces tampoco aparecen en el archivo. Los servidores sin esa capability siguen mandando todo y el filtrado ocurre acá.
+
+Cuando un servidor no logra conectarse, el error apunta a su archivo de log: lo que el servidor haya impreso antes de morir está ahí, y suele ser la razón real.
 
 ### Proveedores de inferencia soportados
 

--- a/README.md
+++ b/README.md
@@ -323,10 +323,22 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 
 #### MCP Server Logging:
 
-What the MCP servers report is always written to `~/.config/ollmcp/logs/<session>/<server>.log`, one directory per run, keeping the last 5. These flags only decide what is also shown live on screen:
+Whatever an MCP server reports is written to `~/.config/ollmcp/logs/<session>/<server>.log`, one directory per run, keeping the last 5. **Nothing a server prints reaches the screen unless you ask for it** — otherwise it would draw over the answer being streamed.
 
-- `--debug`: Show the servers' output as it arrives: the stderr of stdio servers and their MCP log notifications.
-- `--log-level` LEVEL: Show MCP log notifications of this level or higher (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`), and ask the servers to only send those. Does not apply to stderr; use `--debug` for that. Given together with `--debug`, this level wins.
+Servers report through two channels: their **stderr** (only stdio servers, since a remote one runs elsewhere) and **MCP log notifications** (any server). **Both flags only change what you see on screen — the log file gets everything either way:**
+
+| | written to the log file | shown on screen |
+|---|---|---|
+| *(no flag)* | everything the server sends | nothing from the server |
+| `--debug` | everything the server sends | all of it, as it arrives |
+| `--log-level LEVEL` | everything the server sends | only notifications of LEVEL or higher |
+| `--debug --log-level LEVEL` | everything the server sends | stderr in full + notifications of LEVEL or higher |
+
+LEVEL is one of `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.
+
+With no flag, no level is requested at all: the server decides what it emits and all of it is recorded. `--log-level` filters what you see, and is also sent to the server (`logging/setLevel`) when it advertises the logging capability — such a server may then stop emitting the lower levels, which are missing from the file too. Servers without that capability keep sending everything and the filtering happens here.
+
+When a server fails to connect, the error points at its log file: whatever the server printed on its way out is in there, and that is usually the real reason.
 
 ### Supported Inference Providers
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ The `project` scope writes a standard `.mcp.json` file at your project root, com
 - `--install-completion`: Install shell autocompletion scripts for the client
 - `--show-completion`: Show available shell completion options
 
+#### MCP Server Logging:
+
+What the MCP servers report is always written to `~/.config/ollmcp/logs/<session>/<server>.log`, one directory per run, keeping the last 5. These flags only decide what is also shown live on screen:
+
+- `--debug`: Show the servers' output as it arrives: the stderr of stdio servers and their MCP log notifications.
+- `--log-level` LEVEL: Show MCP log notifications of this level or higher (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`), and ask the servers to only send those. Does not apply to stderr; use `--debug` for that. Given together with `--debug`, this level wins.
+
 ### Supported Inference Providers
 
 > [!WARNING]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,6 +325,13 @@ ollmcp mcp add --env API_KEY=YOUR_KEY --transport sse my-sse-server http://local
 - `--install-completion`: 为客户端安装 shell 自动补全脚本
 - `--show-completion`: 显示可用的 shell 补全选项
 
+#### MCP 服务器日志:
+
+MCP 服务器报告的内容始终会写入 `~/.config/ollmcp/logs/<session>/<server>.log`，每次运行一个目录，保留最近 5 次。以下选项只决定哪些内容会同时实时显示在屏幕上：
+
+- `--debug`: 实时显示服务器的输出：stdio 服务器的 stderr 以及它们的 MCP 日志通知。
+- `--log-level` LEVEL: 显示该级别及以上的 MCP 日志通知（`debug`、`info`、`notice`、`warning`、`error`、`critical`、`alert`、`emergency`），并请求服务器只发送这些级别。不影响 stderr，那些请使用 `--debug`。与 `--debug` 同时使用时，以此级别为准。
+
 ### 支持的推理提供商
 
 > [!WARNING]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -327,10 +327,22 @@ ollmcp mcp add --env API_KEY=YOUR_KEY --transport sse my-sse-server http://local
 
 #### MCP 服务器日志:
 
-MCP 服务器报告的内容始终会写入 `~/.config/ollmcp/logs/<session>/<server>.log`，每次运行一个目录，保留最近 5 次。以下选项只决定哪些内容会同时实时显示在屏幕上：
+MCP 服务器报告的所有内容都会写入 `~/.config/ollmcp/logs/<session>/<server>.log`，每次运行一个目录，保留最近 5 次。**除非你主动要求，服务器打印的内容都不会显示在屏幕上** —— 否则它会覆盖正在流式输出的回答。
 
-- `--debug`: 实时显示服务器的输出：stdio 服务器的 stderr 以及它们的 MCP 日志通知。
-- `--log-level` LEVEL: 显示该级别及以上的 MCP 日志通知（`debug`、`info`、`notice`、`warning`、`error`、`critical`、`alert`、`emergency`），并请求服务器只发送这些级别。不影响 stderr，那些请使用 `--debug`。与 `--debug` 同时使用时，以此级别为准。
+服务器通过两个渠道报告：**stderr**（仅限 stdio 服务器，因为远程服务器运行在别处）和 **MCP 日志通知**（任何服务器）。**这两个选项只改变屏幕上显示的内容 —— 日志文件无论如何都会收到全部内容：**
+
+| | 写入日志文件 | 显示在屏幕上 |
+|---|---|---|
+| *(不加选项)* | 服务器发送的全部内容 | 服务器的内容都不显示 |
+| `--debug` | 服务器发送的全部内容 | 全部内容，实时显示 |
+| `--log-level LEVEL` | 服务器发送的全部内容 | 仅该级别及以上的通知 |
+| `--debug --log-level LEVEL` | 服务器发送的全部内容 | 完整的 stderr + 该级别及以上的通知 |
+
+LEVEL 为 `debug`、`info`、`notice`、`warning`、`error`、`critical`、`alert`、`emergency` 之一。
+
+不加选项时不会请求任何级别：由服务器决定发送什么，并全部记录下来。`--log-level` 用于过滤你看到的内容；当服务器声明了 logging capability 时，该级别还会通过 `logging/setLevel` 发送给服务器 —— 此时服务器可能不再发送更低的级别，那些内容也就不会出现在文件里。没有该 capability 的服务器会照常发送全部内容，过滤在客户端进行。
+
+当服务器连接失败时，错误信息会指向它的日志文件：服务器退出前打印的内容都在里面，那通常才是真正的原因。
 
 ### 支持的推理提供商
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -32,7 +32,7 @@ from . import __version__
 from .config.manager import ConfigManager
 from .config.defaults import default_config, default_provider_profile
 from .utils.version import check_for_updates
-from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART, REASONING_EFFORT_LEVELS, DEFAULT_REASONING_EFFORT
+from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART, REASONING_EFFORT_LEVELS, DEFAULT_REASONING_EFFORT, SERVER_LOG_DIR, MCP_LOG_LEVELS
 from .utils.connection import preflight_ollama, validate_provider
 from .utils.images import apply_images
 from .server.connector import ServerConnector
@@ -70,7 +70,7 @@ class MCPClient:
         "multiline": "Multiline",
     }
 
-    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None, persist_api_key: bool = True):
+    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None, persist_api_key: bool = True, debug: bool = False, log_level: str = None):
         # Initialize session and client objects
         self.exit_stack = AsyncExitStack()
         self.host = host
@@ -83,7 +83,7 @@ class MCPClient:
         self.console = Console()
         self.config_manager = ConfigManager(self.console)
         # Initialize the server connector
-        self.server_connector = ServerConnector(self.exit_stack, self.console)
+        self.server_connector = ServerConnector(self.exit_stack, self.console, debug=debug, log_level=log_level)
         # Initialize the model manager
         self.model_manager = ModelManager(console=self.console, default_model=model, llm=self.llm, provider=provider, api_base=host, api_key=api_key or "")
         # Initialize the model config manager
@@ -2101,6 +2101,16 @@ def main(
     version: Optional[bool] = typer.Option(
         None, "--version", "-v",
         help="Show version and exit",
+    ),
+    debug: bool = typer.Option(
+        False, "--debug",
+        help=f"Show the servers' output live. Always saved to {SERVER_LOG_DIR.replace(os.path.expanduser('~'), '~')}/",
+        rich_help_panel="MCP Server Logging",
+    ),
+    log_level: Optional[str] = typer.Option(
+        None, "--log-level",
+        help=f"Show log notifications of this level or higher: {', '.join(MCP_LOG_LEVELS)}.",
+        rich_help_panel="MCP Server Logging",
     )
 ):
     """Run the MCP Client for Ollama with specified options."""
@@ -2112,12 +2122,18 @@ def main(
         typer.echo(f"ollmcp {__version__}")
         raise typer.Exit()
 
+    if log_level is not None:
+        log_level = log_level.lower()
+        if log_level not in MCP_LOG_LEVELS:
+            typer.echo(f"Error: --log-level must be one of {', '.join(MCP_LOG_LEVELS)} (got: {log_level})", err=True)
+            raise typer.Exit(code=1)
+
     # Run the async main function with proper cleanup
     # Use manual loop management to ensure subprocesses cleanup before loop closes
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key))
+        loop.run_until_complete(async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key, debug, log_level))
     finally:
         try:
             # Ensure executor cleanup completes before closing loop
@@ -2126,7 +2142,7 @@ def main(
         finally:
             loop.close()
 
-async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key):
+async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key, debug=False, log_level=None):
     """Asynchronous main function to run the MCP Client for Ollama"""
 
     console = Console()
@@ -2170,7 +2186,7 @@ async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, m
     resolved_model = model or profile.get("model") or DEFAULT_MODEL
 
     try:
-        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key, persist_api_key=persist_api_key)
+        client = MCPClient(model=resolved_model, host=resolved_host, provider=effective_provider, api_key=resolved_api_key, persist_api_key=persist_api_key, debug=debug, log_level=log_level)
     except MissingApiKeyError as e:
         console.print(Panel(
             f"[bold red]API key required:[/bold red] The [bold blue]{effective_provider}[/bold blue] provider needs an API key.\n\n"

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -2104,12 +2104,12 @@ def main(
     ),
     debug: bool = typer.Option(
         False, "--debug",
-        help=f"Show the servers' output live. Always saved to {SERVER_LOG_DIR.replace(os.path.expanduser('~'), '~')}/",
+        help=f"Show on screen what the servers report (stderr and log notifications) as it arrives. Saved to {SERVER_LOG_DIR.replace(os.path.expanduser('~'), '~')}/ either way.",
         rich_help_panel="MCP Server Logging",
     ),
     log_level: Optional[str] = typer.Option(
-        None, "--log-level",
-        help=f"Show log notifications of this level or higher: {', '.join(MCP_LOG_LEVELS)}.",
+        None, "--log-level", metavar="LEVEL",
+        help=f"Show on screen the log notifications of this level or higher (not stderr, that is --debug): {', '.join(MCP_LOG_LEVELS)}.",
         rich_help_panel="MCP Server Logging",
     )
 ):

--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -17,7 +17,8 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from .discovery import process_server_paths, process_server_urls, parse_server_configs, parse_server_config_mapping, load_claude_desktop_servers, deduplicate_servers
-from ..utils.constants import MCP_PROTOCOL_VERSION
+from ..utils.constants import MCP_LOG_LEVELS, MCP_PROTOCOL_VERSION
+from ..utils.server_logs import ServerLogSink
 
 class ServerConnector:
     """Manages connections to one or more MCP servers.
@@ -27,15 +28,21 @@ class ServerConnector:
     tools provided by those servers.
     """
 
-    def __init__(self, exit_stack: AsyncExitStack, console: Optional[Console] = None):
+    def __init__(self, exit_stack: AsyncExitStack, console: Optional[Console] = None, debug: bool = False, log_level: Optional[str] = None):
         """Initialize the ServerConnector.
 
         Args:
             exit_stack: AsyncExitStack to manage server connections
             console: Rich console for output (optional)
+            debug: Show everything the servers report, including the stderr of
+                stdio servers
+            log_level: Lowest level of MCP log notification to show. Wins over
+                debug, which only picks the level when none was asked for.
         """
         self.exit_stack = exit_stack
         self.console = console or Console()
+        self.debug = debug
+        self.log_level = log_level or ("debug" if debug else None)
         self.sessions = {}  # Dict to store multiple sessions
         self.available_tools = []  # List to store all available tools
         self.enabled_tools = {}  # Dict to store tool enabled status
@@ -144,6 +151,8 @@ class ServerConnector:
         # later (while querying capabilities) is not reported as the server
         # failing to answer initialize.
         initialized = False
+        # The server's log file, pointed at if the connection fails
+        log_path = None
 
         try:
             server_type = server.get("type", "script")
@@ -154,6 +163,20 @@ class ServerConnector:
             # cancelled anyio scope so it cannot leak into later operations.
             # On success, contexts are transferred to self.exit_stack via pop_all().
             async with AsyncExitStack() as local_stack:
+
+                # Everything the server reports goes to its own log file: the
+                # stderr of a stdio server would otherwise print over whatever
+                # is on screen, including a streaming answer (issue #293).
+                # Registered before the transport so it closes after it: the
+                # pipe reaches EOF only once the server process is gone.
+                # Only a stdio server has a stderr to intercept; a remote one
+                # reports through log notifications, which the sink echoes on
+                # their own path.
+                is_stdio = server_type not in ("sse", "streamable_http")
+                log_sink = ServerLogSink(server_name, console=self.console, echo_stderr=self.debug and is_stdio)
+                log_path = log_sink.path
+                local_stack.callback(log_sink.close)
+                logging_callback = self._make_logging_callback(log_sink)
 
                 # Connect based on server type
                 if server_type == "sse":
@@ -168,7 +191,9 @@ class ServerConnector:
                     # Connect using SSE transport
                     sse_transport = await local_stack.enter_async_context(sse_client(url, headers=headers))
                     read_stream, write_stream = sse_transport
-                    session = await local_stack.enter_async_context(ClientSession(read_stream, write_stream))
+                    session = await local_stack.enter_async_context(
+                        ClientSession(read_stream, write_stream, logging_callback=logging_callback)
+                    )
 
                 elif server_type == "streamable_http":
                     # Connect to Streamable HTTP server
@@ -184,31 +209,31 @@ class ServerConnector:
                         streamablehttp_client(url, headers=headers)
                     )
                     read_stream, write_stream, session_info = transport
-                    session = await local_stack.enter_async_context(ClientSession(read_stream, write_stream))
+                    session = await local_stack.enter_async_context(
+                        ClientSession(read_stream, write_stream, logging_callback=logging_callback)
+                    )
 
                     # Store session ID if provided
                     if hasattr(session_info, 'session_id') and session_info.session_id:
                         self.session_ids[server_name] = session_info.session_id
 
-                elif server_type == "script":
-                    # Connect to script-based server using STDIO
-                    server_params = self._create_script_params(server)
-                    if server_params is None:
-                        return False
-
-                    stdio_transport = await local_stack.enter_async_context(stdio_client(server_params))
-                    read_stream, write_stream = stdio_transport
-                    session = await local_stack.enter_async_context(ClientSession(read_stream, write_stream))
-
                 else:
-                    # Connect to config-based server using STDIO
-                    server_params = self._create_config_params(server)
+                    # Connect to a STDIO server, given either as a script path
+                    # or as a full command
+                    if server_type == "script":
+                        server_params = self._create_script_params(server)
+                    else:
+                        server_params = self._create_config_params(server)
                     if server_params is None:
                         return False
 
-                    stdio_transport = await local_stack.enter_async_context(stdio_client(server_params))
+                    stdio_transport = await local_stack.enter_async_context(
+                        stdio_client(server_params, errlog=log_sink.stream)
+                    )
                     read_stream, write_stream = stdio_transport
-                    session = await local_stack.enter_async_context(ClientSession(read_stream, write_stream))
+                    session = await local_stack.enter_async_context(
+                        ClientSession(read_stream, write_stream, logging_callback=logging_callback)
+                    )
 
                 # Initialize the session and capture capabilities
                 init_result = await session.initialize()
@@ -224,9 +249,11 @@ class ServerConnector:
                 "tools": []
             }
 
+            capabilities = getattr(init_result, 'capabilities', None)
+            await self._apply_log_level(session, server_name, capabilities)
+
             # Get tools from this server if capability is present
             server_tools = []
-            capabilities = getattr(init_result, 'capabilities', None)
             if capabilities and getattr(capabilities, 'tools', None):
                 try:
                     response = await session.list_tools()
@@ -320,14 +347,17 @@ class ServerConnector:
                     f"initialization. Verify the URL serves an MCP endpoint, not a regular web "
                     f"page or other service.[/red]"
                 )
+            self._print_server_log_hint(log_path)
             return False
         except FileNotFoundError as e:
             self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: File not found - {str(e)}[/red]")
+            self._print_server_log_hint(log_path)
             return False
         except PermissionError:
             self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: Permission denied[/red]")
+            self._print_server_log_hint(log_path)
             return False
         except Exception as e:
             self._discard_server_state(server_name)
@@ -337,7 +367,50 @@ class ServerConnector:
                     self.console.print(f"[red]Error connecting to {server_name}: {str(sub)}[/red]")
             else:
                 self.console.print(f"[red]Error connecting to {server_name}: {str(e)}[/red]")
+            self._print_server_log_hint(log_path)
             return False
+
+    async def _apply_log_level(self, session, server_name: str, capabilities) -> None:
+        """Ask a server to only send log notifications from the wanted level up."""
+        if not self.log_level or not (capabilities and getattr(capabilities, 'logging', None)):
+            return
+        try:
+            await session.set_logging_level(self.log_level)
+        except Exception as e:
+            self.console.print(f"[yellow]Warning: Failed to set log level on {server_name}: {str(e)}[/yellow]")
+
+    def _make_logging_callback(self, log_sink: ServerLogSink):
+        """Build the handler for the log notifications of one server."""
+        async def handle_log_message(params) -> None:
+            level = getattr(params, "level", "info")
+            logger_name = getattr(params, "logger", None)
+            source = f"{level} {logger_name}" if logger_name else level
+            data = params.data if isinstance(params.data, str) else repr(params.data)
+            log_sink.log(f"{source}: {data}", echo=self._shows_level(level))
+
+        return handle_log_message
+
+    def _shows_level(self, level: str) -> bool:
+        """Whether a notification at this level belongs on screen.
+
+        The level is also set on the server, but a server may ignore that and
+        send everything anyway, so the threshold is applied here too.
+        """
+        if not self.log_level:
+            return False
+        if level not in MCP_LOG_LEVELS:
+            # A level the spec does not define: better shown than swallowed
+            return True
+        return MCP_LOG_LEVELS.index(level) >= MCP_LOG_LEVELS.index(self.log_level)
+
+    def _print_server_log_hint(self, log_path: Optional[str]) -> None:
+        """Point at a stdio server's log file, which now holds its stderr.
+
+        Whatever the server printed on its way out is in there instead of on
+        screen, and that is usually the actual reason the connection failed.
+        """
+        if log_path and os.path.exists(log_path) and os.path.getsize(log_path) > 0:
+            self.console.print(f"[dim]Server output: {log_path}[/dim]")
 
     def _create_script_params(self, server: Dict[str, Any]) -> Optional[StdioServerParameters]:
         """Create server parameters for a script-type server

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -13,6 +13,14 @@ if not os.path.exists(DEFAULT_CONFIG_DIR):
 
 DEFAULT_CONFIG_FILE = "config.json"
 
+# Log files of the MCP servers, one directory per ollmcp session
+SERVER_LOG_DIR = os.path.join(DEFAULT_CONFIG_DIR, "logs")
+# How many past sessions to keep there
+KEPT_LOG_SESSIONS = 5
+
+# Levels of the MCP logging channel, least to most severe (RFC 5424)
+MCP_LOG_LEVELS = ("debug", "info", "notice", "warning", "error", "critical", "alert", "emergency")
+
 # MCP server registry files managed by `ollmcp mcp add/list/remove`
 # User scope: global, available across all projects
 USER_MCP_FILE = os.path.join(DEFAULT_CONFIG_DIR, "mcp.json")

--- a/mcp_client_for_ollama/utils/server_logs.py
+++ b/mcp_client_for_ollama/utils/server_logs.py
@@ -1,0 +1,166 @@
+"""Per-server log files for what MCP servers report.
+
+Servers report through two channels: a stdio server writes to stderr, and any
+server can send MCP log notifications. Both end up in the server's log file
+here; what reaches the screen is decided by the caller, since a stdio server
+inherits the client's stderr unless given somewhere else to write and would
+otherwise print over whatever ollmcp is rendering (issue #293).
+"""
+
+import os
+import re
+import shutil
+import threading
+from datetime import datetime
+from typing import Optional
+
+from rich.console import Console
+from rich.markup import escape
+
+from .constants import KEPT_LOG_SESSIONS, SERVER_LOG_DIR
+from .sanitize import strip_control_chars
+
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+# Log directory of one run: a timestamp for ordering plus the pid, which is what
+# keeps several ollmcp windows from writing over each other's files.
+_SESSION_DIR_NAME = f"{datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.getpid()}"
+_SESSION_DIR_PATTERN = re.compile(r"^\d{8}-\d{6}-(\d+)$")
+
+
+def session_log_dir() -> str:
+    """Directory holding the log files of this run."""
+    return os.path.join(SERVER_LOG_DIR, _SESSION_DIR_NAME)
+
+
+def server_log_path(server_name: str) -> str:
+    """Path of a server's log file, with its name made filename-safe."""
+    safe_name = _UNSAFE_FILENAME_CHARS.sub("_", server_name).strip("._") or "server"
+    return os.path.join(session_log_dir(), f"{safe_name}.log")
+
+
+def prune_old_sessions(keep: int = KEPT_LOG_SESSIONS) -> None:
+    """Delete the log directories of previous runs, keeping the newest ones.
+
+    Directories are named after the session's pid, and one whose process is
+    still alive is never deleted: with more windows open than ``keep``, the
+    oldest of them is a running session, not an old one.
+    """
+    try:
+        entries = sorted(os.listdir(SERVER_LOG_DIR))
+    except OSError:
+        return
+
+    sessions = [(name, int(m.group(1))) for name in entries if (m := _SESSION_DIR_PATTERN.match(name))]
+    for name, pid in sessions[:-keep]:
+        if _is_running(pid):
+            continue
+        shutil.rmtree(os.path.join(SERVER_LOG_DIR, name), ignore_errors=True)
+
+
+def _is_running(pid: int) -> bool:
+    """Whether a process is still alive."""
+    if os.name == "nt":
+        # os.kill() on Windows terminates the process instead of probing it.
+        # Nothing is checked there: Windows refuses to delete files a live
+        # session still has open, so its logs survive the prune anyway.
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # Alive but not ours to signal
+        return True
+    return True
+
+
+class ServerLogSink:
+    """Log file of one server, fed by its stderr and its log notifications.
+
+    ``stream`` is what gets handed to ``stdio_client(errlog=...)``. It has to be
+    a real file object: the SDK passes it straight to ``anyio.open_process`` as
+    the subprocess stderr, so an object that merely implements ``write()`` will
+    not do.
+
+    Without ``echo_stderr`` the sink is just the log file. With it, the server
+    writes into a pipe that a reader thread drains into both the file and the
+    console — a thread rather than an asyncio reader so it behaves the same on
+    Windows, and draining is not optional: a pipe nobody reads fills up and
+    blocks the server. Echoed lines are sanitized, since they are text from the
+    server.
+    """
+
+    def __init__(self, server_name: str, console: Optional[Console] = None, echo_stderr: bool = False):
+        self.server_name = server_name
+        self.path = server_log_path(server_name)
+        self._console = console
+        self._lock = threading.Lock()
+        self._reader = None
+        self._pipe = None
+
+        try:
+            os.makedirs(session_log_dir(), exist_ok=True)
+            prune_old_sessions()
+            # Appended to, so reconnecting a server mid-session keeps what came before
+            self._file = open(self.path, "a", encoding="utf-8", errors="replace")
+        except OSError as e:
+            # Nowhere to write (read-only home, no space, ...). Not having a log
+            # file is not a reason to refuse the connection: the server still
+            # connects, its output is just dropped. ``path`` is cleared so the
+            # caller does not point the user at a file that was never written.
+            if console is not None:
+                console.print(
+                    f"[yellow]Warning: could not open the log file for {server_name} "
+                    f"({e}); its output will not be recorded[/yellow]"
+                )
+            self.path = None
+            self._file = open(os.devnull, "w", encoding="utf-8")
+
+        if not (echo_stderr and console is not None):
+            self.stream = self._file
+            return
+
+        read_fd, write_fd = os.pipe()
+        self.stream = os.fdopen(write_fd, "w", encoding="utf-8", errors="replace", buffering=1)
+        self._pipe = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        self._reader = threading.Thread(target=self._drain, daemon=True)
+        self._reader.start()
+
+    def log(self, message: str, echo: bool = True) -> None:
+        """Record a message the server sent over the MCP logging channel."""
+        self._write(message + "\n")
+        if echo:
+            self._echo(message)
+
+    def close(self) -> None:
+        """Close the sink; the reader thread stops once the pipe reaches EOF."""
+        try:
+            self.stream.close()
+        except OSError:
+            pass
+        if self._reader is not None:
+            self._reader.join(timeout=2)
+        if self._pipe is not None:
+            self._pipe.close()
+        if self._file is not self.stream:
+            self._file.close()
+
+    def _drain(self) -> None:
+        for line in self._pipe:
+            self._write(line)
+            self._echo(line)
+
+    def _write(self, text: str) -> None:
+        with self._lock:
+            self._file.write(text)
+            self._file.flush()
+
+    def _echo(self, text: str) -> None:
+        """Print a line from the server, stripped of anything that could spoof
+        the terminal."""
+        if self._console is None:
+            return
+        clean = strip_control_chars(text).strip()
+        if clean:
+            self._console.print(f"[dim]\\[{escape(self.server_name)}] {escape(clean)}[/dim]")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for the test suite."""
+
+import pytest
+
+from mcp_client_for_ollama.utils import server_logs
+
+
+@pytest.fixture(autouse=True)
+def isolate_server_logs(tmp_path_factory, monkeypatch):
+    """Keep server log files out of the user's real ~/.config/ollmcp/logs.
+
+    Any test that opens a connection builds a ServerLogSink, which creates its
+    session directory and prunes the older ones. Without this, running the
+    suite writes into the user's log directory and deletes the logs of their
+    past ollmcp sessions.
+    """
+    monkeypatch.setattr(server_logs, "SERVER_LOG_DIR", str(tmp_path_factory.mktemp("logs")))

--- a/tests/test_server_logs.py
+++ b/tests/test_server_logs.py
@@ -1,0 +1,255 @@
+"""Test the log files MCP servers write to, and what of it reaches the screen."""
+
+import asyncio
+import io
+import os
+import sys
+from contextlib import AsyncExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.types import LoggingCapability, ServerCapabilities
+from rich.console import Console
+
+from mcp_client_for_ollama.server import connector as connector_mod
+from mcp_client_for_ollama.server.connector import ServerConnector
+from mcp_client_for_ollama.utils import server_logs
+from mcp_client_for_ollama.utils.server_logs import ServerLogSink, server_log_path
+
+
+@pytest.fixture
+def log_dir(tmp_path, monkeypatch):
+    """Keep log files out of the real ~/.config/ollmcp/logs."""
+    monkeypatch.setattr(server_logs, "SERVER_LOG_DIR", str(tmp_path))
+    return tmp_path / server_logs._SESSION_DIR_NAME
+
+
+def test_sink_writes_to_its_own_file(log_dir):
+    sink = ServerLogSink("weather")
+
+    assert sink.stream is not sys.stderr
+    sink.stream.write("starting up\n")
+    sink.close()
+
+    assert (log_dir / "weather.log").read_text() == "starting up\n"
+
+
+def test_sink_stays_silent_without_a_console(log_dir, capsys):
+    sink = ServerLogSink("weather")
+    sink.stream.write("noisy line\n")
+    sink.close()
+
+    captured = capsys.readouterr()
+    assert "noisy line" not in captured.out
+    assert "noisy line" not in captured.err
+
+
+def test_sink_echoes_to_the_console_when_given_one(log_dir):
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, width=200)
+
+    sink = ServerLogSink("weather", console=console, echo_stderr=True)
+    sink.stream.write("extension connection ready\n")
+    sink.close()
+
+    assert "[weather] extension connection ready" in output.getvalue()
+    assert (log_dir / "weather.log").read_text() == "extension connection ready\n"
+
+
+def test_sink_sanitizes_echoed_lines(log_dir):
+    """Server output is untrusted: it must not be able to emit raw escapes."""
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, width=200)
+
+    sink = ServerLogSink("weather", console=console, echo_stderr=True)
+    sink.stream.write("safe\x1b[2Jcleared\n")
+    sink.close()
+
+    echoed = output.getvalue()
+    # The ESC is gone, so what is left is inert text rather than a screen clear
+    assert "\x1b" not in echoed
+    assert "[2J" in echoed
+    # The log file keeps the raw bytes; only the terminal echo is sanitized
+    assert "\x1b[2J" in (log_dir / "weather.log").read_text()
+
+
+def test_each_session_gets_its_own_directory(log_dir):
+    """Several ollmcp windows must not write over each other's files."""
+    ServerLogSink("weather").close()
+
+    assert log_dir.name.endswith(f"-{os.getpid()}")
+    assert (log_dir / "weather.log").exists()
+
+
+def test_reconnecting_keeps_what_the_server_already_logged(log_dir):
+    first = ServerLogSink("weather")
+    first.stream.write("before the reload\n")
+    first.close()
+
+    second = ServerLogSink("weather")
+    second.stream.write("after the reload\n")
+    second.close()
+
+    assert (log_dir / "weather.log").read_text() == "before the reload\nafter the reload\n"
+
+
+def test_prune_keeps_the_newest_sessions(tmp_path, monkeypatch):
+    monkeypatch.setattr(server_logs, "SERVER_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(server_logs, "_is_running", lambda pid: False)
+    for name in ["20260101-100000-11", "20260102-100000-22", "20260103-100000-33", "not-a-session"]:
+        (tmp_path / name).mkdir()
+
+    server_logs.prune_old_sessions(keep=2)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "20260102-100000-22", "20260103-100000-33", "not-a-session",
+    ]
+
+
+def test_prune_leaves_running_sessions_alone(tmp_path, monkeypatch):
+    """With more windows open than we keep, the oldest is still a live session."""
+    monkeypatch.setattr(server_logs, "SERVER_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(server_logs, "_is_running", lambda pid: pid == 11)
+    for name in ["20260101-100000-11", "20260102-100000-22", "20260103-100000-33"]:
+        (tmp_path / name).mkdir()
+
+    server_logs.prune_old_sessions(keep=1)
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "20260101-100000-11", "20260103-100000-33",
+    ]
+
+
+def test_sink_degrades_when_the_log_file_cannot_be_opened(tmp_path, monkeypatch):
+    """A log file we cannot write is not a reason to refuse the connection."""
+    blocker = tmp_path / "logs"
+    blocker.write_text("not a directory")
+    monkeypatch.setattr(server_logs, "SERVER_LOG_DIR", str(blocker))
+    output = io.StringIO()
+
+    sink = ServerLogSink("weather", console=Console(file=output, width=200))
+    sink.log("still running")
+    sink.close()
+
+    assert sink.path is None
+    assert "could not open the log file for weather" in output.getvalue()
+
+
+def test_server_log_path_makes_the_name_filename_safe(log_dir):
+    assert server_log_path("../../etc/passwd") == str(log_dir / "etc_passwd.log")
+    assert server_log_path("my server") == str(log_dir / "my_server.log")
+    assert server_log_path("...") == str(log_dir / "server.log")
+
+
+def test_connector_passes_a_log_file_as_errlog(log_dir, monkeypatch):
+    """The stdio transport must never be handed the client's own stderr."""
+    captured = {}
+
+    def fake_stdio_client(server_params, errlog=sys.stderr):
+        captured["errlog"] = errlog
+        raise RuntimeError("stop here, the transport is not what is under test")
+
+    monkeypatch.setattr(connector_mod, "stdio_client", fake_stdio_client)
+
+    async def run():
+        async with AsyncExitStack() as stack:
+            connector = ServerConnector(stack, console=Console(file=io.StringIO()))
+            return await connector._connect_to_server(
+                {"name": "weather", "type": "config", "config": {"command": sys.executable, "args": ["-c", "pass"]}}
+            )
+
+    assert asyncio.run(run()) is False
+    assert captured["errlog"] is not sys.stderr
+    assert captured["errlog"].name == str(log_dir / "weather.log")
+
+
+def make_notification(level, data, logger=None):
+    return SimpleNamespace(level=level, logger=logger, data=data)
+
+
+def test_log_notifications_are_recorded_and_shown_from_the_wanted_level(log_dir):
+    output = io.StringIO()
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=output, width=200), log_level="warning")
+    sink = ServerLogSink("weather", console=connector.console)
+    handle = connector._make_logging_callback(sink)
+
+    asyncio.run(handle(make_notification("error", "upstream API is down")))
+    asyncio.run(handle(make_notification("debug", "cache hit", logger="fetch")))
+    sink.close()
+
+    echoed = output.getvalue()
+    assert "upstream API is down" in echoed
+    assert "cache hit" not in echoed
+    # Both are kept on disk regardless of what made it to the screen
+    assert (log_dir / "weather.log").read_text() == (
+        "error: upstream API is down\ndebug fetch: cache hit\n"
+    )
+
+
+def test_log_notifications_stay_off_screen_without_a_level(log_dir):
+    output = io.StringIO()
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=output, width=200))
+    sink = ServerLogSink("weather", console=connector.console)
+
+    asyncio.run(connector._make_logging_callback(sink)(make_notification("emergency", "everything is on fire")))
+    sink.close()
+
+    assert output.getvalue() == ""
+    assert "everything is on fire" in (log_dir / "weather.log").read_text()
+
+
+def test_log_notifications_keep_their_raw_bytes_on_disk(log_dir):
+    """Same rule as stderr: the file is raw, only the terminal echo is sanitized."""
+    output = io.StringIO()
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=output, width=200), log_level="debug")
+    sink = ServerLogSink("weather", console=connector.console)
+
+    asyncio.run(connector._make_logging_callback(sink)(make_notification("error", "safe\x1b[2Jcleared")))
+    sink.close()
+
+    assert "\x1b" not in output.getvalue()
+    assert "\x1b[2J" in (log_dir / "weather.log").read_text()
+
+
+def test_debug_shows_every_level(log_dir):
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=io.StringIO()), debug=True)
+
+    assert connector.log_level == "debug"
+    assert connector._shows_level("debug") is True
+    # A level outside the spec is shown rather than swallowed
+    assert connector._shows_level("chatty") is True
+
+
+def test_an_explicit_log_level_wins_over_debug(log_dir):
+    """--debug --log-level error means stderr in full, notifications only from error."""
+    connector = ServerConnector(
+        AsyncExitStack(), console=Console(file=io.StringIO()), debug=True, log_level="error"
+    )
+
+    assert connector.log_level == "error"
+    assert connector._shows_level("warning") is False
+    assert connector._shows_level("error") is True
+
+
+def test_log_level_is_set_on_servers_that_support_it():
+    session = MagicMock()
+    session.set_logging_level = AsyncMock()
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=io.StringIO()), log_level="warning")
+
+    asyncio.run(connector._apply_log_level(session, "weather", ServerCapabilities(logging=LoggingCapability())))
+    session.set_logging_level.assert_awaited_once_with("warning")
+
+    session.set_logging_level.reset_mock()
+    asyncio.run(connector._apply_log_level(session, "weather", ServerCapabilities()))
+    session.set_logging_level.assert_not_awaited()
+
+
+def test_log_level_is_not_set_when_none_was_asked_for():
+    session = MagicMock()
+    session.set_logging_level = AsyncMock()
+    connector = ServerConnector(AsyncExitStack(), console=Console(file=io.StringIO()))
+
+    asyncio.run(connector._apply_log_level(session, "weather", ServerCapabilities(logging=LoggingCapability())))
+
+    session.set_logging_level.assert_not_awaited()


### PR DESCRIPTION
A stdio server inherits the client's stderr, so anything it writes lands on top of whatever ollmcp is rendering — in the middle of a streaming answer, the tool menu, or a prompt. Redirecting it away fixes the display but hides the message explaining why a server failed to start, which is usually the only useful thing available when the SDK reports "unhandled errors in a TaskGroup".

ServerLogSink gives each server its own file under ~/.config/ollmcp/logs/<timestamp>-<pid>/<server>.log, fed by two channels: the stderr of stdio servers via stdio_client(errlog=...), and the MCP log notifications any server can send via ClientSession(logging_callback=...). The directory is per run, so several ollmcp windows never share files, and only the last KEPT_LOG_SESSIONS runs are kept — a directory whose pid is still alive is never pruned. A failed connection now points at the file holding the server's own explanation.

The files are always written; two flags decide what is also echoed live:

  --debug            the servers' output as it arrives
  --log-level LEVEL  MCP log notifications of LEVEL or higher, which is
                     also requested from the server via set_logging_level

An explicit --log-level wins over --debug, so --debug --log-level error means full stderr but only error notifications. Echoed lines go through strip_control_chars, since they are text from the server; the files stay raw, so a log keeps exactly what the server emitted.

Failing to open a log file degrades to os.devnull instead of aborting the connection, which would report a connection error for a server that was never contacted.

tests/conftest.py redirects SERVER_LOG_DIR for the whole suite: without it any test that opens a connection writes into the user's real log directory and prunes their past sessions.