### PR TITLE
fix(client): forward structuredContent when a tool sends no text

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -488,6 +488,73 @@ class MCPClient:
             if len(self.chat_history) > max_history:
                 self.console.print(f"[dim](Showing last {max_history} of {len(self.chat_history)} conversations)[/dim]")
 
+    def _extract_tool_response(self, result, has_vision: bool = False):
+        """Build the text forwarded to the LLM from a tool CallToolResult.
+
+        Returns (tool_response, tool_images).
+        """
+        text_parts = []
+        tool_images = []  # List of base64 strings
+        # Whether the server sent any text block of its own. The placeholders we
+        # write for images, audio and resources are ours, not the server's.
+        has_server_text = False
+
+        for content_item in result.content:
+            if hasattr(content_item, 'type') and content_item.type == "image":
+                base64_data = getattr(content_item, 'data', '')
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                tool_images.append(base64_data)
+                if has_vision:
+                    text_parts.append(f"[Image: {mime_type}, {len(base64_data)} bytes]")
+                else:
+                    text_parts.append(f"[Image returned but not processed: {mime_type} - current model does not support vision]")
+            elif hasattr(content_item, 'type') and content_item.type == "audio":
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                data = getattr(content_item, 'data', '')
+                text_parts.append(f"[Audio returned but not processed: {mime_type}, {len(data)} bytes - Ollama does not support audio input]")
+            elif hasattr(content_item, 'type') and content_item.type == "resource" and hasattr(content_item, 'resource'):
+                # TODO: Handle MCP resource content (type="resource") — extract text/blob from
+                #       content_item.resource and forward to LLM once resource support is implemented.
+                resource = content_item.resource
+                uri = getattr(resource, 'uri', 'unknown')
+                mime_type = getattr(resource, 'mime_type', 'unknown')
+                text_parts.append(f"[Resource returned but not processed: {uri} ({mime_type}) - resource support not yet implemented]")
+            elif hasattr(content_item, 'type') and content_item.type == "resource_link":
+                # TODO: Handle MCP resource links (type="resource_link") — fetch content via
+                #       resources/read using the URI once resource support is implemented.
+                uri = getattr(content_item, 'uri', 'unknown')
+                name = getattr(content_item, 'name', '')
+                mime_type = getattr(content_item, 'mime_type', 'unknown')
+                label = f" ({name})" if name else ""
+                text_parts.append(f"[Resource link returned but not fetched: {uri}{label} ({mime_type}) - resource support not yet implemented]")
+            elif hasattr(content_item, 'text'):
+                has_server_text = True
+                text_parts.append(str(content_item.text))
+            else:
+                has_server_text = True
+                text_parts.append(str(content_item))
+
+        # A tool that returns structured content SHOULD also serialize it into a
+        # text block, but the spec asks for that only "for backwards
+        # compatibility" -- a SHOULD, so a conforming server may answer with
+        # structuredContent and no text at all, and the whole result would then
+        # reach the model as "no text content returned" (issue #303). So the
+        # payload is forwarded exactly when the server sent no text of its own.
+        # When it did, that text is what the model gets: both fields carry the
+        # same information by construction -- each SDK builds them from one
+        # return value -- and SEP-1624 is explicit that a client SHOULD NOT
+        # forward both:
+        # https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624
+        # Serialized compactly (this copy is ours, and indentation buys the
+        # model nothing) and with ensure_ascii=False, since escaping non-ASCII
+        # to \uXXXX inflates the payload and small local models echo the escapes
+        # back verbatim.
+        if not has_server_text and result.structured_content is not None:
+            text_parts.append(json.dumps(result.structured_content, separators=(",", ":"), ensure_ascii=False, default=str))
+
+        tool_response = "\n\n".join(text_parts) if text_parts else "Tool executed successfully (no text content returned)"
+        return tool_response, tool_images
+
     async def process_query(self, query: str, images=None) -> str:
         """Process a query using Ollama and available tools"""
         if not self.model_manager.get_current_model():
@@ -695,43 +762,8 @@ class MCPClient:
 
                 # Extract content from tool response - decoupled from display
                 # MCP responses can contain multiple content items (text, images, etc.)
-                text_parts = []
-                tool_images = []  # List of base64 strings
+                tool_response, tool_images = self._extract_tool_response(result, has_vision=has_vision)
 
-                for content_item in result.content:
-                    if hasattr(content_item, 'type') and content_item.type == "image":
-                        base64_data = getattr(content_item, 'data', '')
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        tool_images.append(base64_data)
-                        if has_vision:
-                            text_parts.append(f"[Image: {mime_type}, {len(base64_data)} bytes]")
-                        else:
-                            text_parts.append(f"[Image returned but not processed: {mime_type} - current model does not support vision]")
-                    elif hasattr(content_item, 'type') and content_item.type == "audio":
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        data = getattr(content_item, 'data', '')
-                        text_parts.append(f"[Audio returned but not processed: {mime_type}, {len(data)} bytes - Ollama does not support audio input]")
-                    elif hasattr(content_item, 'type') and content_item.type == "resource" and hasattr(content_item, 'resource'):
-                        # TODO: Handle MCP resource content (type="resource") — extract text/blob from
-                        #       content_item.resource and forward to LLM once resource support is implemented.
-                        resource = content_item.resource
-                        uri = getattr(resource, 'uri', 'unknown')
-                        mime_type = getattr(resource, 'mime_type', 'unknown')
-                        text_parts.append(f"[Resource returned but not processed: {uri} ({mime_type}) - resource support not yet implemented]")
-                    elif hasattr(content_item, 'type') and content_item.type == "resource_link":
-                        # TODO: Handle MCP resource links (type="resource_link") — fetch content via
-                        #       resources/read using the URI once resource support is implemented.
-                        uri = getattr(content_item, 'uri', 'unknown')
-                        name = getattr(content_item, 'name', '')
-                        mime_type = getattr(content_item, 'mime_type', 'unknown')
-                        label = f" ({name})" if name else ""
-                        text_parts.append(f"[Resource link returned but not fetched: {uri}{label} ({mime_type}) - resource support not yet implemented]")
-                    elif hasattr(content_item, 'text'):
-                        text_parts.append(str(content_item.text))
-                    else:
-                        text_parts.append(str(content_item))
-
-                tool_response = "\n\n".join(text_parts) if text_parts else "Tool executed successfully (no text content returned)"
 
                 # Display tool response (independent of content extraction)
                 self.tool_display_manager.display_tool_response(

--- a/tests/test_structured_content_forwarding.py
+++ b/tests/test_structured_content_forwarding.py
@@ -1,0 +1,151 @@
+"""Regression tests for structured tool-result forwarding (#303).
+
+An MCP tool result carries human-oriented items in `content` and, optionally, a
+machine-oriented JSON payload in `structuredContent`. The spec has a server that
+returns structured content ALSO serialize it into a TextContent block, but only
+"for backwards compatibility" -- a SHOULD, not a MUST. A conforming server may
+therefore answer with `structuredContent` and no text at all, and that result
+used to reach the model as "no text content returned".
+
+So the payload is forwarded exactly when the server sent no text of its own.
+When it did, that text is what the model gets: the two fields carry the same
+information by construction, and SEP-1624 asks clients not to forward both.
+"""
+
+import json
+
+from mcp.types import AudioContent, CallToolResult, ImageContent, TextContent
+
+from mcp_client_for_ollama.client import MCPClient
+
+client = MCPClient()
+
+
+def _make_result(structured=None, items=None):
+    return CallToolResult(
+        content=items if items is not None else [
+            TextContent(type="text", text="inspect_project completed.")
+        ],
+        structuredContent=structured,
+        isError=False,
+    )
+
+
+def test_structured_content_reaches_llm_when_there_is_no_text():
+    """The case the spec allows and we used to drop on the floor (#303)."""
+    structured = {
+        "path": "C:\\apps\\shotcut-mcp\\ai-test.mlt",
+        "revision": "947e191e72e5535a6620be650882450e7de7b17024fb4a504b259b4ddcd005cc",
+    }
+    tool_response, _images = client._extract_tool_response(
+        _make_result(structured=structured, items=[])
+    )
+    assert json.loads(tool_response) == structured
+
+
+def test_no_content_and_no_structured_content():
+    """An empty result still says something to the model."""
+    tool_response, images = client._extract_tool_response(
+        _make_result(structured=None, items=[])
+    )
+    assert tool_response == "Tool executed successfully (no text content returned)"
+    assert images == []
+
+
+def test_text_content_is_forwarded_alone():
+    """A server that sent text gets that text forwarded, and only that: both
+    fields hold the same information, so adding the payload would spend the
+    model's context on it twice (SEP-1624)."""
+    structured = {"temperature": 22.5, "conditions": "Partly cloudy"}
+    tool_response, _images = client._extract_tool_response(
+        _make_result(structured=structured, items=[
+            TextContent(type="text", text=json.dumps(structured)),
+        ])
+    )
+    assert tool_response == json.dumps(structured)
+
+
+def test_text_content_wins_whatever_shape_it_has():
+    """Including the shapes the reference SDKs actually emit: the serialized
+    payload, a bare value, or one block per list item."""
+    for label, structured, items, expected in [
+        (
+            "bare value next to the SDK's {'result': ...} wrapper",
+            {"result": "line one\nline two"},
+            [TextContent(type="text", text="line one\nline two")],
+            "line one\nline two",
+        ),
+        (
+            "one text block per list item",
+            {"result": ["uno", "dos"]},
+            [TextContent(type="text", text="uno"), TextContent(type="text", text="dos")],
+            "uno\n\ndos",
+        ),
+    ]:
+        tool_response, _images = client._extract_tool_response(
+            _make_result(structured=structured, items=items)
+        )
+        assert tool_response == expected, f"{label}: {tool_response!r}"
+
+
+def test_plain_content_only_unchanged():
+    """Without structuredContent nothing changes."""
+    tool_response, _images = client._extract_tool_response(_make_result(structured=None))
+    assert tool_response == "inspect_project completed."
+
+
+def test_forwarded_payload_is_compact():
+    """The copy is ours, so it is serialized without indentation the model gains
+    nothing from."""
+    tool_response, _images = client._extract_tool_response(
+        _make_result(structured={"a": 1, "b": [1, 2]}, items=[])
+    )
+    assert tool_response == '{"a":1,"b":[1,2]}'
+
+
+def test_non_ascii_payload_is_not_escaped():
+    r"""Escaping non-ASCII to \uXXXX bloats the payload (~6 chars per CJK
+    character) and small local models echo the escapes back."""
+    structured = {"city": "北京", "note": "café"}
+    tool_response, _images = client._extract_tool_response(
+        _make_result(structured=structured, items=[])
+    )
+    assert tool_response == '{"city":"北京","note":"café"}'
+    assert json.loads(tool_response) == structured
+
+
+def test_structured_content_non_serializable():
+    """Payloads json.dumps cannot encode fall back to str() per value."""
+    class Weird:
+        def __str__(self):
+            return "<weird-object>"
+
+    tool_response, _images = client._extract_tool_response(
+        _make_result(structured={"weird": Weird()}, items=[])
+    )
+    assert "<weird-object>" in tool_response
+
+
+def test_payload_survives_next_to_media_only_content():
+    """Image and audio placeholders are ours, not the server's text, so a tool
+    answering with media plus a payload still forwards the payload."""
+    items = [
+        ImageContent(type="image", data="aGVsbG8=", mimeType="image/png"),
+        AudioContent(type="audio", data="YXVkaW8=", mimeType="audio/wav"),
+    ]
+    tool_response, images = client._extract_tool_response(
+        _make_result(structured={"ok": True}, items=items), has_vision=True
+    )
+    assert images == ["aGVsbG8="]
+    assert "[Image: image/png, 8 bytes]" in tool_response
+    assert tool_response.endswith('{"ok":true}')
+
+
+def test_image_collection_still_works():
+    """The extraction refactor must not break image handling."""
+    image = ImageContent(type="image", data="aGVsbG8=", mimeType="image/png")
+    tool_response, images = client._extract_tool_response(
+        _make_result(items=[image]), has_vision=True
+    )
+    assert images == ["aGVsbG8="]
+    assert "[Image: image/png, 8 bytes]" in tool_response


### PR DESCRIPTION
Covers the client-side half of #303. Opened separately from #304 rather than pushed on top of it, since this takes a narrower approach.

The spec asks a tool that returns structured content to also serialize it into a TextContent block, but only "for backwards compatibility": a SHOULD, not a MUST. A conforming server may answer with `structuredContent` and no text at all, and that whole result reached the model as "Tool executed successfully (no text content returned)". In practice servers fill both fields from the same value, so this is a best effort for the case where only `structuredContent` shows up.

So the payload is now forwarded exactly when the server sent no text of its own. Placeholders we write ourselves for images, audio and resources don't count as the server's text, so a tool answering with media plus a payload forwards both.

When the server did send text, that text is what the model gets, and the payload is not appended. Both fields carry the same information by construction: the Python SDK builds them from one return value in `convert_result`, and the TypeScript SDK's documented idiom is `content: [{ type: 'text', text: JSON.stringify(output) }], structuredContent: output`. And [SEP-1624](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624) is explicit that "Clients SHOULD NOT forward both fields verbatim to models as semantically distinct inputs". Appending it every time would duplicate every tool result in the context window, which is expensive with small local models.

The payload is serialized compactly and with `ensure_ascii=False`, so a non-ASCII result no longer reaches the model as `\uXXXX` escapes.

The extraction loop moves into `_extract_tool_response`, right above its only caller, so the behaviour can be tested without driving a whole query. Thanks @w1977-0, whose #304 found the bug and prompted all of this.