### PR TITLE
chore(deps): bump any-llm-sdk to 1.27.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Jonathan Löwenstern"}
 ]
 dependencies = [
-    "any-llm-sdk[ollama,openai,atlascloud] ~=1.26.0",
+    "any-llm-sdk[ollama,openai,atlascloud] ~=1.27.2",
     "httpx>=0.27,<1",
     "mcp~=2.1.1",
     "prompt-toolkit~=3.0.53",

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "any-llm-sdk"
-version = "1.26.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -59,9 +59,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/23/abf2deede89c7293467e1a62565c3b4b6a3272785ca6c4d3e784e03ea255/any_llm_sdk-1.26.0.tar.gz", hash = "sha256:a2458bce7601e7761ed067ffa784473a83f610fb011862baf3e9eea1cf84cd35", size = 199609, upload-time = "2026-08-17T10:13:41.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/d0/6980a1e05f8ec897bed92942cd8e55e480db004fff9f569cc3c532fd7021/any_llm_sdk-1.27.2.tar.gz", hash = "sha256:4ab1998423825fa01a8ddd39c9816edbc5e78ebc2888a35ef703157e00beaf08", size = 212123, upload-time = "2026-09-10T09:51:48.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6d/1b3eff49eb77851ac525e62d48b305364de87a72e697cdb156325a03479f/any_llm_sdk-1.26.0-py3-none-any.whl", hash = "sha256:b65c5521c79ee974b39d837863532d41f024b768336e797817b2c310a33c73d6", size = 254205, upload-time = "2026-08-17T10:13:40.224Z" },
+    { url = "https://files.pythonhosted.org/packages/64/2f/86bc38f41ed9f46a605f5f6a7d8111da5e6c9164e65f21d591b18e33e7c3/any_llm_sdk-1.27.2-py3-none-any.whl", hash = "sha256:aa1be32d5f0df80a57466cbc723b067d47b3be12bb3a11565be465d6136acada", size = 266888, upload-time = "2026-09-10T09:51:46.127Z" },
 ]
 
 [package.optional-dependencies]
@@ -557,7 +557,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "any-llm-sdk", extras = ["ollama", "openai", "atlascloud"], specifier = "~=1.26.0" },
+    { name = "any-llm-sdk", extras = ["ollama", "openai", "atlascloud"], specifier = "~=1.27.2" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "mcp", specifier = "~=2.1.1" },
     { name = "prompt-toolkit", specifier = "~=3.0.53" },


### PR DESCRIPTION
Pins the floor at 1.27.2 instead of widening the range the way #307 does. 1.27.2 carries fix(ollama): normalize terminal done reasons (mozilla-ai/any-llm#1378), which is the upstream half of #305, and a range that still admits 1.26.0 would not guarantee it. #307 becomes redundant once this lands.

Ollama emits done_reason values OpenAI has no equivalent for -- load and unload, from a lifecycle request with no messages -- and 1.26.0 cast them straight into finish_reason, so the Literal validation raised and killed the chunk. 1.27.2 maps every unknown reason to stop in both the streaming and non-streaming converters, and streaming now also emits stop when a chunk has done=True with no reason at all. We only read finish_reason to flush the tool-call buffers (utils/streaming.py), and the finally clause flushes them anyway, so nothing changes on our side.

Also in the 1.27 line: streamed tool-call arguments are routed by tool_calls index, and the assistant text survives a turn that also calls a tool.

The imported surface is unchanged. exceptions.py and providers/openai/base.py are byte-identical between 1.26.0 and 1.27.2, and AnyLLM.create/acompletion only gained optional keywords.

created_at is still parsed with a strptime format that assumes a fractional part and a Z suffix, so a fraction-less RFC3339Nano timestamp still raises and a non-UTC offset is still silently wrong. That half stays upstream's.

Checked: full suite and cli-package tests pass; a streaming tool call and the tool-result round trip against a local Ollama model behave the same as on 1.26.0, end to end through the client with a stdio MCP server; thinking mode still streams reasoning.