### PR TITLE
fix(streaming): stop a failed chunk from silently emptying the response

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -33,6 +33,7 @@ from .config.manager import ConfigManager
 from .config.defaults import default_config, default_provider_profile
 from .utils.version import check_for_updates
 from .utils.constants import DEFAULT_CLAUDE_CONFIG, DEFAULT_MODEL, DEFAULT_OLLAMA_HOST, DEFAULT_PROVIDER, SUPPORTED_PROVIDERS, DEFAULT_COMPLETION_STYLE, DEFAULT_HISTORY_DISPLAY_LIMIT, MAX_COMPLETION_MENU_ROWS, OLLMCP_ASCII_ART, REASONING_EFFORT_LEVELS, DEFAULT_REASONING_EFFORT, SERVER_LOG_DIR, MCP_LOG_LEVELS
+from .utils.client_logs import start_client_log
 from .utils.connection import preflight_ollama, validate_provider
 from .utils.images import apply_images
 from .server.connector import ServerConnector
@@ -2145,6 +2146,7 @@ def main(
 async def async_main(mcp_server, mcp_server_url, servers_json, claude_desktop, model, host, provider, api_key, debug=False, log_level=None):
     """Asynchronous main function to run the MCP Client for Ollama"""
 
+    start_client_log()
     console = Console()
 
     # Resolve the provider and its saved connection profile before building the

--- a/mcp_client_for_ollama/utils/client_logs.py
+++ b/mcp_client_for_ollama/utils/client_logs.py
@@ -1,0 +1,52 @@
+"""Log file for what ollmcp itself reports.
+
+The MCP servers' output goes to their own files next to this one (see
+server_logs); this is the client's side of the same session directory, so a
+warning ollmcp raises while talking to the provider is recorded somewhere
+instead of printed over the TUI.
+"""
+
+import logging
+import os
+from typing import Optional
+
+from .server_logs import prune_old_sessions, session_log_dir
+
+# ollmcp's own logger: every module's logger propagates up to it. The
+# NullHandler keeps Python's last-resort handler, which writes to stderr and
+# would print over whatever is being rendered, from ever kicking in.
+logger = logging.getLogger("mcp_client_for_ollama")
+logger.addHandler(logging.NullHandler())
+
+# Set once the file is actually open, so nothing points the user at a log that
+# was never written.
+_active_log_path: Optional[str] = None
+
+
+def client_log_path() -> Optional[str]:
+    """Path of the client's log file, or None if nothing is being recorded."""
+    return _active_log_path
+
+
+def start_client_log() -> None:
+    """Send ollmcp's own log records to this run's log file.
+
+    Called once at startup. Nowhere to write (read-only home, no space, ...) is
+    not a reason to refuse to start: the records are simply dropped, same as
+    what a server's sink does with its output.
+    """
+    global _active_log_path
+
+    path = os.path.join(session_log_dir(), "ollmcp.log")
+    try:
+        os.makedirs(session_log_dir(), exist_ok=True)
+        # This runs on every launch, including runs that never connect a server
+        # and so never build a sink to prune from.
+        prune_old_sessions()
+        handler = logging.FileHandler(path, encoding="utf-8")
+    except OSError:
+        return
+
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(handler)
+    _active_log_path = path

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -6,6 +6,9 @@ Classes:
     LiveMarkdownRenderer: Line-by-line markdown renderer with a bounded live tail.
     StreamingManager: Handles streaming responses from Ollama.
 """
+import json
+import logging
+import os
 import shutil
 from io import StringIO
 from time import monotonic
@@ -13,9 +16,56 @@ from time import monotonic
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import Markdown
+from rich.markup import escape
 from rich.text import Text
 
+from .client_logs import client_log_path
 from .metrics import display_metrics, extract_metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _has_complete_arguments(buf) -> bool:
+    """Whether a tool call's buffered arguments arrived in full.
+
+    Arguments are streamed as a JSON string in pieces; one that no longer parses
+    is a call that was cut short. Empty means a tool taking no arguments, which
+    is complete.
+    """
+    if not buf["arguments"]:
+        return True
+    try:
+        json.loads(buf["arguments"])
+    except ValueError:
+        return False
+    return True
+
+
+def _flush_tool_call_buffers(tool_call_buffers, tool_calls):
+    """Move buffered tool call deltas into the completed tool_calls list.
+
+    Called both when a chunk carries finish_reason and once the stream is over,
+    so a tool call that arrived in full is never dropped just because the
+    provider closed the stream without a finish_reason (or the stream died
+    before sending one).
+    """
+    for idx, buf in sorted(tool_call_buffers.items()):
+        if not buf["name"]:
+            continue
+        if not _has_complete_arguments(buf):
+            # A stream that died mid-arguments leaves truncated JSON behind.
+            # There is no calling a tool with it, and passing it on only turns
+            # a partial answer into a crash further down.
+            logger.warning(
+                "Dropping tool call %s: incomplete arguments %r", buf["name"], buf["arguments"]
+            )
+            continue
+        tool_calls.append({
+            "id": buf["id"] or f"call_{idx}",
+            "type": "function",
+            "function": {"name": buf["name"], "arguments": buf["arguments"]},
+        })
+    tool_call_buffers.clear()
 
 
 class BlockMarkdownRenderer:
@@ -344,6 +394,7 @@ class StreamingManager:
         thinking_content = ""
         tool_calls = []
         metrics = None  # Store metrics from final chunk
+        stream_error = None  # Error that ended the stream early, if any
         render_mode = self._normalize_answer_render_mode(answer_render_mode)
         stream_plain_text = render_mode in {"plain", "both"}
         render_markdown = render_mode in {"markdown", "both"}
@@ -369,9 +420,13 @@ class StreamingManager:
                     except StopAsyncIteration:
                         break
                     except Exception as e:
-                        import logging
-                        logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
-                        continue
+                        # The stream is over: a provider's async generator is
+                        # closed once it raises, so there is no next chunk to
+                        # skip to. Keep whatever arrived and say what happened,
+                        # instead of returning an empty response in silence.
+                        stream_error = e
+                        logger.warning("Stream chunk failed: %s", e, exc_info=True)
+                        break
 
                     # Check for cancellation
                     if cancellation_check and cancellation_check():
@@ -453,18 +508,30 @@ class StreamingManager:
 
                     # On finish, emit completed tool calls
                     if getattr(choice, "finish_reason", None) and tool_call_buffers:
-                        for idx, buf in sorted(tool_call_buffers.items()):
-                            tool_calls.append({
-                                "id": buf["id"] or f"call_{idx}",
-                                "type": "function",
-                                "function": {"name": buf["name"], "arguments": buf["arguments"]},
-                            })
-                        tool_call_buffers.clear()
+                        _flush_tool_call_buffers(tool_call_buffers, tool_calls)
 
             finally:
+                # The stream may have ended without a finish_reason (or died
+                # mid-flight); don't lose tool calls that already arrived.
+                _flush_tool_call_buffers(tool_call_buffers, tool_calls)
                 if progressive_renderer is not None:
                     progressive_renderer.finish()
                 status.stop()
+
+            if stream_error is not None:
+                # The message comes from the provider's library and often has
+                # brackets in it (pydantic's are full of them). Left unescaped,
+                # rich either eats the tail as markup or raises out of here.
+                detail = escape(f"{type(stream_error).__name__}: {stream_error}")
+                log_path = client_log_path()
+                where = (
+                    f" Details in {log_path.replace(os.path.expanduser('~'), '~')}"
+                    if log_path else ""
+                )
+                self.console.print(
+                    f"\n[yellow]⚠ The response stream ended early: {detail}[/yellow]\n"
+                    f"[dim]Showing whatever arrived before that.{where}[/dim]"
+                )
 
             # Print newline at end. Thinking (and plain answer text) is streamed
             # with end="", leaving the cursor mid-line. Close that dangling line
@@ -489,9 +556,9 @@ class StreamingManager:
                 except StopAsyncIteration:
                     break
                 except Exception as e:
-                    import logging
-                    logging.getLogger(__name__).debug("Skipping unparseable stream chunk: %s", e)
-                    continue
+                    stream_error = e
+                    logger.warning("Stream chunk failed: %s", e, exc_info=True)
+                    break
 
                 # Check for cancellation
                 if cancellation_check and cancellation_check():
@@ -533,13 +600,9 @@ class StreamingManager:
                                 buf["arguments"] += tc.function.arguments
 
                 if getattr(choice, "finish_reason", None) and tool_call_buffers:
-                    for idx, buf in sorted(tool_call_buffers.items()):
-                        tool_calls.append({
-                            "id": buf["id"] or f"call_{idx}",
-                            "type": "function",
-                            "function": {"name": buf["name"], "arguments": buf["arguments"]},
-                        })
-                    tool_call_buffers.clear()
+                    _flush_tool_call_buffers(tool_call_buffers, tool_calls)
+
+            _flush_tool_call_buffers(tool_call_buffers, tool_calls)
 
         # Display metrics if requested
         if show_metrics and metrics:

--- a/tests/test_client_logs.py
+++ b/tests/test_client_logs.py
@@ -1,0 +1,60 @@
+"""Tests for ollmcp's own log file."""
+
+import logging
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from mcp_client_for_ollama.utils import client_logs
+
+
+class TestClientLog(unittest.TestCase):
+    """The client's warnings land in the session log instead of on screen."""
+
+    def setUp(self):
+        handlers_before = list(client_logs.logger.handlers)
+        path_before = client_logs._active_log_path
+
+        def restore():
+            for handler in client_logs.logger.handlers[len(handlers_before):]:
+                handler.close()
+            client_logs.logger.handlers = handlers_before
+            client_logs._active_log_path = path_before
+
+        self.addCleanup(restore)
+
+    def test_records_go_to_the_session_log_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(client_logs, "session_log_dir", return_value=tmp), patch.object(
+                client_logs, "prune_old_sessions"
+            ):
+                client_logs.start_client_log()
+                logging.getLogger("mcp_client_for_ollama.utils.streaming").warning("boom")
+                with open(client_logs.client_log_path(), encoding="utf-8") as log_file:
+                    content = log_file.read()
+
+        self.assertIn("WARNING mcp_client_for_ollama.utils.streaming: boom", content)
+
+    def test_old_session_directories_are_pruned_on_every_run(self):
+        # Runs that connect no server never build a log sink, so this is the
+        # only chance to clean up after them.
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(client_logs, "session_log_dir", return_value=tmp), patch.object(
+                client_logs, "prune_old_sessions"
+            ) as prune:
+                client_logs.start_client_log()
+
+        prune.assert_called_once()
+
+    def test_unwritable_log_directory_is_not_fatal(self):
+        handlers_before = list(client_logs.logger.handlers)
+        with patch.object(client_logs, "session_log_dir", return_value="/dev/null/nope"):
+            client_logs.start_client_log()
+
+        self.assertEqual(client_logs.logger.handlers, handlers_before)
+        # Nothing is being recorded, so there is no file to point anyone at.
+        self.assertIsNone(client_logs.client_log_path())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -3,8 +3,11 @@
 import os
 import unittest
 from dataclasses import dataclass
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+from rich.console import Console
 
 from mcp_client_for_ollama.utils.streaming import (
     BlockMarkdownRenderer,
@@ -282,6 +285,150 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(thinking_call.kwargs.get("end"), "")
         self.assertEqual(calls[-1].args, ())
         self.assertEqual(calls[-1].kwargs, {})
+
+
+    async def test_tool_call_survives_stream_ending_without_finish_reason(self):
+        # Some providers close the stream without ever sending a finish_reason.
+        # A fully received tool call must still be reported.
+        tool_call = SimpleNamespace(
+            index=0, id="call_1",
+            function=SimpleNamespace(name="time.get_current_time", arguments="{}"),
+        )
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            _, tool_calls, _ = await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(tool_calls=[tool_call]))]),
+                ),
+                print_response=False,
+            )
+
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["function"]["name"], "time.get_current_time")
+
+    async def test_failing_chunk_keeps_partial_output_and_warns(self):
+        # A chunk that fails to parse closes the provider's generator, so the
+        # stream is over. Keep what arrived and surface the error instead of
+        # returning an empty response with no explanation.
+        tool_call = SimpleNamespace(
+            index=0, id="call_1",
+            function=SimpleNamespace(name="time.get_current_time", arguments="{}"),
+        )
+
+        async def failing_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(tool_calls=[tool_call]))])
+            raise ValueError("bad chunk")
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, tool_calls, _ = await manager.process_streaming_response(
+                failing_stream(),
+                answer_render_mode="plain",
+            )
+
+        printed = " ".join(str(call.args[0]) for call in self.console.print.call_args_list if call.args)
+
+        self.assertEqual(response_text, "partial ")
+        self.assertEqual(len(tool_calls), 1)
+        self.assertIn("ended early", printed)
+        self.assertIn("bad chunk", printed)
+
+    async def test_failing_chunk_is_silent_when_not_printing(self):
+        async def failing_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            raise ValueError("bad chunk")
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            response_text, tool_calls, _ = await manager.process_streaming_response(
+                failing_stream(),
+                print_response=False,
+            )
+
+        self.assertEqual(response_text, "partial ")
+        self.assertEqual(tool_calls, [])
+        self.console.print.assert_not_called()
+
+    async def test_tool_call_cut_off_mid_arguments_is_dropped(self):
+        # The stream dies while the arguments are still arriving. Flushing the
+        # truncated JSON would only crash whoever tries to call the tool with it.
+        first_half = SimpleNamespace(
+            index=0, id="call_1",
+            function=SimpleNamespace(name="fs.read_file", arguments='{"path": "/etc/ho'),
+        )
+
+        async def failing_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="reading "))])
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(tool_calls=[first_half]))])
+            raise ValueError("bad chunk")
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            response_text, tool_calls, _ = await manager.process_streaming_response(
+                failing_stream(),
+                answer_render_mode="plain",
+            )
+
+        self.assertEqual(response_text, "reading ")
+        self.assertEqual(tool_calls, [])
+
+    async def test_stream_error_with_markup_characters_is_reported_intact(self):
+        # Provider errors carry brackets (pydantic's validation messages are
+        # full of them); rich must not read them as markup.
+        message = "1 validation error [type=missing, input_value={'a': 1}]"
+
+        async def failing_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            raise ValueError(message)
+
+        console = Console(file=StringIO(), force_terminal=False, width=200, no_color=True)
+        manager = StreamingManager(console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            await manager.process_streaming_response(failing_stream(), answer_render_mode="plain")
+
+        printed = console.file.getvalue()
+        self.assertIn(message, printed)
+
+    async def test_stream_error_omits_log_path_when_nothing_is_recorded(self):
+        async def failing_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            raise ValueError("bad chunk")
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.client_log_path", return_value=None), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None
+        ):
+            await manager.process_streaming_response(failing_stream(), answer_render_mode="plain")
+
+        printed = " ".join(str(call.args[0]) for call in self.console.print.call_args_list if call.args)
+        self.assertIn("ended early", printed)
+        self.assertNotIn("Details in", printed)
+
+    async def test_incomplete_tool_call_buffer_is_dropped(self):
+        # Arguments arrived but no function name: not a callable tool call.
+        partial = SimpleNamespace(
+            index=0, id="call_1",
+            function=SimpleNamespace(name=None, arguments='{"a":'),
+        )
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            _, tool_calls, _ = await manager.process_streaming_response(
+                _stream_chunks(DummyChunk(choices=[DummyChoice(DummyDelta(tool_calls=[partial]))])),
+                print_response=False,
+            )
+
+        self.assertEqual(tool_calls, [])
 
 
 class TestBlockMarkdownRendererHelpers(unittest.TestCase):


### PR DESCRIPTION
A chunk that fails to parse was logged at debug level and skipped, but there is nothing to skip to: the parsing happens inside the provider's async generator, and a generator that raises is closed, so the next `__anext__()` ends the loop. The stream was over, the buffered tool call deltas were never emitted because no finish_reason ever arrived, and process_query got back an empty response with no tool calls. What the user saw was the "No Response from Model" panel blaming the model for what could just as well be a dropped connection, an Ollama restart, or a chunk any-llm cannot convert (a created_at without fractional seconds raises there, as does a done_reason of load or unload).

The error now ends the stream deliberately: it is logged with its traceback and reported on screen, so a transport failure stops looking like a model that had nothing to say. Buffered tool calls are flushed once the stream is over as well as on finish_reason, which also covers a provider that closes without sending one. A tool call whose name never arrived, or whose streamed arguments no longer parse as JSON, is dropped rather than passed on to client.py's unguarded `json.loads`.

ollmcp gets its own log file, `ollmcp.log`, in the same per-session directory the MCP servers already log to, so these warnings land somewhere with their traceback instead of being printed over the TUI by Python's last-resort handler. Old session directories are now pruned on every launch, including runs that never connect a server and so never build a sink to prune from.

The streaming suite gets the cases this opens up: a stream that dies mid-flight keeps its partial text and its completed tool calls, a stream that ends without a finish_reason still reports the tool call it received, a tool call cut off mid-arguments is dropped instead of crashing the turn, and a provider error full of brackets reaches the screen intact instead of being eaten as rich markup. The new log file has its own tests, including a log directory that cannot be written to.

Found while investigating #305