### PR TITLE
chore(deps): migrate to mcp SDK 2.x

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1196,6 +1196,13 @@ Los servidores MCP Streamable HTTP típicamente exponen el endpoint MCP en `/mcp
 
 Puedes encontrar más detalles en la [especificación MCP versión 2025-06-18 - Transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
 
+> [!NOTE]
+> Los certificados HTTPS de los servidores MCP remotos se validan contra el **almacén de confianza del sistema operativo**, no contra el paquete `certifi`. Si un servidor MCP está detrás de una CA privada o corporativa, o ejecutas ollmcp en un contenedor mínimo sin almacén de CA del sistema, el handshake TLS falla con un error que no menciona a ollmcp. Apunta `SSL_CERT_FILE` (un archivo de bundle) o `SSL_CERT_DIR` (un directorio) a tu CA para solucionarlo:
+>
+> ```bash
+> export SSL_CERT_FILE=/ruta/a/ca-corporativa.pem
+> ```
+
 ## Modelos compatibles
 
 Los siguientes modelos de Ollama funcionan bien con el uso de herramientas:

--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,13 @@ Streamable HTTP MCP servers typically expose the MCP endpoint at `/mcp` (e.g., `
 
 You can find more details in the [MCP specification version 2025-06-18 - Transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports).
 
+> [!NOTE]
+> HTTPS certificates for remote MCP servers are verified against your **operating system trust store**, not the `certifi` bundle. If an MCP server sits behind a private or corporate CA, or you run ollmcp in a minimal container with no system CA store, the TLS handshake fails with an error that does not mention ollmcp. Point `SSL_CERT_FILE` (a bundle file) or `SSL_CERT_DIR` (a directory) at your CA to fix it:
+>
+> ```bash
+> export SSL_CERT_FILE=/path/to/corporate-ca.pem
+> ```
+
 ## Compatible Models
 
 The following Ollama models work well with tool use:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1196,6 +1196,13 @@ Streamable HTTP MCP 服务器通常在 `/mcp` 暴露 MCP 端点（例如 `https:
 
 更多详情见 [MCP 规范 2025-06-18 版 - Transports](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports)。
 
+> [!NOTE]
+> 远程 MCP 服务器的 HTTPS 证书是根据**操作系统信任库**验证的，而不是 `certifi` 证书包。如果 MCP 服务器位于私有或企业 CA 之后，或者你在没有系统 CA 库的精简容器中运行 ollmcp，TLS 握手会失败，且错误信息不会提及 ollmcp。将 `SSL_CERT_FILE`（证书包文件）或 `SSL_CERT_DIR`（目录）指向你的 CA 即可解决:
+>
+> ```bash
+> export SSL_CERT_FILE=/path/to/corporate-ca.pem
+> ```
+
 ## 兼容的模型
 
 以下 Ollama 模型在工具使用方面表现良好:

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -548,7 +548,7 @@ class MCPClient:
             "function": {
                 "name": tool.name,
                 "description": tool.description,
-                "parameters": tool.inputSchema
+                "parameters": tool.input_schema
             }
         } for tool in enabled_tool_objects]
 
@@ -701,14 +701,14 @@ class MCPClient:
                 for content_item in result.content:
                     if hasattr(content_item, 'type') and content_item.type == "image":
                         base64_data = getattr(content_item, 'data', '')
-                        mime_type = getattr(content_item, 'mimeType', 'unknown')
+                        mime_type = getattr(content_item, 'mime_type', 'unknown')
                         tool_images.append(base64_data)
                         if has_vision:
                             text_parts.append(f"[Image: {mime_type}, {len(base64_data)} bytes]")
                         else:
                             text_parts.append(f"[Image returned but not processed: {mime_type} - current model does not support vision]")
                     elif hasattr(content_item, 'type') and content_item.type == "audio":
-                        mime_type = getattr(content_item, 'mimeType', 'unknown')
+                        mime_type = getattr(content_item, 'mime_type', 'unknown')
                         data = getattr(content_item, 'data', '')
                         text_parts.append(f"[Audio returned but not processed: {mime_type}, {len(data)} bytes - Ollama does not support audio input]")
                     elif hasattr(content_item, 'type') and content_item.type == "resource" and hasattr(content_item, 'resource'):
@@ -716,14 +716,14 @@ class MCPClient:
                         #       content_item.resource and forward to LLM once resource support is implemented.
                         resource = content_item.resource
                         uri = getattr(resource, 'uri', 'unknown')
-                        mime_type = getattr(resource, 'mimeType', 'unknown')
+                        mime_type = getattr(resource, 'mime_type', 'unknown')
                         text_parts.append(f"[Resource returned but not processed: {uri} ({mime_type}) - resource support not yet implemented]")
                     elif hasattr(content_item, 'type') and content_item.type == "resource_link":
                         # TODO: Handle MCP resource links (type="resource_link") — fetch content via
                         #       resources/read using the URI once resource support is implemented.
                         uri = getattr(content_item, 'uri', 'unknown')
                         name = getattr(content_item, 'name', '')
-                        mime_type = getattr(content_item, 'mimeType', 'unknown')
+                        mime_type = getattr(content_item, 'mime_type', 'unknown')
                         label = f" ({name})" if name else ""
                         text_parts.append(f"[Resource link returned but not fetched: {uri}{label} ({mime_type}) - resource support not yet implemented]")
                     elif hasattr(content_item, 'text'):

--- a/mcp_client_for_ollama/resources/handler.py
+++ b/mcp_client_for_ollama/resources/handler.py
@@ -65,16 +65,16 @@ class ResourceHandler:
             for resource in resources:
                 uri = str(resource.uri)
                 name = resource.name
-                mime_type = getattr(resource, 'mimeType', '') or ''
+                mime_type = getattr(resource, 'mime_type', '') or ''
                 description = getattr(resource, 'description', '') or ''
                 is_binary = self._is_binary_type(mime_type)
                 type_display = f"{mime_type} [red][binary][/red]" if is_binary and mime_type else mime_type
                 table.add_row(uri, name, type_display, description)
 
             for template in templates:
-                uri_template = template.uriTemplate
+                uri_template = template.uri_template
                 name = template.name
-                mime_type = getattr(template, 'mimeType', '') or ''
+                mime_type = getattr(template, 'mime_type', '') or ''
                 description = getattr(template, 'description', '') or ''
                 table.add_row(
                     uri_template,
@@ -174,7 +174,7 @@ class ResourceHandler:
             images: List[str] = []
 
             for content in read_result.contents:
-                mime_type = getattr(content, 'mimeType', None) or ''
+                mime_type = getattr(content, 'mime_type', None) or ''
 
                 if hasattr(content, 'blob') and content.blob:
                     if mime_type.startswith(_IMAGE_MIME_PREFIXES):

--- a/mcp_client_for_ollama/resources/manager.py
+++ b/mcp_client_for_ollama/resources/manager.py
@@ -37,7 +37,7 @@ class ResourceManager:
                     'name': resource.name,
                     'server': server_name,
                     'description': getattr(resource, 'description', None),
-                    'mimeType': getattr(resource, 'mimeType', None),
+                    'mimeType': getattr(resource, 'mime_type', None),
                 })
         return resources
 
@@ -47,11 +47,11 @@ class ResourceManager:
         for server_name, server_templates in self.templates_by_server.items():
             for template in server_templates:
                 templates.append({
-                    'uriTemplate': template.uriTemplate,
+                    'uriTemplate': template.uri_template,
                     'name': template.name,
                     'server': server_name,
                     'description': getattr(template, 'description', None),
-                    'mimeType': getattr(template, 'mimeType', None),
+                    'mimeType': getattr(template, 'mime_type', None),
                 })
         return templates
 
@@ -68,5 +68,5 @@ class ResourceManager:
                 uris.add(str(resource.uri))
         for templates in self.templates_by_server.values():
             for template in templates:
-                uris.add(template.uriTemplate)
+                uris.add(template.uri_template)
         return uris

--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -7,14 +7,16 @@ initialization, and communication.
 import asyncio
 import os
 import shutil
+import warnings
 from contextlib import AsyncExitStack
 from typing import Dict, List, Any, Optional, Tuple
 from rich.console import Console
 from rich.panel import Panel
-from mcp import ClientSession, Tool
+import httpx2
+from mcp import ClientSession, MCPDeprecationWarning, Tool
 from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 from .discovery import process_server_paths, process_server_urls, parse_server_configs, parse_server_config_mapping, load_claude_desktop_servers, deduplicate_servers
 from ..utils.constants import MCP_LOG_LEVELS, MCP_PROTOCOL_VERSION
@@ -46,7 +48,6 @@ class ServerConnector:
         self.sessions = {}  # Dict to store multiple sessions
         self.available_tools = []  # List to store all available tools
         self.enabled_tools = {}  # Dict to store tool enabled status
-        self.session_ids = {}  # Dict to store session IDs for HTTP connections
         self.prompts_by_server = {}  # Dict to store prompts grouped by server
         self.resources_by_server = {}  # Dict to store resources grouped by server
         self.templates_by_server = {}  # Dict to store resource templates grouped by server
@@ -204,18 +205,23 @@ class ServerConnector:
 
                     headers = self._get_headers_from_server(server)
 
-                    # Use the streamablehttp_client for Streamable HTTP connections
-                    transport = await local_stack.enter_async_context(
-                        streamablehttp_client(url, headers=headers)
+                    # streamable_http_client takes no transport-level options: headers,
+                    # timeouts and redirects are configured on the httpx2 client instead.
+                    # The values mirror the ones the SDK applies to a client of its own.
+                    http_client = await local_stack.enter_async_context(
+                        httpx2.AsyncClient(
+                            headers=headers,
+                            timeout=httpx2.Timeout(30, read=300),
+                            follow_redirects=True,
+                        )
                     )
-                    read_stream, write_stream, session_info = transport
+                    transport = await local_stack.enter_async_context(
+                        streamable_http_client(url, http_client=http_client)
+                    )
+                    read_stream, write_stream = transport
                     session = await local_stack.enter_async_context(
                         ClientSession(read_stream, write_stream, logging_callback=logging_callback)
                     )
-
-                    # Store session ID if provided
-                    if hasattr(session_info, 'session_id') and session_info.session_id:
-                        self.session_ids[server_name] = session_info.session_id
 
                 else:
                     # Connect to a STDIO server, given either as a script path
@@ -265,8 +271,8 @@ class ServerConnector:
                         tool_copy = Tool(
                             name=qualified_name,
                             description=f"[{server_name}] {tool.description}" if hasattr(tool, 'description') else f"Tool from {server_name}",
-                            inputSchema=tool.inputSchema,
-                            outputSchema=tool.outputSchema if hasattr(tool, 'outputSchema') else None
+                            input_schema=tool.input_schema,
+                            output_schema=tool.output_schema
                         )
                         server_tools.append(tool_copy)
                         self.enabled_tools[qualified_name] = True
@@ -310,7 +316,7 @@ class ServerConnector:
                     self.console.print(f"[yellow]Warning: Failed to list resources from {server_name}: {str(e)}[/yellow]")
                 try:
                     templates_response = await session.list_resource_templates()
-                    server_templates = templates_response.resourceTemplates if hasattr(templates_response, 'resourceTemplates') else []
+                    server_templates = templates_response.resource_templates
                     if server_templates:
                         self.templates_by_server[server_name] = server_templates
                 except asyncio.CancelledError:
@@ -361,21 +367,35 @@ class ServerConnector:
             return False
         except Exception as e:
             self._discard_server_state(server_name)
-            sub_exceptions = getattr(e, 'exceptions', None)
-            if sub_exceptions:
-                for sub in sub_exceptions:
-                    self.console.print(f"[red]Error connecting to {server_name}: {str(sub)}[/red]")
-            else:
-                self.console.print(f"[red]Error connecting to {server_name}: {str(e)}[/red]")
+            for message in self._leaf_error_messages(e):
+                self.console.print(f"[red]Error connecting to {server_name}: {message}[/red]")
             self._print_server_log_hint(log_path)
             return False
+
+    def _leaf_error_messages(self, exc: BaseException) -> list[str]:
+        """The messages of the real failures inside an exception.
+
+        A transport error surfaces wrapped in one ExceptionGroup per nested
+        TaskGroup, and only the leaves name a cause: unwrapping a single level
+        can still leave nothing but "unhandled errors in a TaskGroup".
+        """
+        sub_exceptions = getattr(exc, 'exceptions', None)
+        if not sub_exceptions:
+            return [str(exc) or type(exc).__name__]
+        return [message for sub in sub_exceptions for message in self._leaf_error_messages(sub)]
 
     async def _apply_log_level(self, session, server_name: str, capabilities) -> None:
         """Ask a server to only send log notifications from the wanted level up."""
         if not self.log_level or not (capabilities and getattr(capabilities, 'logging', None)):
             return
         try:
-            await session.set_logging_level(self.log_level)
+            # SEP-2577 deprecated the logging capability, so the SDK warns on every call.
+            # It stays the only way to set a level on a 2025-era server, which is the era
+            # ClientSession negotiates, and MCPDeprecationWarning subclasses UserWarning:
+            # left alone it prints to stderr over whatever is being rendered.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", MCPDeprecationWarning)
+                await session.set_logging_level(self.log_level)
         except Exception as e:
             self.console.print(f"[yellow]Warning: Failed to set log level on {server_name}: {str(e)}[/yellow]")
 
@@ -611,7 +631,6 @@ class ServerConnector:
         """
         prefix = f"{server_name}."
         self.sessions.pop(server_name, None)
-        self.session_ids.pop(server_name, None)
         self.prompts_by_server.pop(server_name, None)
         self.resources_by_server.pop(server_name, None)
         self.templates_by_server.pop(server_name, None)
@@ -631,5 +650,4 @@ class ServerConnector:
         self.sessions.clear()
         self.available_tools.clear()
         self.enabled_tools.clear()
-        self.session_ids.clear()
         self.prompts_by_server.clear()

--- a/mcp_client_for_ollama/tools/manager.py
+++ b/mcp_client_for_ollama/tools/manager.py
@@ -534,7 +534,7 @@ class ToolManager:
 
             # Schema content with JSON syntax highlighting
             try:
-                schema_json = json.dumps(tool.inputSchema, indent=2)
+                schema_json = json.dumps(tool.input_schema, indent=2)
                 syntax = Syntax(schema_json, "json", theme="monokai", line_numbers=False)
                 schema_panel = Panel(
                     syntax,
@@ -544,7 +544,7 @@ class ToolManager:
                 self.console.print(schema_panel)
             except Exception as e:
                 error_panel = Panel(
-                    f"[red]Error: {str(e)}[/red]\n[yellow]Raw: {tool.inputSchema}[/yellow]",
+                    f"[red]Error: {str(e)}[/red]\n[yellow]Raw: {tool.input_schema}[/yellow]",
                     title="Schema Error",
                     border_style="red"
                 )

--- a/mcp_client_for_ollama/utils/constants.py
+++ b/mcp_client_for_ollama/utils/constants.py
@@ -1,7 +1,7 @@
 """Constants used throughout the MCP Client for Ollama application."""
 
 import os
-from mcp.types import LATEST_PROTOCOL_VERSION
+from mcp.types.version import LATEST_HANDSHAKE_VERSION
 
 # Default Claude config file location
 DEFAULT_CLAUDE_CONFIG = os.path.expanduser("~/Library/Application Support/Claude/claude_desktop_config.json")
@@ -60,10 +60,13 @@ MAX_COMPLETION_MENU_ROWS = 7
 # URL for checking package updates on PyPI
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/mcp-client-for-ollama/json"
 
-# MCP Protocol Version - Using SDK's latest supported version (currently "2025-11-25")
+# MCP Protocol Version - the revision the initialize handshake offers (currently "2025-11-25").
 # The SDK handles backward compatibility with servers on older protocol versions:
 # Supported versions: ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]
-MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION
+# Deliberately not LATEST_PROTOCOL_VERSION: since SDK v2 that name means the newest revision
+# the SDK speaks in any era ("2026-07-28"), which initialize cannot negotiate. Advertising it
+# in the header would claim a revision the connection never agreed on.
+MCP_PROTOCOL_VERSION = LATEST_HANDSHAKE_VERSION
 
 # Startup ASCII banner shown when launching ollmcp
 OLLMCP_ASCII_ART = r"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 ]
 dependencies = [
     "any-llm-sdk[ollama,openai,atlascloud] ~=1.26.0",
-    "mcp>=1.25,<2",
+    "httpx>=0.27,<1",
+    "mcp~=2.1.1",
     "prompt-toolkit~=3.0.53",
     "rich>=14.2.0,<14.3",
     "typer~=0.27.0",

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -10,6 +10,36 @@ from mcp_client_for_ollama.utils.constants import MCP_PROTOCOL_VERSION
 from contextlib import AsyncExitStack
 
 
+def test_protocol_version_header_is_the_negotiable_revision():
+    """The advertised revision must be one the initialize handshake can negotiate.
+
+    Every other header test compares against MCP_PROTOCOL_VERSION itself, so none of
+    them notices when the constant changes value. SDK v2 redefined
+    LATEST_PROTOCOL_VERSION to mean the newest revision the SDK speaks in any era
+    ("2026-07-28"), which initialize never negotiates -- sourcing the header from it
+    would silently advertise a revision the connection did not agree on.
+    """
+    assert MCP_PROTOCOL_VERSION == "2025-11-25"
+
+
+def test_leaf_error_messages_unwraps_nested_groups():
+    """A transport failure must name its cause, however deeply it is wrapped.
+
+    mcp 2.x runs the streamable-HTTP transport inside nested TaskGroups, so a
+    server answering with a plain web page arrives as an ExceptionGroup holding
+    another ExceptionGroup. Unwrapping one level printed only "unhandled errors
+    in a TaskGroup", which says nothing about what went wrong.
+    """
+    connector = ServerConnector(AsyncExitStack())
+    cause = RuntimeError("Unexpected content type: text/html")
+    nested = ExceptionGroup("outer", [ExceptionGroup("inner", [cause])])
+
+    assert connector._leaf_error_messages(nested) == ["Unexpected content type: text/html"]
+    assert connector._leaf_error_messages(cause) == ["Unexpected content type: text/html"]
+    # An exception carrying no message still has to identify itself.
+    assert connector._leaf_error_messages(ConnectionResetError()) == ["ConnectionResetError"]
+
+
 def test_get_headers_from_server_sse():
     """Test that headers are correctly extracted and formatted for SSE servers."""
     connector = ServerConnector(AsyncExitStack())
@@ -329,7 +359,7 @@ class TestCapabilityHandling(unittest.IsolatedAsyncioTestCase):
             mock_tool = MagicMock()
             mock_tool.name = "test_tool"
             mock_tool.description = "A test tool"
-            mock_tool.inputSchema = {}
+            mock_tool.input_schema = {}
             mock_tools_response = MagicMock()
             mock_tools_response.tools = [mock_tool]
             mock_session.list_tools.return_value = mock_tools_response
@@ -446,8 +476,8 @@ class TestPostInitCancellation(unittest.IsolatedAsyncioTestCase):
         mock_tool = MagicMock()
         mock_tool.name = "spawn_actor"
         mock_tool.description = "Spawn an actor"
-        mock_tool.inputSchema = {}
-        mock_tool.outputSchema = None
+        mock_tool.input_schema = {}
+        mock_tool.output_schema = None
         mock_tools_response = MagicMock()
         mock_tools_response.tools = [mock_tool]
         mock_session.list_tools.return_value = mock_tools_response

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -29,7 +29,7 @@ class TestResourceManager(unittest.TestCase):
         mock_resource.uri = "file:///test.txt"
         mock_resource.name = "test.txt"
         mock_resource.description = "Test file"
-        mock_resource.mimeType = "text/plain"
+        mock_resource.mime_type = "text/plain"
 
         self.manager.set_resources({"test-server": [mock_resource]})
 
@@ -38,10 +38,10 @@ class TestResourceManager(unittest.TestCase):
 
     def test_set_templates(self):
         mock_template = MagicMock()
-        mock_template.uriTemplate = "file:///{path}"
+        mock_template.uri_template = "file:///{path}"
         mock_template.name = "Project Files"
         mock_template.description = "Access project files"
-        mock_template.mimeType = None
+        mock_template.mime_type = None
 
         self.manager.set_templates({"test-server": [mock_template]})
 
@@ -73,7 +73,7 @@ class TestResourceManager(unittest.TestCase):
             r.uri = f"file:///test{i}.txt"
             r.name = f"test{i}.txt"
             r.description = f"Test file {i}"
-            r.mimeType = "text/plain"
+            r.mime_type = "text/plain"
             self.manager.set_resources({srv: [r]} if i == 1 else {**self.manager.resources_by_server, srv: [r]})
 
         resources = self.manager.list_all()
@@ -84,7 +84,7 @@ class TestResourceManager(unittest.TestCase):
         mock_resource.uri = "file:///test.txt"
         mock_resource.name = "test.txt"
         mock_resource.description = "Test file"
-        mock_resource.mimeType = "text/plain"
+        mock_resource.mime_type = "text/plain"
 
         self.manager.set_resources({"test-server": [mock_resource]})
 
@@ -99,7 +99,7 @@ class TestResourceManager(unittest.TestCase):
         mock_resource.name = "test.txt"
 
         mock_template = MagicMock()
-        mock_template.uriTemplate = "file:///{path}"
+        mock_template.uri_template = "file:///{path}"
         mock_template.name = "Project Files"
 
         self.manager.set_resources({"server1": [mock_resource]})
@@ -130,12 +130,12 @@ class TestResourceManagerMultiContent(unittest.IsolatedAsyncioTestCase):
         handler = ResourceHandler(console, manager, MagicMock())
 
         # Build a read_result with two text content blocks
-        block1 = MagicMock(spec=['text', 'mimeType'])
+        block1 = MagicMock(spec=['text', 'mime_type'])
         block1.text = "Hello"
-        block1.mimeType = 'text/plain'
-        block2 = MagicMock(spec=['text', 'mimeType'])
+        block1.mime_type = 'text/plain'
+        block2 = MagicMock(spec=['text', 'mime_type'])
         block2.text = "World"
-        block2.mimeType = 'text/plain'
+        block2.mime_type = 'text/plain'
 
         mock_read_result = MagicMock()
         mock_read_result.contents = [block1, block2]
@@ -164,9 +164,9 @@ class TestResourceManagerMultiContent(unittest.IsolatedAsyncioTestCase):
 
         handler = ResourceHandler(console, manager, MagicMock())
 
-        blob_block = MagicMock(spec=['blob', 'mimeType'])
+        blob_block = MagicMock(spec=['blob', 'mime_type'])
         blob_block.blob = b"%PDF-binary-data"
-        blob_block.mimeType = 'application/pdf'  # non-image binary
+        blob_block.mime_type = 'application/pdf'  # non-image binary
 
         mock_read_result = MagicMock()
         mock_read_result.contents = [blob_block]
@@ -194,9 +194,9 @@ class TestResourceManagerMultiContent(unittest.IsolatedAsyncioTestCase):
         handler = ResourceHandler(console, manager, MagicMock())
 
         raw_bytes = b"\x89PNG\r\nfakedata"
-        blob_block = MagicMock(spec=['blob', 'mimeType'])
+        blob_block = MagicMock(spec=['blob', 'mime_type'])
         blob_block.blob = raw_bytes
-        blob_block.mimeType = 'image/png'
+        blob_block.mime_type = 'image/png'
 
         mock_read_result = MagicMock()
         mock_read_result.contents = [blob_block]
@@ -228,9 +228,9 @@ class TestResourceManagerMultiContent(unittest.IsolatedAsyncioTestCase):
         handler = ResourceHandler(console, manager, MagicMock())
 
         b64_string = base64.b64encode(b"fakepng").decode('ascii')
-        blob_block = MagicMock(spec=['blob', 'mimeType'])
+        blob_block = MagicMock(spec=['blob', 'mime_type'])
         blob_block.blob = b64_string  # already a string
-        blob_block.mimeType = 'image/png'
+        blob_block.mime_type = 'image/png'
 
         mock_read_result = MagicMock()
         mock_read_result.contents = [blob_block]
@@ -270,14 +270,14 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
             mock_resource.name = "test.txt"
 
             mock_template = MagicMock()
-            mock_template.uriTemplate = "file:///{path}"
+            mock_template.uri_template = "file:///{path}"
             mock_template.name = "Project Files"
 
             mock_resources_response = MagicMock()
             mock_resources_response.resources = [mock_resource]
 
             mock_templates_response = MagicMock()
-            mock_templates_response.resourceTemplates = [mock_template]
+            mock_templates_response.resource_templates = [mock_template]
 
             mock_session.initialize.return_value = mock_init_result
             mock_session.list_resources.return_value = mock_resources_response
@@ -296,7 +296,7 @@ class TestResourceCapability(unittest.IsolatedAsyncioTestCase):
                 assert "test-server" in connector.resources_by_server
                 assert connector.resources_by_server["test-server"][0].uri == "file:///test.txt"
                 assert "test-server" in connector.templates_by_server
-                assert connector.templates_by_server["test-server"][0].uriTemplate == "file:///{path}"
+                assert connector.templates_by_server["test-server"][0].uri_template == "file:///{path}"
                 mock_session.list_resources.assert_called_once()
                 mock_session.list_resource_templates.assert_called_once()
 

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,8 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 
 [[package]]
@@ -315,6 +316,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -330,12 +344,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -483,15 +514,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -501,9 +532,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
 [[package]]
@@ -512,6 +543,7 @@ version = "0.33.3"
 source = { editable = "." }
 dependencies = [
     { name = "any-llm-sdk", extra = ["ollama"] },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "prompt-toolkit" },
     { name = "rich" },
@@ -526,7 +558,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "any-llm-sdk", extras = ["ollama", "openai", "atlascloud"], specifier = "~=1.26.0" },
-    { name = "mcp", specifier = ">=1.25,<2" },
+    { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "mcp", specifier = "~=2.1.1" },
     { name = "prompt-toolkit", specifier = "~=3.0.53" },
     { name = "rich", specifier = ">=14.2.0,<14.3" },
     { name = "typer", specifier = "~=0.27.0" },
@@ -534,6 +567,19 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = "~=9.1.0" }]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
 
 [[package]]
 name = "mdurl"
@@ -586,6 +632,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/eb/cb4a855a27c6cf04af2d47c896b6549040a86bb75e6a59cb687a8bcf19aa/openresponses_types-2.4.0.tar.gz", hash = "sha256:cd55e7fa17230d8edd46e254ef34666ca6f250b7efa3712a110aac546c7dc8d5", size = 22101, upload-time = "2026-08-05T12:22:46.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/ef/2605d7219b0fa648e66ab15043bae492f4e8d3c4de4fdad85fc5eadb95a3/openresponses_types-2.4.0-py3-none-any.whl", hash = "sha256:186406592bc115bf12d9ee88320f8051ab1ade0a8fa8941fd1e44b0be16684f1", size = 15097, upload-time = "2026-08-05T12:22:45.044Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -745,20 +803,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -795,15 +839,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1041,6 +1076,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The 1.x line is maintenance-only now, so pin mcp~=2.1.1. The wire is unchanged: ClientSession still negotiates 2025-11-25, so servers on any handshake revision from 2024-11-05 up keep working.

- streamable_http_client replaces streamablehttp_client; headers, timeouts and redirects move onto an httpx2.AsyncClient, and the transport now yields two streams instead of three. session_ids was only ever written, so it goes with the removed get_session_id callback.
- Protocol types are snake_case in v2. Reading a camelCase attribute now raises, and the hasattr/getattr guards around them would have degraded silently instead: an always-empty template list, a dropped outputSchema, resource images skipped for a missing mime type.
- Source the protocol header from LATEST_HANDSHAKE_VERSION. In v2 LATEST_PROTOCOL_VERSION means the newest revision the SDK speaks in any era ("2026-07-28"), which initialize cannot negotiate, so it would have advertised a revision the connection never agreed on. Covered by a test pinning the literal, since the existing header tests compare against the constant itself and pass either way.
- Unwrap nested ExceptionGroups when a connection fails. v2 runs the transport inside nested TaskGroups, so a URL serving a plain web page reported only "unhandled errors in a TaskGroup" -- in v1 that case hung until the timeout and surfaced through the branch that names it.
- Silence MCPDeprecationWarning around set_logging_level (SEP-2577): it subclasses UserWarning, so it printed to stderr over the Rich render.
- Declare httpx directly. It talks to Ollama, not MCP, its exception hierarchy backs the preflight error panel, and it only reached us as a transitive of mcp, which v2 drops. The <1 mirrors what anthropic and openai already declare; the floor is ollama's, so it is never the binding constraint. httpx2 stays undeclared on purpose: we never use it on our own, only to build a client for mcp's own API.

Document the TLS change in all three READMEs: httpx2 verifies against the OS trust store via truststore rather than the certifi bundle, which breaks HTTPS servers behind a private CA with an error that never mentions ollmcp.