### PR TITLE
fix(client): forward structuredContent from tool results to the LLM

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -70,6 +70,65 @@ class MCPClient:
         "multiline": "Multiline",
     }
 
+    @staticmethod
+    def _extract_tool_response(result, has_vision: bool = False):
+        """Build the text forwarded to the LLM from a tool CallToolResult.
+
+        Handles content items (text/image/audio/resource) and the
+        machine-oriented structuredContent payload, which agents need for
+        follow-up calls (issue #303). Returns (tool_response, tool_images).
+        """
+        text_parts = []
+        tool_images = []  # List of base64 strings
+
+        for content_item in result.content:
+
+            if hasattr(content_item, 'type') and content_item.type == "image":
+                base64_data = getattr(content_item, 'data', '')
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                tool_images.append(base64_data)
+                if has_vision:
+                    text_parts.append(f"[Image: {mime_type}, {len(base64_data)} bytes]")
+                else:
+                    text_parts.append(f"[Image returned but not processed: {mime_type} - current model does not support vision]")
+            elif hasattr(content_item, 'type') and content_item.type == "audio":
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                data = getattr(content_item, 'data', '')
+                text_parts.append(f"[Audio returned but not processed: {mime_type}, {len(data)} bytes - Ollama does not support audio input]")
+            elif hasattr(content_item, 'type') and content_item.type == "resource" and hasattr(content_item, 'resource'):
+                # TODO: Handle MCP resource content (type="resource") — extract text/blob from
+                #       content_item.resource and forward to LLM once resource support is implemented.
+                resource = content_item.resource
+                uri = getattr(resource, 'uri', 'unknown')
+                mime_type = getattr(resource, 'mime_type', 'unknown')
+                text_parts.append(f"[Resource returned but not processed: {uri} ({mime_type}) - resource support not yet implemented]")
+            elif hasattr(content_item, 'type') and content_item.type == "resource_link":
+                # TODO: Handle MCP resource links (type="resource_link") — fetch content via
+                #       resources/read using the URI once resource support is implemented.
+                uri = getattr(content_item, 'uri', 'unknown')
+                name = getattr(content_item, 'name', '')
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                label = f" ({name})" if name else ""
+                text_parts.append(f"[Resource link returned but not fetched: {uri}{label} ({mime_type}) - resource support not yet implemented]")
+            elif hasattr(content_item, 'text'):
+                text_parts.append(str(content_item.text))
+            else:
+                text_parts.append(str(content_item))
+
+        # Forward structuredContent so agent workflows can use machine-readable
+        # tool results in subsequent calls (issue #303).
+        structured_content = getattr(result, "structured_content", None)
+        if structured_content is None:
+            structured_content = getattr(result, "structuredContent", None)
+        if structured_content is not None:
+            try:
+                text_parts.append("[Structured tool result]\n" + json.dumps(structured_content, indent=2, default=str))
+            except Exception:
+                text_parts.append("[Structured tool result]\n" + str(structured_content))
+
+        tool_response = "\n\n".join(text_parts) if text_parts else "Tool executed successfully (no text content returned)"
+        return tool_response, tool_images
+
     def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_OLLAMA_HOST, provider: str = DEFAULT_PROVIDER, api_key: str = None, persist_api_key: bool = True, debug: bool = False, log_level: str = None):
         # Initialize session and client objects
         self.exit_stack = AsyncExitStack()
@@ -695,44 +754,7 @@ class MCPClient:
 
                 # Extract content from tool response - decoupled from display
                 # MCP responses can contain multiple content items (text, images, etc.)
-                text_parts = []
-                tool_images = []  # List of base64 strings
-
-                for content_item in result.content:
-                    if hasattr(content_item, 'type') and content_item.type == "image":
-                        base64_data = getattr(content_item, 'data', '')
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        tool_images.append(base64_data)
-                        if has_vision:
-                            text_parts.append(f"[Image: {mime_type}, {len(base64_data)} bytes]")
-                        else:
-                            text_parts.append(f"[Image returned but not processed: {mime_type} - current model does not support vision]")
-                    elif hasattr(content_item, 'type') and content_item.type == "audio":
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        data = getattr(content_item, 'data', '')
-                        text_parts.append(f"[Audio returned but not processed: {mime_type}, {len(data)} bytes - Ollama does not support audio input]")
-                    elif hasattr(content_item, 'type') and content_item.type == "resource" and hasattr(content_item, 'resource'):
-                        # TODO: Handle MCP resource content (type="resource") — extract text/blob from
-                        #       content_item.resource and forward to LLM once resource support is implemented.
-                        resource = content_item.resource
-                        uri = getattr(resource, 'uri', 'unknown')
-                        mime_type = getattr(resource, 'mime_type', 'unknown')
-                        text_parts.append(f"[Resource returned but not processed: {uri} ({mime_type}) - resource support not yet implemented]")
-                    elif hasattr(content_item, 'type') and content_item.type == "resource_link":
-                        # TODO: Handle MCP resource links (type="resource_link") — fetch content via
-                        #       resources/read using the URI once resource support is implemented.
-                        uri = getattr(content_item, 'uri', 'unknown')
-                        name = getattr(content_item, 'name', '')
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        label = f" ({name})" if name else ""
-                        text_parts.append(f"[Resource link returned but not fetched: {uri}{label} ({mime_type}) - resource support not yet implemented]")
-                    elif hasattr(content_item, 'text'):
-                        text_parts.append(str(content_item.text))
-                    else:
-                        text_parts.append(str(content_item))
-
-                tool_response = "\n\n".join(text_parts) if text_parts else "Tool executed successfully (no text content returned)"
-
+                tool_response, tool_images = self._extract_tool_response(result, has_vision=has_vision)
                 # Display tool response (independent of content extraction)
                 self.tool_display_manager.display_tool_response(
                     tool_name, tool_args, tool_response,

--- a/tests/test_structured_content_forwarding.py
+++ b/tests/test_structured_content_forwarding.py
@@ -1,0 +1,95 @@
+"""Regression tests for structured tool-result forwarding (#303).
+
+MCP tools can return both `content` (human-oriented items) and
+`structuredContent` (machine-oriented JSON). The LLM message must include
+the structured data too, otherwise agent workflows that depend on it (e.g.
+revision-guarded follow-up calls) cannot proceed.
+"""
+
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from mcp_client_for_ollama.client import MCPClient
+
+
+def _make_result(structured=None, items=None):
+    return CallToolResult(
+        content=items if items is not None else [
+            TextContent(type="text", text="inspect_project completed. The complete result is available in structuredContent.")
+        ],
+        structuredContent=structured,
+        isError=False,
+    )
+
+
+def test_structured_content_reaches_llm_message():
+    """The text forwarded to the LLM must contain the structuredContent JSON."""
+    structured = {
+        "path": "C:\\apps\\shotcut-mcp\\ai-test.mlt",
+        "revision": "947e191e72e5535a6620be650882450e7de7b17024fb4a504b259b4ddcd005cc",
+    }
+    tool_response, _images = MCPClient._extract_tool_response(_make_result(structured))
+    assert "947e191e72e5535a6620be650882450e7de7b17024fb4a504b259b4ddcd005cc" in tool_response, (
+        "structuredContent was not forwarded to the LLM (issue #303)"
+    )
+    assert "[Structured tool result]" in tool_response
+    # plain text content is still forwarded unchanged
+    assert "inspect_project completed" in tool_response
+
+
+def test_plain_content_only_unchanged():
+    """Without structuredContent the response is identical to the old behaviour."""
+    tool_response, _images = MCPClient._extract_tool_response(_make_result(structured=None))
+    assert "inspect_project completed" in tool_response
+    assert "[Structured tool result]" not in tool_response
+
+
+def test_structured_content_non_serializable():
+    """Non-JSON-serializable structured payloads must not crash the loop."""
+    class Weird:
+        def __str__(self):
+            return "<weird-object>"
+
+    tool_response, _images = MCPClient._extract_tool_response(
+        _make_result(structured={"weird": Weird()})
+    )
+    assert "[Structured tool result]" in tool_response
+    assert "<weird-object>" in tool_response
+
+
+def test_empty_content_with_structured_only():
+    """Some tools return only structuredContent and no content items."""
+    tool_response, _images = MCPClient._extract_tool_response(
+        _make_result(structured={"ok": True}, items=[])
+    )
+    assert "[Structured tool result]" in tool_response
+    assert '"ok": true' in tool_response
+
+
+def test_image_collection_still_works():
+    """The refactor must not break image extraction from content items."""
+    image = ImageContent(type="image", data="aGVsbG8=", mimeType="image/png")
+    tool_response, images = MCPClient._extract_tool_response(
+        _make_result(items=[image]), has_vision=True
+    )
+    assert images == ["aGVsbG8="]
+    assert "[Image: image/png, 8 bytes]" in tool_response
+
+
+def test_snake_and_camel_case_attrs():
+    """MCP SDK 2.x exposes structuredContent; older objects may use snake_case.
+
+    The getter accepts both attribute spellings.
+    """
+
+    class CamelResult:
+        content = [TextContent(type="text", text="done")]
+        structuredContent = {"camel": True}
+
+    class SnakeResult:
+        content = [TextContent(type="text", text="done")]
+        structured_content = {"snake": True}
+
+    camel_response, _ = MCPClient._extract_tool_response(CamelResult())
+    snake_response, _ = MCPClient._extract_tool_response(SnakeResult())
+    assert '"camel": true' in camel_response
+    assert '"snake": true' in snake_response


### PR DESCRIPTION
## Problem

When an MCP tool returns important data via `structuredContent`, ollmcp forwards only the tool's `content` items to the LLM (#303). Agent workflows that depend on structured fields — e.g. Shotcut MCP's revision-guarded `edit_project` after `inspect_project` — cannot proceed: the model is told the tool completed but never sees the machine-readable payload.

Root cause: the query loop in `mcp_client_for_ollama/client.py` iterates only over `result.content` when building the tool response.

## Fix

- Extracted the message assembly into `MCPClient._extract_tool_response(result, has_vision)` so it is directly unit-testable, with behaviour otherwise unchanged.
- After the content-item pass, the structured payload (either `structured_content` or `structuredContent` attribute — the MCP SDK exposes it as camelCase on `CallToolResult`) is appended as a `[Structured tool result]` block with `json.dumps(..., indent=2, default=str)`, falling back to `str()` if serialization fails.
- Tools that return *only* `structuredContent` (no content items) now produce a meaningful response instead of the generic "no text content returned" placeholder.

## Tests

New `tests/test_structured_content_forwarding.py` (6 cases):

- structured payload reaches the LLM message; plain text still forwarded
- no structuredContent → output identical to previous behaviour
- non-serializable payload → graceful `str()` fallback, no crash
- empty `content` + structured-only tool
- image collection from content items unchanged by the refactor
- both snake_case / camelCase attribute spellings accepted

Full suite: **270 passed** (264 pre-existing + 6 new), no regressions.

```text
$ python -m pytest tests/ -q
270 passed, 1 warning, 6 subtests passed in 14.46s
```

## Notes for reviewers

- The extraction refactor was needed to make the path testable without standing up real MCP/Ollama sessions; the diff of the moved code is otherwise line-for-line identical.
- Follows the fix direction sketched in the issue (which the reporter verified end-to-end with Qwen 3.5 9B + Shotcut MCP: with the change, the model read the revision hash and completed the follow-up `edit_project` call).

Closes #303