### PR TITLE
fix: tool calls and stream errors against cloud providers

### DIFF
--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -41,7 +41,7 @@ from .server import registry
 from .server.cli_commands import mcp_app
 from .models.manager import ModelManager
 from .models.config_manager import ModelConfigManager
-from .tools.manager import ToolManager
+from .tools.manager import ToolManager, build_tool_payload
 from .prompts.manager import PromptManager
 from .prompts.handler import PromptHandler
 from .prompts.commands import run_slash_command
@@ -611,14 +611,9 @@ class MCPClient:
         if not enabled_tool_objects:
             self.console.print("[yellow]Warning: No tools are enabled. Model will respond without tool access.[/yellow]")
 
-        available_tools = [{
-            "type": "function",
-            "function": {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.input_schema
-            }
-        } for tool in enabled_tool_objects]
+        # Providers reject the dot in a qualified "<server>.<tool>" name, so the
+        # payload carries a sanitized one and we map it back before dispatching.
+        available_tools, wire_to_qualified = build_tool_payload(enabled_tool_objects)
 
         # Get current model from the model manager
         model = self.model_manager.get_current_model()
@@ -699,7 +694,9 @@ class MCPClient:
             loop_count += 1
 
             for tool in pending_tool_calls:
-                tool_name = tool["function"]["name"]
+                # Back to the qualified name everything below (and the user) knows.
+                # A model that echoes the qualified name anyway still resolves.
+                tool_name = wire_to_qualified.get(tool["function"]["name"], tool["function"]["name"])
                 tool_call_id = tool["id"]
                 tool_args = json.loads(tool["function"]["arguments"]) if tool["function"]["arguments"] else {}
 

--- a/mcp_client_for_ollama/client.py
+++ b/mcp_client_for_ollama/client.py
@@ -624,16 +624,21 @@ class MCPClient:
         # Check vision capability once for the entire query
         has_vision = await self.supports_vision()
 
-        # Initial LLM API call with the query and available tools
-        stream = await self.llm.acompletion(
-            model=model,
-            messages=apply_images(messages),
-            stream=True,
-            stream_options={"include_usage": True},
-            tools=available_tools or None,
-            **self._reasoning_effort_kwargs(supports_thinking),
-            **self.model_config_manager.get_completion_kwargs(self.provider),
-        )
+        # Initial LLM API call with the query and available tools.
+        # The spinner in the streaming manager only starts once the response
+        # headers are in, so without one here the terminal sits blank for the
+        # whole request. Locally that is imperceptible; against a cloud provider
+        # it is seconds, and a request that never comes back looks like a freeze.
+        with self.console.status(f"[cyan]waiting for {self.provider}..."):
+            stream = await self.llm.acompletion(
+                model=model,
+                messages=apply_images(messages),
+                stream=True,
+                stream_options={"include_usage": True},
+                tools=available_tools or None,
+                **self._reasoning_effort_kwargs(supports_thinking),
+                **self.model_config_manager.get_completion_kwargs(self.provider),
+            )
 
         # Process the streaming response with thinking mode support
         response_text = ""
@@ -793,15 +798,16 @@ class MCPClient:
 
 
             # Get stream response from LLM with the tool results
-            stream = await self.llm.acompletion(
-                model=model,
-                messages=apply_images(messages),
-                stream=True,
-                stream_options={"include_usage": True},
-                tools=available_tools or None,
-                **self._reasoning_effort_kwargs(supports_thinking),
-                **self.model_config_manager.get_completion_kwargs(self.provider),
-            )
+            with self.console.status(f"[cyan]waiting for {self.provider}..."):
+                stream = await self.llm.acompletion(
+                    model=model,
+                    messages=apply_images(messages),
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    tools=available_tools or None,
+                    **self._reasoning_effort_kwargs(supports_thinking),
+                    **self.model_config_manager.get_completion_kwargs(self.provider),
+                )
 
             # Process the streaming response with thinking mode support
             followup_response, pending_tool_calls, followup_metrics = await self.streaming_manager.process_streaming_response(
@@ -1555,15 +1561,16 @@ class MCPClient:
             ),
         })
 
-        stream = await self.llm.acompletion(
-            model=model,
-            messages=apply_images(messages),
-            stream=True,
-            stream_options={"include_usage": True},
-            tools=None,
-            **self._reasoning_effort_kwargs(supports_thinking),
-            **self.model_config_manager.get_completion_kwargs(self.provider),
-        )
+        with self.console.status(f"[cyan]waiting for {self.provider}..."):
+            stream = await self.llm.acompletion(
+                model=model,
+                messages=apply_images(messages),
+                stream=True,
+                stream_options={"include_usage": True},
+                tools=None,
+                **self._reasoning_effort_kwargs(supports_thinking),
+                **self.model_config_manager.get_completion_kwargs(self.provider),
+            )
 
         wrap_text, _, wrap_metrics = await self.streaming_manager.process_streaming_response(
             stream,

--- a/mcp_client_for_ollama/tools/manager.py
+++ b/mcp_client_for_ollama/tools/manager.py
@@ -4,6 +4,7 @@ This module handles enabling, disabling, and selecting tools from MCP servers.
 """
 
 import json
+import re
 from typing import Dict, List, Optional, Tuple, Callable
 from mcp import Tool
 from rich.console import Console
@@ -12,6 +13,53 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.text import Text
 from rich.syntax import Syntax
+
+_INVALID_WIRE_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def wire_name(qualified_name: str) -> str:
+    """The qualified tool name in the shape a provider accepts as a function name.
+
+    OpenAI documents "a-z, A-Z, 0-9, or ... underscores and dashes" and
+    Anthropic documents ^[a-zA-Z0-9_-]{1,128}$, so the dot in "<server>.<tool>"
+    makes the request invalid. Ollama does not validate the name, which is why
+    this only ever surfaced against cloud providers.
+
+    Names longer than OpenAI's 64 character limit are left alone: they are
+    rejected today with or without this, and no MCP server has run into it yet.
+    """
+    return _INVALID_WIRE_CHARS.sub("_", qualified_name)
+
+
+def build_tool_payload(tools: List[Tool]) -> Tuple[List[Dict], Dict[str, str]]:
+    """Tool definitions for the LLM, plus the map back to qualified names.
+
+    Both come from one pass so the payload and the map cannot drift apart. Two
+    qualified names can sanitize to the same string, and dispatching the wrong
+    one would run a tool the user never approved, so a collision takes the first
+    free suffix. The suffixed name is a name like any other, so it has to be
+    checked against the ones already taken too.
+    """
+    payload = []
+    wire_to_qualified = {}
+    for tool in tools:
+        name = wire_name(tool.name)
+        if name in wire_to_qualified:
+            suffix = 2
+            while f"{name}_{suffix}" in wire_to_qualified:
+                suffix += 1
+            name = f"{name}_{suffix}"
+        wire_to_qualified[name] = tool.name
+        payload.append({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": tool.description,
+                "parameters": tool.input_schema
+            }
+        })
+    return payload, wire_to_qualified
+
 
 class ToolManager:
     """Manages MCP tools.

--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -25,6 +25,34 @@ from .metrics import display_metrics, extract_metrics
 logger = logging.getLogger(__name__)
 
 
+class StreamProviderError(Exception):
+    """An error the provider reported inside the stream instead of raising it."""
+
+
+def _provider_error_message(error) -> str:
+    """A readable one-liner for an error a provider reported inside the stream."""
+    message = error.get("message") if isinstance(error, dict) else getattr(error, "message", None)
+    return str(message or error)
+
+
+async def _close_stream(stream):
+    """Release a stream we stopped reading before it ended.
+
+    Leaving the loop on an error the provider reported inside a chunk, or on an
+    abort, leaves its async generator suspended and the HTTP connection with it
+    until the garbage collector gets there. A generator that already raised is
+    closed and ignores this.
+    """
+    aclose = getattr(stream, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:
+        # Closing is cleanup: it must not replace whatever we are reporting.
+        logger.debug("Closing the response stream failed", exc_info=True)
+
+
 def _has_complete_arguments(buf) -> bool:
     """Whether a tool call's buffered arguments arrived in full.
 
@@ -438,6 +466,18 @@ class StreamingManager:
                     if extracted_metrics:
                         metrics = extracted_metrics
 
+                    # A provider that fails once the stream is open reports it
+                    # as a chunk carrying an error rather than by dropping the
+                    # connection, and it may keep the connection alive
+                    # afterwards. Since such a chunk has no choices, skipping it
+                    # leaves us reading a stream that will never produce
+                    # anything, with nothing on screen to explain the wait.
+                    chunk_error = getattr(chunk, "error", None)
+                    if chunk_error:
+                        stream_error = StreamProviderError(_provider_error_message(chunk_error))
+                        logger.warning("Provider reported an error in the stream: %r", chunk_error)
+                        break
+
                     if not getattr(chunk, "choices", None):
                         continue
 
@@ -514,6 +554,7 @@ class StreamingManager:
                 # The stream may have ended without a finish_reason (or died
                 # mid-flight); don't lose tool calls that already arrived.
                 _flush_tool_call_buffers(tool_call_buffers, tool_calls)
+                await _close_stream(stream)
                 if progressive_renderer is not None:
                     progressive_renderer.finish()
                 status.stop()
@@ -568,6 +609,12 @@ class StreamingManager:
                 if extracted_metrics:
                     metrics = extracted_metrics
 
+                chunk_error = getattr(chunk, "error", None)
+                if chunk_error:
+                    stream_error = StreamProviderError(_provider_error_message(chunk_error))
+                    logger.warning("Provider reported an error in the stream: %r", chunk_error)
+                    break
+
                 if not getattr(chunk, "choices", None):
                     continue
 
@@ -603,6 +650,7 @@ class StreamingManager:
                     _flush_tool_call_buffers(tool_call_buffers, tool_calls)
 
             _flush_tool_call_buffers(tool_call_buffers, tool_calls)
+            await _close_stream(stream)
 
         # Display metrics if requested
         if show_metrics and metrics:

--- a/tests/test_query_progress.py
+++ b/tests/test_query_progress.py
@@ -1,0 +1,85 @@
+"""The request itself must show progress, not just the stream that follows it.
+
+The streaming manager's spinner only starts once the response headers are in,
+so the wait for the response used to leave the terminal blank. Against a cloud
+provider that is seconds, and a request that never returns looks like a freeze
+with nothing on screen to explain it.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from mcp_client_for_ollama.client import MCPClient
+
+
+class RecordingStatus:
+    """A console.status double that records whether it is currently showing."""
+
+    def __init__(self, message):
+        self.message = message
+        self.active = False
+        self.was_entered = False
+
+    def __enter__(self):
+        self.active = True
+        self.was_entered = True
+        return self
+
+    def __exit__(self, *exc_info):
+        self.active = False
+        return False
+
+
+class TestQueryProgress(unittest.IsolatedAsyncioTestCase):
+    """A spinner covers the request, and is gone before the stream renders."""
+
+    def setUp(self):
+        self.client = MCPClient()
+        self.statuses = []
+
+        self.client.console = MagicMock()
+        self.client.console.status.side_effect = self._make_status
+
+        self.client.supports_thinking_mode = AsyncMock(return_value=False)
+        self.client.supports_vision = AsyncMock(return_value=False)
+        self.client.model_manager.get_current_model = MagicMock(return_value="a-model")
+        self.client.tool_manager.get_enabled_tool_objects = MagicMock(return_value=[])
+
+        self.status_active_during_request = None
+        self.status_active_during_streaming = None
+
+        self.client.llm.acompletion = AsyncMock(side_effect=self._record_request)
+        self.client.streaming_manager.process_streaming_response = AsyncMock(
+            side_effect=self._record_streaming
+        )
+
+    def _make_status(self, message, **kwargs):
+        status = RecordingStatus(message)
+        self.statuses.append(status)
+        return status
+
+    async def _record_request(self, *args, **kwargs):
+        self.status_active_during_request = any(s.active for s in self.statuses)
+        return MagicMock()
+
+    async def _record_streaming(self, *args, **kwargs):
+        self.status_active_during_streaming = any(s.active for s in self.statuses)
+        return "an answer", [], None
+
+    async def test_a_spinner_covers_the_wait_for_the_response(self):
+        await self.client.process_query("hello")
+
+        self.assertTrue(self.status_active_during_request)
+        self.assertIn("waiting for", self.statuses[0].message)
+
+    async def test_the_spinner_is_gone_before_the_stream_renders(self):
+        # Two live displays at once garble each other, and the streaming
+        # manager starts its own as soon as it is handed the stream.
+        await self.client.process_query("hello")
+
+        self.assertFalse(self.status_active_during_streaming)
+        self.assertTrue(self.statuses[0].was_entered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -39,6 +39,7 @@ class DummyChunk:
 
     choices: list
     usage: object = None
+    error: object = None
 
 
 async def _stream_chunks(*chunks):
@@ -429,6 +430,85 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(tool_calls, [])
+
+    async def test_error_reported_inside_a_chunk_ends_the_stream(self):
+        # A provider that fails after the stream opened reports it as a chunk
+        # carrying an error and an empty choices list, then keeps the
+        # connection alive. Skipping it leaves the client reading a stream that
+        # will never produce anything, with nothing on screen to explain why.
+        consumed_past_error = False
+
+        async def erroring_stream():
+            nonlocal consumed_past_error
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            yield DummyChunk(
+                choices=[DummyChoice(DummyDelta(content=""), finish_reason="error")],
+                error={"code": 400, "message": "invalid tool name"},
+            )
+            consumed_past_error = True
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="never arrives"))])
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, _, _ = await manager.process_streaming_response(
+                erroring_stream(),
+                answer_render_mode="plain",
+            )
+
+        printed = " ".join(str(call.args[0]) for call in self.console.print.call_args_list if call.args)
+
+        self.assertFalse(consumed_past_error)
+        self.assertEqual(response_text, "partial ")
+        self.assertIn("ended early", printed)
+        self.assertIn("invalid tool name", printed)
+
+    async def test_stream_left_early_is_closed(self):
+        # Leaving the loop on a provider error abandons a stream that is still
+        # open, holding its HTTP connection until the garbage collector runs.
+        async def erroring_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            yield DummyChunk(
+                choices=[DummyChoice(DummyDelta(content=""), finish_reason="error")],
+                error={"message": "invalid tool name"},
+            )
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="never arrives"))])
+
+        stream = erroring_stream()
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            await manager.process_streaming_response(stream, answer_render_mode="plain")
+
+        # A closed async generator refuses to resume.
+        with self.assertRaises(StopAsyncIteration):
+            await stream.__anext__()
+
+    async def test_error_reported_inside_a_chunk_is_silent_when_not_printing(self):
+        async def erroring_stream():
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="partial "))])
+            yield DummyChunk(
+                choices=[DummyChoice(DummyDelta(content=""), finish_reason="error")],
+                error={"code": 400, "message": "invalid tool name"},
+            )
+            yield DummyChunk(choices=[DummyChoice(DummyDelta(content="never arrives"))])
+
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.extract_metrics", return_value=None):
+            response_text, _, _ = await manager.process_streaming_response(
+                erroring_stream(),
+                print_response=False,
+            )
+
+        self.assertEqual(response_text, "partial ")
+        self.console.print.assert_not_called()
 
 
 class TestBlockMarkdownRendererHelpers(unittest.TestCase):

--- a/tests/test_tool_wire_names.py
+++ b/tests/test_tool_wire_names.py
@@ -1,0 +1,78 @@
+"""Tests for the tool names ollmcp puts on the wire."""
+
+import unittest
+
+from mcp import Tool
+
+from mcp_client_for_ollama.tools.manager import build_tool_payload, wire_name
+
+
+def _tool(name):
+    return Tool(name=name, description=f"desc for {name}", inputSchema={"type": "object"})
+
+
+class TestWireName(unittest.TestCase):
+    """Qualified names must survive a provider's function-name validation."""
+
+    def test_dot_separator_is_replaced(self):
+        # OpenAI and Anthropic both reject the dot in "<server>.<tool>".
+        self.assertEqual(wire_name("playwright.browser_navigate"), "playwright_browser_navigate")
+
+    def test_allowed_characters_are_left_alone(self):
+        self.assertEqual(wire_name("my-server_tool2"), "my-server_tool2")
+
+    def test_other_invalid_characters_are_replaced(self):
+        # Server names come from user config, so dots are not the only risk.
+        self.assertEqual(wire_name("my server:v1.do it"), "my_server_v1_do_it")
+
+
+class TestBuildToolPayload(unittest.TestCase):
+    """The payload and the map back to qualified names come from one pass."""
+
+    def test_payload_carries_sanitized_names_and_maps_back(self):
+        payload, wire_to_qualified = build_tool_payload([_tool("playwright.browser_navigate")])
+
+        self.assertEqual(payload[0]["function"]["name"], "playwright_browser_navigate")
+        self.assertEqual(
+            wire_to_qualified["playwright_browser_navigate"], "playwright.browser_navigate"
+        )
+
+    def test_description_and_schema_are_passed_through(self):
+        payload, _ = build_tool_payload([_tool("time.now")])
+
+        self.assertEqual(payload[0]["function"]["description"], "desc for time.now")
+        self.assertEqual(payload[0]["function"]["parameters"], {"type": "object"})
+
+    def test_colliding_names_are_disambiguated(self):
+        # "github.list_repos" and "github_list.repos" sanitize alike, and
+        # dispatching the wrong one would run a tool the user never approved.
+        names = ["github.list_repos", "github_list.repos"]
+
+        payload, wire_to_qualified = build_tool_payload([_tool(n) for n in names])
+
+        wire_names = [entry["function"]["name"] for entry in payload]
+        self.assertEqual(len(set(wire_names)), 2)
+        self.assertEqual(set(wire_to_qualified.values()), set(names))
+        for wire, qualified in wire_to_qualified.items():
+            self.assertIn(wire, wire_names)
+            self.assertIn(qualified, names)
+
+    def test_suffix_does_not_land_on_a_name_already_taken(self):
+        # The suffix is itself a name, so it has to be checked too. Otherwise
+        # the map rebinds to the later tool and the payload ships two functions
+        # called the same thing, which is the mis-dispatch this guards against.
+        names = ["example_com.search_2", "example_com.search", "example.com.search"]
+
+        payload, wire_to_qualified = build_tool_payload([_tool(n) for n in names])
+
+        wire_names = [entry["function"]["name"] for entry in payload]
+        self.assertEqual(len(set(wire_names)), 3)
+        self.assertEqual(set(wire_to_qualified.values()), set(names))
+
+    def test_no_enabled_tools_yields_empty_payload(self):
+        # process_query passes "available_tools or None" to the provider.
+        self.assertEqual(build_tool_payload([]), ([], {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three fixes that came out of investigating #311. They don't share a cause, so they're three commits.

None of them is confirmed to be what hangs for the reporter, so this does not close #311. I've asked there for the two things that would tell us.

### Tool names a provider will not accept

Tools go out namespaced as `<server>.<tool>`, and that dot is not valid in a function name. OpenAI documents "a-z, A-Z, 0-9, or ... underscores and dashes" with a max of 64, Anthropic documents `^[a-zA-Z0-9_-]{1,128}$`. Ollama doesn't validate the name, which is why this only showed up against cloud providers and only with at least one tool enabled.

Against OpenRouter, same request, only the name changed:

```
name 'demo_echo'      : OK  hdrs=0.70s chunks=40
name 'demo_echo' call : OK  tool call streamed back fine
name 'demo.echo'      : 400 Validation: Function at index 0 has an invalid name:
                            "demo.echo". Only a-z, A-Z, 0-9, underscores, and
                            dashes are allowed.   (provider: Nvidia)
name 'demo-echo'      : OK  hdrs=0.45s chunks=54
```

The payload now carries a sanitized name and a map takes it back before dispatch, so the sessions lookup, the tool panel, the confirmation prompt and the saved `enabledTools` keys keep seeing the qualified name. Saved configs are untouched. A model that echoes the qualified name back still resolves.

Two qualified names can sanitize alike (`github.list_repos` and `github_list.repos` both give `github_list_repos`), which would ship two identically named functions and dispatch one to the wrong server, so a collision takes the first free suffix.

End to end after the fix, same tool that used to 400:

```
wire name sent: 'demo_echo'
model called 'demo_echo' args={"flag":true}
resolved to 'demo.echo' -> session 'demo', tool 'echo'
```

### An error the provider sends inside the stream

Once the headers are out a provider can't answer with an HTTP error, so it sends the failure as a chunk. OpenRouter documents the shape: normal chunk fields, a top level `error`, a choice with `finish_reason: "error"`, HTTP 200.

Nothing looked at that field. The chunk went through as an ordinary one, contributed its empty content, and the stream ended, so the turn came back empty and the user got the "No Response from Model" panel blaming the model for a request the provider had refused. Same misdirection #310 removed for a chunk that fails to parse, through the one path that still had it.

```
   with fix: text='partial ' error_shown=True
without fix: text='partial ' error_shown=False
```

The provider's message now reaches the screen through the notice #310 added, with the raw payload in `ollmcp.log`. Reading stops there, which is what the protocol says happens anyway, and buffered tool calls are still flushed.

A stream left before it ended is now closed explicitly, since breaking out leaves the async generator suspended and the connection with it until GC. That also covers the abort path, which had the same leak.

### Nothing on screen while the response is awaited

The spinner and the `'a'` hint live in the streaming manager, which is handed a stream that already exists. They cover the wait between chunks, not the wait for the response, so from Enter until the headers arrive the terminal shows nothing.

On localhost that's imperceptible. Measured against two cloud providers: 3.3s to headers plain, 6.5s with tools attached, and longer with a big tool payload or extended thinking. No timeout is passed, so the SDK default of 600s applies and each byte resets it.

It also lines up with the one thing a user sees differently with tools on and off: with no tools there's a warning printed before the request, so something appears immediately. With tools, nothing.

A status now covers the request at all three call sites. Aborting already worked during that window; what was missing was any sign there was something to abort.

### Tests

297 passing, and green at each commit individually (292 → 295 → 297). Each new test was confirmed red before its fix.

Beyond the suite: replayed OpenRouter-shaped streams against the streaming manager for regressions, drove `process_query` with a real `Console` to make sure the new status doesn't collide with the streaming manager's own live display, and ran the tool-name fix against OpenRouter itself.
