### PR TITLE
docs: add You.com MCP server example for remote web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,12 @@ ollmcp mcp add --transport http github https://api.githubcopilot.com/mcp/ --head
 ollmcp mcp add --transport stdio playwright npx @playwright/mcp@latest
 ollmcp mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /allowed-dir1 ~/allowed-dir2 # stdio transport by default
 ollmcp mcp add --env API_KEY=YOUR_KEY --transport sse my-sse-server http://localhost:8000/sse
+ollmcp mcp add --transport http you https://api.you.com/mcp --header "Authorization: Bearer YOUR_YDC_API_KEY" # You.com web search (key: https://you.com/platform/api-keys)
+ollmcp mcp add --transport http you-free "https://api.you.com/mcp?profile=free" # keyless basic web search, no token needed
 ```
+
+> [!TIP]
+> The [You.com MCP server](https://you.com/docs) gives local models live web access through the `you-search` tool (current web search; the authenticated endpoint adds `you-contents` for URL content extraction). The `?profile=free` endpoint works without any API key, so it is the quickest way to try a remote HTTP server with a local model.
 
 
 ### mcp add options


### PR DESCRIPTION
This adds two `mcp add` examples for the [You.com MCP server](https://you.com/docs) to the existing "Examples" block in the README, following the same shape as the GitHub Copilot MCP entry that's already there:

```bash
# Authenticated (API key from https://you.com/platform/api-keys)
ollmcp mcp add --transport http you https://api.you.com/mcp --header "Authorization: Bearer YOUR_YDC_API_KEY"

# Keyless — basic web search, no token needed
ollmcp mcp add --transport http you-free "https://api.you.com/mcp?profile=free"
```

Why this is useful for ollmcp specifically: web search is one of the most common remote tools people want to hook up to a local model, and the keyless `?profile=free` endpoint is a nice zero-setup way for a new user to try a remote streamable-HTTP server — no token, no npx, just one `mcp add` line and the model can call `you-search`.

What changed:
- Two lines in the existing `mcp add` examples block (README only)
- A short `> [!TIP]` callout explaining the `you-search` tool and the keyless profile

I kept this docs-only since the client already fully supports remote HTTP servers with bearer headers — no code changes needed.

Validation performed:
- `uv run pytest tests/ -q` → 264 passed (docs-only change; CI also ignores `**/*.md`)
- Verified `ollmcp mcp add --help` syntax matches the examples
- Registered the keyless server locally (`ollmcp mcp add --transport http you-free "https://api.you.com/mcp?profile=free"` → shows up in `ollmcp mcp list`)
- Live-tested the keyless endpoint with the same MCP SDK 2.x + httpx2 stack ollmcp uses: `initialize()` succeeds and the server exposes `you-search` and `you-discover`

If you'd rather not name a specific vendor in the examples, happy to reword or drop the tip callout.