### PR TITLE
fix(streaming): don't print the thinking header for whitespace-only reasoning

### DIFF
--- a/mcp_client_for_ollama/utils/streaming.py
+++ b/mcp_client_for_ollama/utils/streaming.py
@@ -21,6 +21,7 @@ from rich.text import Text
 
 from .client_logs import client_log_path
 from .metrics import display_metrics, extract_metrics
+from .sanitize import strip_control_chars
 
 logger = logging.getLogger(__name__)
 
@@ -435,6 +436,8 @@ class StreamingManager:
         # already arrived. Silent still means silent, though: a stream that
         # ends early is logged there, never printed.
         thinking_started = False
+        # Reasoning deltas held back until one carries non-whitespace text
+        pending_thinking = ""
         # Show initial working spinner until first chunk arrives
         first_chunk = True
         # Buffer for incremental tool call deltas
@@ -500,21 +503,37 @@ class StreamingManager:
                     thinking = reasoning.content if hasattr(reasoning, "content") else (reasoning if isinstance(reasoning, str) else None)
 
                 if thinking_mode and thinking:
-                    if print_response and first_chunk and show_thinking:
-                        status.stop()
-                        first_chunk = False
-                    if print_response and not thinking_content:
-                        # The header doubles as the first piece of the
-                        # transcript, so it only belongs to the rendered one.
-                        thinking_content = "🤔 **Thinking:**\n\n"
-                        if not thinking_started and show_thinking:
-                            self.console.print(Markdown("🤔 **Thinking:**\n"))
-                            self.console.print(Markdown("---"))
-                            self.console.print()
-                            thinking_started = True
-                    thinking_content += thinking
-                    if print_response and show_thinking:
-                        self.console.print(thinking, end="")
+                    # A reasoning delta can carry nothing but whitespace (some
+                    # OpenAI-compatible providers open the stream that way).
+                    # Emitting on those printed the header with an empty body,
+                    # so they are held back until one carries something
+                    # visible, then flushed together to keep the spacing
+                    # between words intact.
+                    pending_thinking += thinking
+                    if pending_thinking.strip():
+                        if print_response and first_chunk and show_thinking:
+                            status.stop()
+                            first_chunk = False
+                        if print_response and not thinking_content:
+                            # Whitespace ahead of the first visible text would
+                            # render as a gap under the header.
+                            pending_thinking = pending_thinking.lstrip()
+                            # The header doubles as the first piece of the
+                            # transcript, so it only belongs to the rendered one.
+                            thinking_content = "🤔 **Thinking:**\n\n"
+                            if not thinking_started and show_thinking:
+                                self.console.print(Markdown("🤔 **Thinking:**\n"))
+                                self.console.print(Markdown("---"))
+                                self.console.print()
+                                thinking_started = True
+                        thinking_content += pending_thinking
+                        if print_response and show_thinking:
+                            # Reasoning text comes from the provider: left as
+                            # is, rich eats anything bracketed as markup (which
+                            # can empty the body on its own) and a raw ESC
+                            # could spoof the terminal.
+                            self.console.print(escape(strip_control_chars(pending_thinking)), end="")
+                        pending_thinking = ""
 
                 # Handle regular content
                 content = getattr(delta, "content", None) or ""

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -287,6 +287,80 @@ class TestStreamingManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(calls[-1].args, ())
         self.assertEqual(calls[-1].kwargs, {})
 
+    async def test_whitespace_only_reasoning_prints_no_thinking_header(self):
+        # A provider that only ever sends whitespace in its reasoning deltas
+        # used to get the "Thinking:" header rendered above an empty body.
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            response_text, _, _ = await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning=" "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="\n"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(content="answer"))]),
+                ),
+                thinking_mode=True,
+                show_thinking=True,
+                answer_render_mode="plain",
+            )
+
+        printed = [call.args[0] for call in self.console.print.call_args_list if call.args]
+        self.assertEqual(response_text, "answer")
+        self.assertFalse(any("\U0001f914" in str(item) for item in printed))
+
+    async def test_leading_whitespace_reasoning_flushes_with_first_visible_text(self):
+        # The whitespace held back before the first visible delta must not
+        # reappear as a gap under the header, but spacing between words does.
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="\n\n"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="plan"))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning=" "))]),
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="ning"))]),
+                ),
+                thinking_mode=True,
+                show_thinking=True,
+                answer_render_mode="plain",
+            )
+
+        streamed = [
+            call.args[0] for call in self.console.print.call_args_list
+            if call.args and call.kwargs.get("end") == ""
+        ]
+        self.assertEqual(streamed, ["plan", " ning"])
+
+    async def test_bracketed_reasoning_is_escaped_before_printing(self):
+        # Rich would parse "[dim]" as markup and print nothing for it, and a
+        # raw ESC from the provider could spoof the terminal.
+        manager = StreamingManager(self.console)
+
+        with patch("mcp_client_for_ollama.utils.streaming.Markdown", side_effect=lambda text: f"MD::{text}"), patch(
+            "mcp_client_for_ollama.utils.streaming.extract_metrics",
+            return_value=None,
+        ):
+            await manager.process_streaming_response(
+                _stream_chunks(
+                    DummyChunk(choices=[DummyChoice(DummyDelta(reasoning="\x1b[2Jstep [dim]one"))]),
+                ),
+                thinking_mode=True,
+                show_thinking=True,
+                answer_render_mode="plain",
+            )
+
+        streamed = [
+            call.args[0] for call in self.console.print.call_args_list
+            if call.args and call.kwargs.get("end") == ""
+        ]
+        self.assertEqual(streamed, ["[2Jstep \\[dim]one"])
 
     async def test_tool_call_survives_stream_ending_without_finish_reason(self):
         # Some providers close the stream without ever sending a finish_reason.


### PR DESCRIPTION
Some OpenAI-compatible providers open the stream with reasoning deltas that carry nothing but whitespace. Any truthy delta emitted the "Thinking:" header, so the header showed up above an empty body.

Hold reasoning deltas in a buffer and flush them only once one carries non-whitespace text, which keeps the spacing between words intact while dropping the leading gap under the header. Also escape and strip control characters before printing: unescaped, rich parses bracketed text as markup (which can empty the body on its own) and a raw ESC from the provider could spoof the terminal.