### PR TITLE
fix(server): stop a dropped capability listing from killing the client

### DIFF
--- a/mcp_client_for_ollama/server/connector.py
+++ b/mcp_client_for_ollama/server/connector.py
@@ -22,6 +22,15 @@ from .discovery import process_server_paths, process_server_urls, parse_server_c
 from ..utils.constants import MCP_LOG_LEVELS, MCP_PROTOCOL_VERSION
 from ..utils.server_logs import ServerLogSink
 
+# The request each capability is listed with, named the way it goes over the
+# wire so a server-side log can be matched against the warning.
+CAPABILITY_LISTINGS = {
+    "tools": "tools/list",
+    "prompts": "prompts/list",
+    "resources": "resources/list",
+    "resource_templates": "resources/templates/list",
+}
+
 class ServerConnector:
     """Manages connections to one or more MCP servers.
 
@@ -139,11 +148,39 @@ class ServerConnector:
     async def _connect_to_server(self, server: Dict[str, Any]) -> bool:
         """Connect to a single MCP server
 
+        A server can advertise a capability and then kill the transport when it
+        is actually queried (issue #274). Losing the whole server over that
+        would cost the user the tools that do work, so the attempt is repeated
+        without the listing that dropped the connection.
+
         Args:
             server: Server configuration dictionary
 
         Returns:
             bool: True if connection was successful, False otherwise
+        """
+        skipped: set[str] = set()
+        while True:
+            connected, dropped = await self._attempt_connection(server, skipped)
+            if dropped is None or dropped in skipped:
+                return connected
+            skipped.add(dropped)
+            self.console.print(
+                f"[yellow]Warning: {server['name']} closed the connection on "
+                f"{CAPABILITY_LISTINGS[dropped]}; reconnecting without it[/yellow]"
+            )
+
+    async def _attempt_connection(self, server: Dict[str, Any], skipped: set[str]) -> Tuple[bool, Optional[str]]:
+        """Make one connection attempt to a single MCP server
+
+        Args:
+            server: Server configuration dictionary
+            skipped: Capabilities whose listing killed the transport on an
+                earlier attempt, and must not be queried again
+
+        Returns:
+            Tuple of (connected, dropped), where dropped names the capability
+            whose listing closed the connection, or None
         """
         server_name = server["name"]
         self.console.print(f"[cyan]Connecting to server: {server_name}[/cyan]")
@@ -155,6 +192,7 @@ class ServerConnector:
         # The server's log file, pointed at if the connection fails
         log_path = None
 
+        dropped = None
         try:
             server_type = server.get("type", "script")
             session = None
@@ -162,7 +200,9 @@ class ServerConnector:
             # Use a local exit stack for this connection attempt.  On failure
             # it exits immediately, closing the transport and clearing any
             # cancelled anyio scope so it cannot leak into later operations.
-            # On success, contexts are transferred to self.exit_stack via pop_all().
+            # It owns the connection until the capabilities have been listed;
+            # only a fully answered handshake is transferred to self.exit_stack
+            # via pop_all().
             async with AsyncExitStack() as local_stack:
 
                 # Everything the server reports goes to its own log file: the
@@ -185,7 +225,7 @@ class ServerConnector:
                     url = self._get_url_from_server(server)
                     if not url:
                         self.console.print(f"[red]Error: SSE server {server_name} missing URL[/red]")
-                        return False
+                        return False, None
 
                     headers = self._get_headers_from_server(server)
 
@@ -201,7 +241,7 @@ class ServerConnector:
                     url = self._get_url_from_server(server)
                     if not url:
                         self.console.print(f"[red]Error: HTTP server {server_name} missing URL[/red]")
-                        return False
+                        return False, None
 
                     headers = self._get_headers_from_server(server)
 
@@ -231,7 +271,7 @@ class ServerConnector:
                     else:
                         server_params = self._create_config_params(server)
                     if server_params is None:
-                        return False
+                        return False, None
 
                     stdio_transport = await local_stack.enter_async_context(
                         stdio_client(server_params, errlog=log_sink.stream)
@@ -245,103 +285,34 @@ class ServerConnector:
                 init_result = await session.initialize()
                 initialized = True
 
-                # Success — transfer connection contexts to the main exit_stack.
-                # local_stack is now empty; its __aexit__ becomes a no-op.
-                await self.exit_stack.enter_async_context(local_stack.pop_all())
+                # Capabilities are listed while local_stack still owns the
+                # connection: a server that dies when one of them is queried
+                # (issue #274) would otherwise leave its cancelled anyio scope
+                # in the shared exit stack, from where it cancels the client
+                # itself at the next await, long after this call returned.
+                dropped = await self._list_capabilities(session, server_name, init_result, skipped)
 
-            # Store the session
-            self.sessions[server_name] = {
-                "session": session,
-                "tools": []
-            }
+                if dropped is None:
+                    # Success — transfer connection contexts to the main exit_stack.
+                    # local_stack is now empty; its __aexit__ becomes a no-op.
+                    await self.exit_stack.enter_async_context(local_stack.pop_all())
 
-            capabilities = getattr(init_result, 'capabilities', None)
-            await self._apply_log_level(session, server_name, capabilities)
+            if dropped is not None:
+                # local_stack has just unwound the dead transport. Unwinding it
+                # usually raises on its way out and lands in the handlers below,
+                # but a clean one ends up here.
+                self._discard_server_state(server_name)
+                return False, dropped
 
-            # Get tools from this server if capability is present
-            server_tools = []
-            if capabilities and getattr(capabilities, 'tools', None):
-                try:
-                    response = await session.list_tools()
-                    # Store and merge tools, prepending server name to avoid conflicts
-                    for tool in response.tools:
-                        # Create a qualified name for the tool that includes the server
-                        qualified_name = f"{server_name}.{tool.name}"
-                        # Clone the tool but update the name
-                        tool_copy = Tool(
-                            name=qualified_name,
-                            description=f"[{server_name}] {tool.description}" if hasattr(tool, 'description') else f"Tool from {server_name}",
-                            input_schema=tool.input_schema,
-                            output_schema=tool.output_schema
-                        )
-                        server_tools.append(tool_copy)
-                        self.enabled_tools[qualified_name] = True
-                except asyncio.CancelledError:
-                    self.console.print(f"[yellow]Warning: Listing tools from {server_name} was cancelled; continuing without them[/yellow]")
-                except Exception as e:
-                    self.console.print(f"[yellow]Warning: Failed to list tools from {server_name}: {str(e)}[/yellow]")
-            else:
-                self.console.print(f"[dim]Server {server_name} does not support tools capability[/dim]")
-
-            self.sessions[server_name]["tools"] = server_tools
-            self.available_tools.extend(server_tools)
-
-            # Get prompts from this server if capability is present
-            server_prompts = []
-            if capabilities and getattr(capabilities, 'prompts', None):
-                try:
-                    prompts_response = await session.list_prompts()
-                    server_prompts = prompts_response.prompts if hasattr(prompts_response, 'prompts') else []
-                    if server_prompts:
-                        self.prompts_by_server[server_name] = server_prompts
-                except asyncio.CancelledError:
-                    self.console.print(f"[yellow]Warning: Listing prompts from {server_name} was cancelled; continuing without them[/yellow]")
-                except Exception as e:
-                    self.console.print(f"[yellow]Warning: Failed to list prompts from {server_name}: {str(e)}[/yellow]")
-            else:
-                self.console.print(f"[dim]Server {server_name} does not support prompts capability[/dim]")
-
-            # Get resources (static list + templates) if capability is present
-            server_resources = []
-            server_templates = []
-            if capabilities and getattr(capabilities, 'resources', None):
-                try:
-                    resources_response = await session.list_resources()
-                    server_resources = resources_response.resources if hasattr(resources_response, 'resources') else []
-                    if server_resources:
-                        self.resources_by_server[server_name] = server_resources
-                except asyncio.CancelledError:
-                    self.console.print(f"[yellow]Warning: Listing resources from {server_name} was cancelled; continuing without them[/yellow]")
-                except Exception as e:
-                    self.console.print(f"[yellow]Warning: Failed to list resources from {server_name}: {str(e)}[/yellow]")
-                try:
-                    templates_response = await session.list_resource_templates()
-                    server_templates = templates_response.resource_templates
-                    if server_templates:
-                        self.templates_by_server[server_name] = server_templates
-                except asyncio.CancelledError:
-                    self.console.print(f"[yellow]Warning: Listing resource templates from {server_name} was cancelled; continuing without them[/yellow]")
-                except Exception as e:
-                    self.console.print(f"[yellow]Warning: Failed to list resource templates from {server_name}: {str(e)}[/yellow]")
-                summary_parts = []
-                if server_resources:
-                    summary_parts.append(f"{len(server_resources)} resource(s)")
-                if server_templates:
-                    summary_parts.append(f"{len(server_templates)} template(s)")
-                if summary_parts:
-                    self.console.print(f"[dim]  {server_name}: {', '.join(summary_parts)}[/dim]")
-                else:
-                    self.console.print(f"[dim]  {server_name} has resources capability but returned none[/dim]")
-            else:
-                self.console.print(f"[dim]Server {server_name} does not support resources capability[/dim]")
-
-            prompt_count_msg = f" and {len(server_prompts)} prompt(s)" if server_prompts else ""
-            resource_count_msg = f" and {len(server_resources) + len(server_templates)} resource(s)/template(s)" if (server_resources or server_templates) else ""
-            self.console.print(f"[green]Successfully connected to {server_name} with {len(server_tools)} tool(s){prompt_count_msg}{resource_count_msg}[/green]")
-            return True
+            return True, None
 
         except asyncio.CancelledError:
             self._discard_server_state(server_name)
+            if dropped is not None:
+                # Unwinding the transport that died under a capability listing
+                # is what raised here. `dropped` is the real reason this attempt
+                # ended, and the caller retries without that listing.
+                return False, dropped
             if initialized:
                 self.console.print(
                     f"[red]Error connecting to {server_name}: Connection dropped after a "
@@ -354,23 +325,146 @@ class ServerConnector:
                     f"page or other service.[/red]"
                 )
             self._print_server_log_hint(log_path)
-            return False
+            return False, None
         except FileNotFoundError as e:
             self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: File not found - {str(e)}[/red]")
             self._print_server_log_hint(log_path)
-            return False
+            return False, None
         except PermissionError:
             self._discard_server_state(server_name)
             self.console.print(f"[red]Error connecting to {server_name}: Permission denied[/red]")
             self._print_server_log_hint(log_path)
-            return False
+            return False, None
         except Exception as e:
             self._discard_server_state(server_name)
+            if dropped is not None:
+                return False, dropped  # teardown noise from the dead transport, as above
             for message in self._leaf_error_messages(e):
                 self.console.print(f"[red]Error connecting to {server_name}: {message}[/red]")
             self._print_server_log_hint(log_path)
-            return False
+            return False, None
+
+    async def _list_capabilities(self, session, server_name: str, init_result, skipped: set[str]) -> Optional[str]:
+        """Ask a freshly initialized server for everything it advertises.
+
+        Registers the tools, prompts, resources and templates it reports. A
+        listing that merely fails is a warning: the connection is still good.
+        A listing that gets *cancelled* is the transport dying underneath it,
+        and the caller has to unwind the connection before its cancelled scope
+        reaches the shared exit stack - hence the early return.
+
+        Args:
+            session: The initialized ClientSession
+            server_name: Name the server is registered under
+            init_result: Result of the initialize call, holding the capabilities
+            skipped: Capabilities not to query, because their listing already
+                dropped the connection on an earlier attempt
+
+        Returns:
+            The capability whose listing closed the connection, or None when
+            the server answered everything it advertised.
+        """
+        # Store the session
+        self.sessions[server_name] = {
+            "session": session,
+            "tools": []
+        }
+
+        capabilities = getattr(init_result, 'capabilities', None)
+
+        def advertises(name: str) -> bool:
+            """Whether this capability is worth a request: reported by the
+            server, and not one that already cost us the connection."""
+            return bool(capabilities and getattr(capabilities, name, None)) and name not in skipped
+
+        await self._apply_log_level(session, server_name, capabilities)
+
+        # Get tools from this server if capability is present
+        server_tools = []
+        if advertises("tools"):
+            try:
+                response = await session.list_tools()
+                # Store and merge tools, prepending server name to avoid conflicts
+                for tool in response.tools:
+                    # Create a qualified name for the tool that includes the server
+                    qualified_name = f"{server_name}.{tool.name}"
+                    # Clone the tool but update the name
+                    tool_copy = Tool(
+                        name=qualified_name,
+                        description=f"[{server_name}] {tool.description}" if hasattr(tool, 'description') else f"Tool from {server_name}",
+                        input_schema=tool.input_schema,
+                        output_schema=tool.output_schema
+                    )
+                    server_tools.append(tool_copy)
+                    self.enabled_tools[qualified_name] = True
+            except asyncio.CancelledError:
+                return "tools"
+            except Exception as e:
+                self.console.print(f"[yellow]Warning: Failed to list tools from {server_name}: {str(e)}[/yellow]")
+        elif "tools" not in skipped:
+            self.console.print(f"[dim]Server {server_name} does not support tools capability[/dim]")
+
+        self.sessions[server_name]["tools"] = server_tools
+        self.available_tools.extend(server_tools)
+
+        # Get prompts from this server if capability is present
+        server_prompts = []
+        if advertises("prompts"):
+            try:
+                prompts_response = await session.list_prompts()
+                server_prompts = prompts_response.prompts if hasattr(prompts_response, 'prompts') else []
+                if server_prompts:
+                    self.prompts_by_server[server_name] = server_prompts
+            except asyncio.CancelledError:
+                return "prompts"
+            except Exception as e:
+                self.console.print(f"[yellow]Warning: Failed to list prompts from {server_name}: {str(e)}[/yellow]")
+        elif "prompts" not in skipped:
+            self.console.print(f"[dim]Server {server_name} does not support prompts capability[/dim]")
+
+        # Get resources (static list + templates) if capability is present
+        server_resources = []
+        server_templates = []
+        if advertises("resources"):
+            try:
+                resources_response = await session.list_resources()
+                server_resources = resources_response.resources if hasattr(resources_response, 'resources') else []
+                if server_resources:
+                    self.resources_by_server[server_name] = server_resources
+            except asyncio.CancelledError:
+                return "resources"
+            except Exception as e:
+                self.console.print(f"[yellow]Warning: Failed to list resources from {server_name}: {str(e)}[/yellow]")
+            # Templates are a second request under the same capability, and a
+            # server can answer one and die on the other, so they are skipped
+            # on their own.
+            if "resource_templates" not in skipped:
+                try:
+                    templates_response = await session.list_resource_templates()
+                    server_templates = templates_response.resource_templates
+                    if server_templates:
+                        self.templates_by_server[server_name] = server_templates
+                except asyncio.CancelledError:
+                    return "resource_templates"
+                except Exception as e:
+                    self.console.print(f"[yellow]Warning: Failed to list resource templates from {server_name}: {str(e)}[/yellow]")
+            summary_parts = []
+            if server_resources:
+                summary_parts.append(f"{len(server_resources)} resource(s)")
+            if server_templates:
+                summary_parts.append(f"{len(server_templates)} template(s)")
+            if summary_parts:
+                self.console.print(f"[dim]  {server_name}: {', '.join(summary_parts)}[/dim]")
+            else:
+                self.console.print(f"[dim]  {server_name} has resources capability but returned none[/dim]")
+        elif "resources" not in skipped:
+            self.console.print(f"[dim]Server {server_name} does not support resources capability[/dim]")
+
+        prompt_count_msg = f" and {len(server_prompts)} prompt(s)" if server_prompts else ""
+        resource_count_msg = f" and {len(server_resources) + len(server_templates)} resource(s)/template(s)" if (server_resources or server_templates) else ""
+        self.console.print(f"[green]Successfully connected to {server_name} with {len(server_tools)} tool(s){prompt_count_msg}{resource_count_msg}[/green]")
+        return None
 
     def _leaf_error_messages(self, exc: BaseException) -> list[str]:
         """The messages of the real failures inside an exception.

--- a/tests/test_connector_e2e.py
+++ b/tests/test_connector_e2e.py
@@ -6,12 +6,19 @@ that drops the stream on resources/list makes the pending request fail *after*
 a successful handshake, and that used to be reported as the server never
 answering initialize.
 
+Round two of the same issue is here as well: dropping the stream cancels the
+anyio scope the transport runs in, so *swallowing* that cancellation and
+keeping the connection left the scope cancelled inside the client's own task,
+which then died with "Cancelled via cancel scope ..." at the next await, long
+after the connection had been reported as successful.
+
 The server runs in-process on an ephemeral port, so nothing here depends on a
 fixed port being free. Assertions target the observable outcome (does the
 connection survive, are the tools usable) rather than the exception type the
 SDK happens to raise, so they stay valid across mcp releases.
 """
 
+import asyncio
 import contextlib
 import json
 import socket
@@ -38,7 +45,7 @@ class _MCPTestServer(ThreadingHTTPServer):
 
     daemon_threads = True
     allow_reuse_address = True
-    mode = "healthy"  # or "drop_on_resources"
+    mode = "healthy"  # or "drop_on_resources" / "drop_on_templates"
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -71,6 +78,13 @@ class _Handler(BaseHTTPRequestHandler):
     def _result(self, msg_id, result, extra_headers=None):
         self._send_json({"jsonrpc": "2.0", "id": msg_id, "result": result}, extra_headers)
 
+    def _drop(self):
+        """Die mid-request, the way the server in #274 does."""
+        with contextlib.suppress(OSError):
+            self.connection.shutdown(socket.SHUT_RDWR)
+        self.connection.close()
+        self.close_connection = True
+
     def do_POST(self):
         raw = self.rfile.read(int(self.headers.get("Content-Length", 0)))
         try:
@@ -100,16 +114,16 @@ class _Handler(BaseHTTPRequestHandler):
         elif method == "resources/list":
             if self.server.mode == "drop_on_resources":
                 # The #274 trigger: advertise resources, then die when asked.
-                with contextlib.suppress(OSError):
-                    self.connection.shutdown(socket.SHUT_RDWR)
-                self.connection.close()
-                self.close_connection = True
-                return
+                return self._drop()
             self._result(msg_id, {"resources": [
                 {"uri": "file:///level.umap", "name": "level.umap"},
             ]})
 
         elif method == "resources/templates/list":
+            if self.server.mode == "drop_on_templates":
+                # What the reporter's server actually does: resources/list is
+                # answered, the request right after it kills the connection.
+                return self._drop()
             self._result(msg_id, {"resourceTemplates": []})
 
         else:
@@ -142,41 +156,93 @@ class TestConnectorAgainstRealServer(unittest.IsolatedAsyncioTestCase):
         cls.thread.join(timeout=5)
 
     async def _connect(self, mode):
-        """Connect to the fake server in the given mode; returns (ok, connector, output)."""
+        """Connect to the fake server in the given mode.
+
+        Returns (ok, connector, output, still_running): `still_running` is what
+        catches a cancellation left behind by a dead transport - it is False
+        when an ordinary await after the connection gets cancelled.
+        """
         type(self).server.mode = mode
         console = Console(record=True, width=200)
         stack = AsyncExitStack()
         connector = ServerConnector(stack, console=console)
+        still_running = False
         try:
             ok = await connector._connect_to_server({
                 "name": "unreal-mcp", "type": "streamable_http", "url": self.url,
             })
+            try:
+                # The client does plenty of awaiting after connecting; a scope
+                # left cancelled by the connection turns the first of them into
+                # a CancelledError with nothing to blame it on.
+                await asyncio.sleep(0)
+                still_running = True
+            except asyncio.CancelledError:
+                still_running = False
         finally:
             # In drop mode the server hard-resets the socket, so unwinding the
             # transport raises on its way out. That teardown noise is not what
             # these tests are about.
             with contextlib.suppress(BaseException):
                 await stack.aclose()
-        return ok, connector, console.export_text()
+        return ok, connector, console.export_text(), still_running
 
     async def test_healthy_server_connects_with_tools_and_resources(self):
         """Sanity check on the fake server: a well-behaved one connects fully."""
-        ok, connector, _ = await self._connect("healthy")
+        ok, connector, _, still_running = await self._connect("healthy")
 
         assert ok is True
         assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
         assert "unreal-mcp" in connector.resources_by_server
+        assert still_running is True
 
     async def test_stream_dropped_on_resources_keeps_the_connection(self):
         """#274: losing the stream on resources/list must not undo a working
         connection, nor be blamed on the URL."""
-        ok, connector, output = await self._connect("drop_on_resources")
+        ok, connector, output, _ = await self._connect("drop_on_resources")
 
         assert ok is True, "a broken resources/list must not fail the connection"
         assert "unreal-mcp" in connector.sessions
         assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
         assert connector.enabled_tools == {"unreal-mcp.spawn_actor": True}
         assert HANDSHAKE_ERROR not in output, "initialize succeeded; do not blame the URL"
+
+    async def test_dropped_listing_leaves_no_cancellation_behind(self):
+        """#274 round two: the dead transport's cancelled scope must not be
+        handed to the shared exit stack, where it cancels the client itself."""
+        for mode in ("drop_on_resources", "drop_on_templates"):
+            with self.subTest(mode=mode):
+                ok, connector, output, still_running = await self._connect(mode)
+
+                assert ok is True
+                assert still_running is True, (
+                    "the connection left a cancelled scope in the client's task"
+                )
+                assert [t.name for t in connector.available_tools] == ["unreal-mcp.spawn_actor"]
+
+    async def test_retry_names_the_listing_that_closed_the_connection(self):
+        """The user gets told which request the server died on, spelled the way
+        it goes over the wire so it can be matched with a server-side log."""
+        _, _, output, _ = await self._connect("drop_on_templates")
+
+        assert "closed the connection on resources/templates/list" in output
+        # The listing that did answer is still there.
+        assert "1 resource(s)" in output
+
+    async def test_dropped_listing_keeps_the_session_usable(self):
+        """Reconnecting is only worth it if the surviving session works."""
+        type(self).server.mode = "drop_on_templates"
+        stack = AsyncExitStack()
+        connector = ServerConnector(stack, console=Console(record=True, width=200))
+        try:
+            assert await connector._connect_to_server({
+                "name": "unreal-mcp", "type": "streamable_http", "url": self.url,
+            })
+            live = await connector.sessions["unreal-mcp"]["session"].list_tools()
+            assert [t.name for t in live.tools] == ["spawn_actor"]
+        finally:
+            with contextlib.suppress(BaseException):
+                await stack.aclose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A server can answer initialize and then kill the transport when one of the capability listings is queried. The transport's task group cancels the anyio scope it runs in, which is the client's own, so catching that CancelledError to keep the connection did not undo the cancellation: the scope stayed cancelled and open, and was then handed to the shared exit stack, where it lives for the rest of the session and cancels the client at the next await. ollmcp printed "Successfully connected" and died some awaits later with "Cancelled via cancel scope 0x...", blaming nothing in particular.

Keep the connection in the attempt's local exit stack until the capabilities have been listed, and transfer it with pop_all() only once they are all answered. A cancelled listing now unwinds the attempt, closing the dead transport along with its scope, and the server is reconnected with that listing skipped: a server that dies on resources/templates/list no longer costs the user the tools that do work.

The e2e suite gets the reporter's actual case (resources/list answered, the request right after it drops the connection) and, more importantly, asserts that an ordinary await after connecting is not cancelled, which is the symptom the previous fix left behind.

Relates to #274